### PR TITLE
feat: resolve Maven properties in found POMs

### DIFF
--- a/src/macaron/dependency_analyzer/java_repo_finder.py
+++ b/src/macaron/dependency_analyzer/java_repo_finder.py
@@ -187,6 +187,7 @@ def _resolve_properties(pom: Element, values: list[str]) -> list[str]:
                 text = text.replace("project.", "")
             else:
                 text = f"properties.{text}"
+            # Call find_scm with property resolution flag set to False to prevent the possibility of endless looping
             value_iterator, count = find_scm(pom, [text], False)
             if count == 0:
                 break

--- a/tests/dependency_analyzer/java_repo_finder/resources/example_pom.xml
+++ b/tests/dependency_analyzer/java_repo_finder/resources/example_pom.xml
@@ -25,7 +25,7 @@
         <license>
             <name>Example_License</name>
             <url>https://example.example/license</url>
-            <distribution>repo</distribution>
+            <distribution>${licenses.license.distribution}</distribution>
         </license>
     </licenses>
     <scm>
@@ -33,7 +33,7 @@
             ssh://git@hostname:port/owner/${project.licenses.license.name}.git
         </connection>
         <developerConnection>
-            git@github.com:owner/project${javac.src.version}.git
+            git@github.com:owner/project${javac.src.version}-${project.inceptionYear}.git
         </developerConnection>
         <url>https://github.com/owner/project</url>
         <tag>example-0.0.1</tag>

--- a/tests/dependency_analyzer/java_repo_finder/resources/example_pom.xml
+++ b/tests/dependency_analyzer/java_repo_finder/resources/example_pom.xml
@@ -23,17 +23,17 @@
     <inceptionYear>2023</inceptionYear>
     <licenses>
         <license>
-            <name>Example License</name>
+            <name>Example_License</name>
             <url>https://example.example/license</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
     <scm>
         <connection>
-            ssh://git@hostname:port/owner/project.git
+            ssh://git@hostname:port/owner/${project.licenses.license.name}.git
         </connection>
         <developerConnection>
-            git@github.com:owner/project.git
+            git@github.com:owner/project${javac.src.version}.git
         </developerConnection>
         <url>https://github.com/owner/project</url>
         <tag>example-0.0.1</tag>

--- a/tests/dependency_analyzer/java_repo_finder/test_java_repo_finder.py
+++ b/tests/dependency_analyzer/java_repo_finder/test_java_repo_finder.py
@@ -27,12 +27,15 @@ def test_java_repo_finder() -> None:
         file_data = file.read()
         pom = parse_pom(file_data)
         assert pom is not None
-        found_urls, count = find_scm(pom, ["scm.url", "scm.connection", "scm.developerConnection"])
-        assert count == 3
+        found_urls, count = find_scm(
+            pom, ["scm.url", "scm.connection", "scm.developerConnection", "licenses.license.distribution"]
+        )
+        assert count == 4
         expected = [
             "https://github.com/owner/project",
             "ssh://git@hostname:port/owner/Example_License.git",
-            "git@github.com:owner/project1.8.git",
+            "git@github.com:owner/project1.8-2023.git",
+            "${licenses.license.distribution}",
         ]
         assert expected == list(found_urls)
 

--- a/tests/dependency_analyzer/java_repo_finder/test_java_repo_finder.py
+++ b/tests/dependency_analyzer/java_repo_finder/test_java_repo_finder.py
@@ -31,8 +31,8 @@ def test_java_repo_finder() -> None:
         assert count == 3
         expected = [
             "https://github.com/owner/project",
-            "ssh://git@hostname:port/owner/project.git",
-            "git@github.com:owner/project.git",
+            "ssh://git@hostname:port/owner/Example_License.git",
+            "git@github.com:owner/project1.8.git",
         ]
         assert expected == list(found_urls)
 


### PR DESCRIPTION
This is a small extension to the repo finding feature. It exists to provide support for Maven properties found within SCM metadata. These are of the form: ${property}

Maven provides five ways in which these property values can be used. See https://maven.apache.org/pom.html
We support only the two where the property references another tag within the same POM file. No attempt is made to resolve properties that reference external values such as environmental variables, Java properties, etc.