### PR TITLE
feat: add support for cloning GitLab repositories

### DIFF
--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -37,6 +37,15 @@ echo -e "-----------------------------------------------------------------------
 $RUN_MACARON analyze -rp https://github.com/micronaut-projects/micronaut-core -b 3.5.x --skip-deps || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
+echo "gitlab.com/tinyMediaManager/tinyMediaManager: Analyzing the repo path and the branch name when automatic dependency resolution is skipped."
+echo -e "----------------------------------------------------------------------------------\n"
+JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/tinyMediaManager/tinyMediaManager.json
+JSON_RESULT=$WORKSPACE/output/reports/gitlab_com/tinyMediaManager/tinyMediaManager/tinyMediaManager.json
+$RUN_MACARON analyze -rp https://gitlab.com/tinyMediaManager/tinyMediaManager -b main -d cca6b67a335074eca42136556f0a321f75dc4f48 --skip-deps || log_fail
+
+python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+
+echo -e "\n----------------------------------------------------------------------------------"
 echo "jenkinsci/plot-plugin: Analyzing the repo path, the branch name and the commit digest when automatic dependency resolution is skipped."
 echo -e "----------------------------------------------------------------------------------\n"
 JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/plot-plugin/plot-plugin.json

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -413,6 +413,8 @@ docker run \
     -e "USER_UID=${USER_UID}" \
     -e "USER_GID=${USER_GID}" \
     -e "GITHUB_TOKEN=${GITHUB_TOKEN}" \
+    -e "MCN_PUBLIC_GITLAB_TOKEN=${MCN_PUBLIC_GITLAB_TOKEN}" \
+    -e "MCN_PRIVATE_GITLAB_TOKEN=${MCN_PRIVATE_GITLAB_TOKEN}" \
     "${proxy_vars[@]}" \
     "${prod_vars[@]}" \
     "${mounts[@]}" \

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -143,7 +143,7 @@ def perform_action(action_args: argparse.Namespace) -> None:
                 for git_service in GIT_SERVICES:
                     git_service.load_defaults()
             except ConfigurationError as error:
-                logger.error(str(error))
+                logger.error(error)
                 sys.exit(os.EX_USAGE)
 
             analyze_slsa_levels_single(action_args)

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -16,10 +16,12 @@ import macaron
 from macaron.config.defaults import create_defaults, load_defaults
 from macaron.config.global_config import global_config
 from macaron.config.target_config import TARGET_CONFIG_SCHEMA
+from macaron.errors import ConfigurationError
 from macaron.output_reporter.reporter import HTMLReporter, JSONReporter, PolicyReporter
 from macaron.parsers.yaml.loader import YamlLoader
 from macaron.policy_engine.policy_engine import run_policy_engine, show_prelude
 from macaron.slsa_analyzer.analyzer import Analyzer
+from macaron.slsa_analyzer.git_service import GIT_SERVICES
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -134,6 +136,16 @@ def perform_action(action_args: argparse.Namespace) -> None:
                 logger.error("GitHub access token not set.")
                 sys.exit(os.EX_USAGE)
             global_config.gh_token = gh_token
+
+            # TODO: Here we should try to statically analyze the config before
+            # actually running the analysis.
+            try:
+                for git_service in GIT_SERVICES:
+                    git_service.load_defaults()
+            except ConfigurationError as error:
+                logger.error(str(error))
+                sys.exit(os.EX_USAGE)
+
             analyze_slsa_levels_single(action_args)
         case _:
             logger.error("Macaron does not support command option %s.", action_args.action)

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -58,14 +58,21 @@ parent_limit = 10
 # E.g. com.oracle.coherence.ce:coherence
 artifact_ignore_list =
 
-[git]
-# The list of allowed git hosts.
-# Host names are separated by spaces and they can be defined in multiple lines.
-# Duplicated host names are ignored.
-allowed_hosts =
-    github.com
-    ol-bitbucket.us.oracle.com
-    gitlab.com
+# Git services that Macaron has access to clone repositories.
+# For security purposes, Macaron will only clone repositories from the domains specified.
+
+# Access to GitHub is required in most case for Macaron to analyse not only the main
+# repo but also its dependencies.
+[git_service.github]
+domain = github.com
+
+# Access to public GitLab (gitlab.com).
+[git_service.gitlab.public]
+domain = gitlab.com
+
+# Access to a private GitLab instance (e.g. your organization's self-hosted GitLab instance).
+# [git_service.gitlab.private]
+# domain = example.org
 
 # This is the spec for trusted Maven build tools.
 [builder.maven]

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -67,10 +67,15 @@ artifact_ignore_list =
 domain = github.com
 
 # Access to public GitLab (gitlab.com).
+# An optional access token can be provided through the `MCN_PUBLIC_GITLAB_TOKEN` environment variable.
+# This access token is optional, only necessary when you need to clone private repositories.
+# The `read_repository` permission is required for this token.
 [git_service.gitlab.public]
 domain = gitlab.com
 
 # Access to a private GitLab instance (e.g. your organization's self-hosted GitLab instance).
+# If this section is enabled, an access token must be provided through the `MCN_PRIVATE_GITLAB_TOKEN` environment variable.
+# The `read_repository` permission is required for this token.
 # [git_service.gitlab.private]
 # domain = example.org
 

--- a/src/macaron/errors.py
+++ b/src/macaron/errors.py
@@ -22,3 +22,7 @@ class CUEExpectationError(MacaronError):
 
 class CUERuntimeError(MacaronError):
     """Happens when there are errors in CUE expectation validation."""
+
+
+class ConfigurationError(MacaronError):
+    """Happens when there is an error in the configuration (.ini) file."""

--- a/src/macaron/errors.py
+++ b/src/macaron/errors.py
@@ -26,3 +26,7 @@ class CUERuntimeError(MacaronError):
 
 class ConfigurationError(MacaronError):
     """Happens when there is an error in the configuration (.ini) file."""
+
+
+class CloneError(MacaronError):
+    """Happens when cannot clone a git repository."""

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -27,6 +27,7 @@ from macaron.dependency_analyzer import (
     NoneDependencyAnalyzer,
 )
 from macaron.dependency_analyzer.cyclonedx import get_deps_from_sbom
+from macaron.errors import CloneError
 from macaron.output_reporter.reporter import FileReporter
 from macaron.output_reporter.results import Record, Report, SCMStatus
 from macaron.slsa_analyzer import git_url
@@ -527,13 +528,13 @@ class Analyzer:
                 return None
 
             git_service = self.get_git_service(resolved_remote_path)
-            if not git_service.can_clone_remote_repo(resolved_remote_path):
-                logger.error("Cannot clone the remote repo at %s", resolved_remote_path)
-                return None
-
             repo_unique_path = git_url.get_repo_dir_name(resolved_remote_path)
             resolved_local_path = os.path.join(target_dir, repo_unique_path)
-            git_url.clone_remote_repo(resolved_local_path, resolved_remote_path)
+            try:
+                git_service.clone_repo(resolved_local_path, resolved_remote_path)
+            except CloneError as error:
+                logger.error("Cannot clone %s: %s", resolved_remote_path, str(error))
+                return None
         else:
             logger.info("The path to repo %s is a local path.", repo_path)
             resolved_local_path = self._resolve_local_path(self.local_repos_path, repo_path)
@@ -577,7 +578,6 @@ class Analyzer:
             The git service derived from the remote path.
         """
         for git_service in GIT_SERVICES:
-            git_service.load_defaults()
             if git_service.is_detected(remote_path):
                 return git_service
 

--- a/src/macaron/slsa_analyzer/git_service/__init__.py
+++ b/src/macaron/slsa_analyzer/git_service/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The git_service package contains the supported git services for Macaron."""
@@ -6,8 +6,8 @@
 from .base_git_service import BaseGitService
 from .bitbucket import BitBucket
 from .github import GitHub
-from .gitlab import GitLab
+from .gitlab import PrivateGitLab, PublicGitLab
 
 # The list of supported git services. The order of the list determines the order
 # in which each git service is checked against the target repository.
-GIT_SERVICES: list[BaseGitService] = [GitHub(), GitLab(), BitBucket()]
+GIT_SERVICES: list[BaseGitService] = [GitHub(), PublicGitLab(), PrivateGitLab(), BitBucket()]

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -6,7 +6,7 @@
 from abc import abstractmethod
 
 from macaron.config.defaults import defaults
-from macaron.errors import ConfigurationError
+from macaron.errors import CloneError, ConfigurationError
 from macaron.slsa_analyzer import git_url
 
 
@@ -109,6 +109,25 @@ class BaseGitService:
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def clone_repo(self, clone_dir: str, url: str) -> None:
+        """Clone a repository.
+
+        Parameters
+        ----------
+        clone_dir: str
+            The name of the directory to clone into.
+            This is equivalent to the <directory> argument of ``git clone``.
+        url : str
+            The url to the repository.
+
+        Raises
+        ------
+        CloneError
+            If there is an error cloning the repo.
+        """
+        raise NotImplementedError()
+
 
 class NoneGitService(BaseGitService):
     """This class can be used to initialize an empty git service."""
@@ -153,3 +172,16 @@ class NoneGitService(BaseGitService):
             True if the repo can be cloned, else False.
         """
         return False
+
+    def clone_repo(self, _clone_dir: str, url: str) -> None:
+        """Clone a repo.
+
+        In this particular case, since this class represents a ``None`` git service,
+        we do nothing but raise a ``CloneError``.
+
+        Raises
+        ------
+        CloneError
+            Always raise, since this method should not be used to clone any repository.
+        """
+        raise CloneError(f"Internal error encountered when cloning the repo '{url}'.")

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 
 from macaron.config.defaults import defaults
 from macaron.errors import ConfigurationError
+from macaron.slsa_analyzer import git_url
 
 
 class BaseGitService:
@@ -67,7 +68,10 @@ class BaseGitService:
         return domain
 
     def is_detected(self, url: str) -> bool:
-        """Return True if the remote repo is using this git service.
+        """Check if the remote repo at the given ``url`` is hosted on this git service.
+
+        This check is done by checking the URL of the repo against the domain of this
+        git service.
 
         Parameters
         ----------
@@ -77,9 +81,17 @@ class BaseGitService:
         Returns
         -------
         bool
-            True if this git service is detected else False.
+            True if the repo is indeed hosted on this git service.
         """
-        raise NotImplementedError
+        if self.domain is None:
+            return False
+        return (
+            git_url.parse_remote_url(
+                url,
+                allowed_git_service_domains=[self.domain],
+            )
+            is not None
+        )
 
     @abstractmethod
     def can_clone_remote_repo(self, url: str) -> bool:

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -32,7 +32,7 @@ class BaseGitService:
     def load_domain(self, section_name: str) -> str | None:
         """Load the domain of the git service from the ini configuration section ``section_name``.
 
-        The section may or may not be available in the configuration. In both case,
+        The section may or may not be available in the configuration. In both cases,
         the method should not raise ``ConfigurationError``.
 
         Meanwhile, if the section is present but there is a schema violation (e.g. a key such as

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -94,22 +94,6 @@ class BaseGitService:
         )
 
     @abstractmethod
-    def can_clone_remote_repo(self, url: str) -> bool:
-        """Return True if the remote repository can be cloned.
-
-        Parameters
-        ----------
-        url : str
-            The remote url.
-
-        Returns
-        -------
-        bool
-            True if the repo can be cloned, else False.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def clone_repo(self, clone_dir: str, url: str) -> None:
         """Clone a repository.
 
@@ -155,21 +139,6 @@ class NoneGitService(BaseGitService):
         -------
         bool
             True if this git service is detected else False.
-        """
-        return False
-
-    def can_clone_remote_repo(self, url: str) -> bool:
-        """Return True if the remote repository can be cloned.
-
-        Parameters
-        ----------
-        url : str
-            The remote url.
-
-        Returns
-        -------
-        bool
-            True if the repo can be cloned, else False.
         """
         return False
 

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -1,9 +1,12 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the BaseGitService class to be inherited by a git service."""
 
 from abc import abstractmethod
+
+from macaron.config.defaults import defaults
+from macaron.errors import ConfigurationError
 
 
 class BaseGitService:
@@ -18,13 +21,51 @@ class BaseGitService:
             The name of the git service.
         """
         self.name = name
+        self.domain: str | None = None
 
     @abstractmethod
     def load_defaults(self) -> None:
-        """Load the default values from defaults.ini."""
+        """Load the values for this git service from the ini configuration."""
         raise NotImplementedError
 
-    @abstractmethod
+    def load_domain(self, section_name: str) -> str | None:
+        """Load the domain of the git service from the ini configuration section ``section_name``.
+
+        The section may or may not be available in the configuration. In both case,
+        the method should not raise ``ConfigurationError``.
+
+        Meanwhile, if the section is present but there is a schema violation (e.g. a key such as
+        ``domain`` is missing), this method will raise a ``ConfigurationError``.
+
+        Parameters
+        ----------
+        section_name : str
+            The name of the git service section in the ini configuration file.
+
+        Returns
+        -------
+        str | None
+            The domain. This can be ``None`` if the git section is not found in
+            the ini configuration file, meaning the user does not enable the
+            corresponding git service.
+
+        Raises
+        ------
+        ConfigurationError
+            If there is a schema violation in the git service section.
+        """
+        if not defaults.has_section(section_name):
+            # We do not raise ConfigurationError here because it is not compulsory
+            # to have all available git services in the ini config.
+            return None
+        section = defaults[section_name]
+        domain = section.get("domain")
+        if not domain:
+            raise ConfigurationError(
+                f'The "domain" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+        return domain
+
     def is_detected(self, url: str) -> bool:
         """Return True if the remote repo is using this git service.
 
@@ -65,7 +106,11 @@ class NoneGitService(BaseGitService):
         super().__init__("")
 
     def load_defaults(self) -> None:
-        """Load the default values from defaults.ini."""
+        """Load the values for this git service from the ini configuration.
+
+        In this particular case, since this class represents a ``None`` git service,
+        we do nothing.
+        """
 
     def is_detected(self, url: str) -> bool:
         """Return True if the remote repo is using this git service.

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -46,7 +46,7 @@ class BaseGitService:
         Returns
         -------
         str | None
-            The domain. This can be ``None`` if the git section is not found in
+            The domain. This can be ``None`` if the git service section is not found in
             the ini configuration file, meaning the user does not enable the
             corresponding git service.
 

--- a/src/macaron/slsa_analyzer/git_service/bitbucket.py
+++ b/src/macaron/slsa_analyzer/git_service/bitbucket.py
@@ -26,19 +26,3 @@ class BitBucket(BaseGitService):
         """Clone a BitBucket repo."""
         # TODO: implement this once support for BitBucket is added.
         logger.info("Cloning BitBucket repositories is not supported yet. Please clone the repository manually.")
-
-    def can_clone_remote_repo(self, url: str) -> bool:
-        """Return True if the remote repository can be cloned.
-
-        Parameters
-        ----------
-        url : str
-            The remote url.
-
-        Returns
-        -------
-        bool
-            True if the repo can be cloned, else False.
-        """
-        logger.info("Cloning BitBucket repositories is not supported yet. Please clone the repository manually.")
-        return False

--- a/src/macaron/slsa_analyzer/git_service/bitbucket.py
+++ b/src/macaron/slsa_analyzer/git_service/bitbucket.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the spec for the BitBucket service."""
@@ -19,7 +19,8 @@ class BitBucket(BaseGitService):
         super().__init__("bitbucket")
 
     def load_defaults(self) -> None:
-        """Load the default values from defaults.ini."""
+        """Load the values for this git service from the ini configuration."""
+        return None
 
     def can_clone_remote_repo(self, url: str) -> bool:
         """Return True if the remote repository can be cloned.

--- a/src/macaron/slsa_analyzer/git_service/bitbucket.py
+++ b/src/macaron/slsa_analyzer/git_service/bitbucket.py
@@ -5,7 +5,6 @@
 
 import logging
 
-from macaron.slsa_analyzer import git_url
 from macaron.slsa_analyzer.git_service.base_git_service import BaseGitService
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -37,22 +36,3 @@ class BitBucket(BaseGitService):
         """
         logger.info("Cloning BitBucket repositories is not supported yet. Please clone the repository manually.")
         return False
-
-    def is_detected(self, url: str) -> bool:
-        """Return True if the remote repo is using this git service.
-
-        Parameters
-        ----------
-        url : str
-            The url of the remote repo.
-
-        Returns
-        -------
-        bool
-            True if this git service is detected else False.
-        """
-        parsed_url = git_url.parse_remote_url(url)
-        if not parsed_url or self.name not in parsed_url.netloc:
-            return False
-
-        return True

--- a/src/macaron/slsa_analyzer/git_service/bitbucket.py
+++ b/src/macaron/slsa_analyzer/git_service/bitbucket.py
@@ -19,7 +19,13 @@ class BitBucket(BaseGitService):
 
     def load_defaults(self) -> None:
         """Load the values for this git service from the ini configuration."""
+        # TODO: implement this once support for BitBucket is added.
         return None
+
+    def clone_repo(self, _clone_dir: str, _url: str) -> None:
+        """Clone a BitBucket repo."""
+        # TODO: implement this once support for BitBucket is added.
+        logger.info("Cloning BitBucket repositories is not supported yet. Please clone the repository manually.")
 
     def can_clone_remote_repo(self, url: str) -> bool:
         """Return True if the remote repository can be cloned.

--- a/src/macaron/slsa_analyzer/git_service/github.py
+++ b/src/macaron/slsa_analyzer/git_service/github.py
@@ -42,26 +42,6 @@ class GitHub(BaseGitService):
 
         return self._api_client
 
-    def can_clone_remote_repo(self, url: str) -> bool:
-        """Return True if the remote repository can be cloned.
-
-        Parameters
-        ----------
-        url : str
-            The remote url.
-
-        Returns
-        -------
-        bool
-            True if the repo can be cloned, else False.
-        """
-        remote_url = git_url.get_remote_vcs_url(url)
-        full_name = git_url.get_repo_full_name_from_url(remote_url)
-        if not self.api_client.get_repo_data(full_name):
-            return False
-
-        return True
-
     def clone_repo(self, clone_dir: str, url: str) -> None:
         """Clone a GitHub repository.
 

--- a/src/macaron/slsa_analyzer/git_service/github.py
+++ b/src/macaron/slsa_analyzer/git_service/github.py
@@ -62,21 +62,3 @@ class GitHub(BaseGitService):
 
         return True
 
-    def is_detected(self, url: str) -> bool:
-        """Return True if the remote repo is using this git service.
-
-        Parameters
-        ----------
-        url : str
-            The url of the remote repo.
-
-        Returns
-        -------
-        bool
-            True if this git service is detected else False.
-        """
-        parsed_url = git_url.parse_remote_url(url)
-        if not parsed_url or self.name not in parsed_url.netloc:
-            return False
-
-        return True

--- a/src/macaron/slsa_analyzer/git_service/github.py
+++ b/src/macaron/slsa_analyzer/git_service/github.py
@@ -62,3 +62,17 @@ class GitHub(BaseGitService):
 
         return True
 
+    def clone_repo(self, clone_dir: str, url: str) -> None:
+        """Clone a GitHub repository.
+
+        clone_dir: str
+            The name of the directory to clone into.
+            This is equivalent to the <directory> argument of ``git clone``.
+            The url to the repository.
+
+        Raises
+        ------
+        CloneError
+            If there is an error cloning the repo.
+        """
+        git_url.clone_remote_repo(clone_dir, url)

--- a/src/macaron/slsa_analyzer/git_service/github.py
+++ b/src/macaron/slsa_analyzer/git_service/github.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the spec for the GitHub service."""
 
 from macaron.config.global_config import global_config
+from macaron.errors import ConfigurationError
 from macaron.slsa_analyzer import git_url
 from macaron.slsa_analyzer.git_service.api_client import GhAPIClient, get_default_gh_client
 from macaron.slsa_analyzer.git_service.base_git_service import BaseGitService
@@ -15,10 +16,20 @@ class GitHub(BaseGitService):
     def __init__(self) -> None:
         """Initialize instance."""
         super().__init__("github")
-        self._api_client: GhAPIClient = None  # type: ignore
+        self._api_client: GhAPIClient | None = None
 
     def load_defaults(self) -> None:
-        """Load the default values from defaults.ini."""
+        """Load the values for this git service from the ini configuration and environment variables.
+
+        Raises
+        ------
+        ConfigurationError
+            If there is an error loading the configuration.
+        """
+        try:
+            self.domain = self.load_domain(section_name="git_service.github")
+        except ConfigurationError as error:
+            raise error
 
     @property
     def api_client(self) -> GhAPIClient:

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -22,7 +22,6 @@ import os
 from abc import abstractmethod
 
 from macaron.errors import ConfigurationError
-from macaron.slsa_analyzer import git_url
 from macaron.slsa_analyzer.git_service.base_git_service import BaseGitService
 
 
@@ -54,24 +53,7 @@ class GitLab(BaseGitService):
         """
         return False
 
-    def is_detected(self, url: str) -> bool:
-        """Return True if the remote repo is using this git service.
 
-        Parameters
-        ----------
-        url : str
-            The url of the remote repo.
-
-        Returns
-        -------
-        bool
-            True if this git service is detected else False.
-        """
-        parsed_url = git_url.parse_remote_url(url)
-        if not parsed_url or self.name not in parsed_url.netloc:
-            return False
-
-        return True
 
 
 class PrivateGitLab(GitLab):

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -39,21 +39,6 @@ class GitLab(BaseGitService):
         """Load the .ini configuration."""
         raise NotImplementedError()
 
-    def can_clone_remote_repo(self, url: str) -> bool:
-        """Return True if the remote repository can be cloned.
-
-        Parameters
-        ----------
-        url : str
-            The remote url.
-
-        Returns
-        -------
-        bool
-            True if the repo can be cloned, else False.
-        """
-        return False
-
     def construct_clone_url(self, url: str) -> str:
         """Construct a clone URL for GitLab, with or without access token.
 

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -18,12 +18,15 @@ In the ini configuration file, settings for the ``public`` GitLab service is in 
 is in the ``[git_service.gitlab.private]`` section.
 """
 
+import logging
 import os
 from abc import abstractmethod
 
 from macaron.errors import CloneError, ConfigurationError
 from macaron.slsa_analyzer import git_url
 from macaron.slsa_analyzer.git_service.base_git_service import BaseGitService
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class GitLab(BaseGitService):
@@ -58,12 +61,10 @@ class GitLab(BaseGitService):
         CloneError
             If there is an error parsing the URL.
         """
-        class_name = type(self).__name__
         if not self.domain:
             # This should not happen.
-            raise CloneError(
-                f"Internal error: The repository '{url} should not be cloned from the git service '{class_name}'."
-            )
+            logger.debug("Cannot clone with a Git service having no domain.")
+            raise CloneError(f"Cannot clone the repo '{url}' due to an internal error.")
 
         url_parse_result = git_url.parse_remote_url(
             url,
@@ -71,8 +72,7 @@ class GitLab(BaseGitService):
         )
         if not url_parse_result:
             raise CloneError(
-                f"Cannot clone the repo '{url}' from the git service '{class_name}'"
-                "the URL format is invalid or not supported by Macaron."
+                f"Cannot clone the repo '{url}' due to the URL format being invalid or not supported by Macaron."
             )
 
         if self.access_token:

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -1,8 +1,27 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
-"""This module contains the spec for the GitLab service."""
+"""This module contains the spec for the GitLab service.
 
+Note: We are making the assumption that we are only supporting two different GitLab
+services: one is called ``public`` and the other is called ``private``.
+
+The corresponding access tokens are stored in the environment variables
+``MCN_PUBLIC_GITLAB_TOKEN`` and ``MCN_PRIVATE_GITLAB_TOKEN``, respectively.
+
+Reason for this is mostly because of our assumption that Macaron is used as a
+container. Fixing static names for the environment variables allows for easier
+propagation of these variables into the container.
+
+In the ini configuration file, settings for the ``public`` GitLab service is in the
+``[git_service.gitlab.public]`` section; settings for the ``private`` GitLab service
+is in the ``[git_service.gitlab.private]`` section.
+"""
+
+import os
+from abc import abstractmethod
+
+from macaron.errors import ConfigurationError
 from macaron.slsa_analyzer import git_url
 from macaron.slsa_analyzer.git_service.base_git_service import BaseGitService
 
@@ -13,9 +32,12 @@ class GitLab(BaseGitService):
     def __init__(self) -> None:
         """Initialize instance."""
         super().__init__("gitlab")
+        self.access_token: str | None = None
 
+    @abstractmethod
     def load_defaults(self) -> None:
-        """Load the default values from defaults.ini."""
+        """Load the .ini configuration."""
+        raise NotImplementedError()
 
     def can_clone_remote_repo(self, url: str) -> bool:
         """Return True if the remote repository can be cloned.
@@ -50,3 +72,56 @@ class GitLab(BaseGitService):
             return False
 
         return True
+
+
+class PrivateGitLab(GitLab):
+    """The private GitLab instance."""
+
+    def load_defaults(self) -> None:
+        """Load the values for this git service from the ini configuration and environment variables.
+
+        In this case, the environment variable ``MCN_PRIVATE_GITLAB_TOKEN`` holding
+        the access token for the private GitLab service is expected.
+
+        Raises
+        ------
+        ConfigurationError
+            If there is an error loading the configuration.
+        """
+        try:
+            self.domain = self.load_domain(section_name="git_service.gitlab.private")
+        except ConfigurationError as error:
+            raise error
+
+        if not self.domain:
+            return
+
+        access_token_env_var = "MCN_PRIVATE_GITLAB_TOKEN"  # nosec B105
+        self.access_token = os.environ.get(access_token_env_var)
+
+        if not self.access_token:
+            raise ConfigurationError(
+                f"Environment variable '{access_token_env_var}' is not set for private GitLab service '{self.domain}'."
+            )
+
+
+class PublicGitLab(GitLab):
+    """The public GitLab instance."""
+
+    def load_defaults(self) -> None:
+        """Load the values for this git service from the ini configuration and environment variables.
+
+        In this case, the environment variable ``MCN_PUBLIC_GITLAB_TOKEN`` holding
+        the access token for the public GitLab service is optional.
+
+        Raises
+        ------
+        ConfigurationError
+            If there is an error loading the configuration.
+        """
+        try:
+            self.domain = self.load_domain(section_name="git_service.gitlab.public")
+        except ConfigurationError as error:
+            raise error
+
+        self.access_token = os.environ.get("MCN_PUBLIC_GITLAB_TOKEN")

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -453,8 +453,14 @@ def get_remote_origin_of_local_repo(git_obj: Git) -> str:
     # This is because cloning from GitLab with an access token requires us to embed
     # the token in the URL.
     if "oauth2" in remote_origin_path:
-        url_parse_result = urllib.parse.urlparse(remote_origin_path)
+        try:
+            url_parse_result = urllib.parse.urlparse(remote_origin_path)
+        except ValueError:
+            logger.error("Error occurs while processing the remote URL of repo %s.", git_obj.project_name)
+            return ""
+
         _, _, domain = url_parse_result.netloc.rpartition("@")
+
         new_url_parse_result = urllib.parse.ParseResult(
             scheme=url_parse_result.scheme,
             netloc=domain,

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -327,18 +327,27 @@ def clone_remote_repo(clone_dir: str, url: str) -> Repo | None:
     # Macaron attempting to clone a repository multiple times.
     # In these cases, we should not error since it may interrupt the analysis.
     if os.path.isdir(clone_dir):
+        logger.info("Checking if the repo %s needs cloning.", url)
         try:
             os.rmdir(clone_dir)
             logger.info(
-                "The clone dir %s is empty. It has been deleted for cloning the repo.",
+                "The clone dir %s is empty. It has been deleted for cloning the repo %s.",
                 clone_dir,
+                url,
             )
         except OSError:
-            logger.info("The clone dir %s is not empty. No cloning is proceeded.", clone_dir)
+            logger.info(
+                "The clone dir %s is not empty. This probably means the repo %s has already been clone. "
+                "No cloning is proceeded.",
+                clone_dir,
+                url,
+            )
             return None
 
-    # The Repo.clone_from method handles creating intermediate dirs.
+    logger.info("Cloning the repo %s to %s.", url, clone_dir)
+
     try:
+        # The Repo.clone_from method handles creating intermediate dirs.
         return Repo.clone_from(
             url=url,
             to_path=clone_dir,

--- a/tests/e2e/expected_results/tinyMediaManager/tinyMediaManager.json
+++ b/tests/e2e/expected_results/tinyMediaManager/tinyMediaManager.json
@@ -1,0 +1,211 @@
+{
+    "metadata": {
+        "timestamps": "2023-06-20 18:27:38"
+    },
+    "target": {
+        "info": {
+            "full_name": "tinyMediaManager/tinyMediaManager",
+            "local_cloned_path": "git_repos/gitlab_com/tinyMediaManager/tinyMediaManager",
+            "remote_path": "https://gitlab.com/tinyMediaManager/tinyMediaManager",
+            "branch": "main",
+            "commit_hash": "cca6b67a335074eca42136556f0a321f75dc4f48",
+            "commit_date": "2023-05-23T15:54:04+00:00"
+        },
+        "provenances": {
+            "is_inferred": true,
+            "content": {
+                "gitlab_ci": [
+                    {
+                        "_type": "https://in-toto.io/Statement/v0.1",
+                        "subject": [],
+                        "predicateType": "https://slsa.dev/provenance/v0.2",
+                        "predicate": {
+                            "builder": {
+                                "id": "<URI>"
+                            },
+                            "buildType": "<URI>",
+                            "invocation": {
+                                "configSource": {
+                                    "uri": "<URI>",
+                                    "digest": {
+                                        "sha1": "<STING>"
+                                    },
+                                    "entryPoint": "<STRING>"
+                                },
+                                "parameters": {},
+                                "environment": {}
+                            },
+                            "buildConfig": {},
+                            "metadata": {
+                                "buildInvocationId": "<STRING>",
+                                "buildStartedOn": "<TIMESTAMP>",
+                                "buildFinishedOn": "<TIMESTAMP>",
+                                "completeness": {
+                                    "parameters": "false",
+                                    "environment": "false",
+                                    "materials": "false"
+                                },
+                                "reproducible": "false"
+                            },
+                            "materials": [
+                                {
+                                    "uri": "<URI>",
+                                    "digest": {}
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "checks": {
+            "summary": {
+                "DISABLED": 0,
+                "FAILED": 6,
+                "PASSED": 2,
+                "SKIPPED": 0,
+                "UNKNOWN": 0
+            },
+            "results": [
+                {
+                    "check_id": "mcn_build_script_1",
+                    "check_description": "Check if the target repo has a valid build script.",
+                    "slsa_requirements": [
+                        "Scripted Build - SLSA Level 1"
+                    ],
+                    "justification": [
+                        "The target repository uses build tool maven."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_version_control_system_1",
+                    "check_description": "Check whether the target repo uses a version control system.",
+                    "slsa_requirements": [
+                        "Version controlled - SLSA Level 2"
+                    ],
+                    "justification": [
+                        {
+                            "This is a Git repository": "https://gitlab.com/tinyMediaManager/tinyMediaManager"
+                        }
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_build_as_code_1",
+                    "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
+                    "slsa_requirements": [
+                        "Build as code - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "The target repository does not use maven to deploy."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_build_service_1",
+                    "check_description": "Check if the target repo has a valid build service.",
+                    "slsa_requirements": [
+                        "Build service - SLSA Level 2"
+                    ],
+                    "justification": [
+                        "The target repository does not have a build service."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_available_1",
+                    "check_description": "Check whether the target has intoto provenance.",
+                    "slsa_requirements": [
+                        "Provenance - Available - SLSA Level 1",
+                        "Provenance content - Identifies build instructions - SLSA Level 1",
+                        "Provenance content - Identifies artifacts - SLSA Level 1",
+                        "Provenance content - Identifies builder - SLSA Level 1"
+                    ],
+                    "justification": [
+                        "Could not find any SLSA provenances."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_expectation_1",
+                    "check_description": "Check whether the SLSA provenance for the produced artifact conforms to the expected value.",
+                    "slsa_requirements": [
+                        "Provenance conforms with expectations - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_level_three_1 FAILED."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_level_three_1",
+                    "check_description": "Check whether the target has SLSA provenance level 3.",
+                    "slsa_requirements": [
+                        "Provenance - Non falsifiable - SLSA Level 3",
+                        "Provenance content - Includes all build parameters - SLSA Level 3",
+                        "Provenance content - Identifies entry point - SLSA Level 3",
+                        "Provenance content - Identifies source code - SLSA Level 2"
+                    ],
+                    "justification": [
+                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_trusted_builder_level_three_1",
+                    "check_description": "Check whether the target uses a trusted SLSA level 3 builder.",
+                    "slsa_requirements": [
+                        "Hermetic - SLSA Level 4",
+                        "Isolated - SLSA Level 3",
+                        "Parameterless - SLSA Level 4",
+                        "Ephemeral environment - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                    ],
+                    "result_type": "FAILED"
+                }
+            ]
+        }
+    },
+    "dependencies": {
+        "analyzed_deps": 0,
+        "unique_dep_repos": 0,
+        "checks_summary": [
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_available_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            }
+        ],
+        "dep_status": []
+    }
+}

--- a/tests/slsa_analyzer/git_service/test_github.py
+++ b/tests/slsa_analyzer/git_service/test_github.py
@@ -5,10 +5,8 @@
 This module tests the GitHub git service.
 """
 
-from unittest.mock import patch
 
 from macaron.slsa_analyzer.git_service import GitHub
-from macaron.slsa_analyzer.git_service.api_client import GhAPIClient
 
 from ...macaron_testcase import MacaronTestCase
 
@@ -29,12 +27,3 @@ class TestGitHub(MacaronTestCase):
         assert not github.is_detected("git@githubb.com:org/name")
         assert not github.is_detected("git@not_supported_git_host.com:7999/org/name")
         assert not github.is_detected("ssh://git@bitbucket.com:7999/org/name")
-
-    def test_can_clone_remote_repo(self) -> None:
-        """Test the can clone remote repo method."""
-        github = GitHub()
-        with patch.object(GhAPIClient, "get_repo_data", return_value=True):
-            assert github.can_clone_remote_repo("can_clone_repo_url")
-
-        with patch.object(GhAPIClient, "get_repo_data", return_value=False):
-            assert not github.can_clone_remote_repo("invalid_repo_url")

--- a/tests/slsa_analyzer/git_service/test_github.py
+++ b/tests/slsa_analyzer/git_service/test_github.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """
@@ -19,6 +19,7 @@ class TestGitHub(MacaronTestCase):
     def test_is_detected(self) -> None:
         """Test the is detected method."""
         github = GitHub()
+        github.load_defaults()
 
         assert github.is_detected("http://github.com/org/name")
         assert github.is_detected("git@github.com:org/name")

--- a/tests/slsa_analyzer/git_service/test_gitlab.py
+++ b/tests/slsa_analyzer/git_service/test_gitlab.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Tests for the GitLab git service."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from macaron.slsa_analyzer.git_service.gitlab import PublicGitLab
+
+
+@pytest.mark.parametrize(
+    ("repo_url"),
+    [
+        "https://gitlab.com/owner/repo.git",
+        "https://gitlab.com/owner/repo",
+    ],
+)
+def test_construct_clone_url_without_token(repo_url: str) -> None:
+    """Test if the ``construct_clone_url`` method produces proper clone URLs without the access token."""
+    clone_url = repo_url
+    gitlab = PublicGitLab()
+    gitlab.load_defaults()
+    assert gitlab.construct_clone_url(repo_url) == clone_url
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "clone_url"),
+    [
+        (
+            "https://gitlab.com/owner/repo.git",
+            "https://oauth2:abcxyz@gitlab.com/owner/repo.git",
+        ),
+        (
+            "https://gitlab.com/owner/repo",
+            "https://oauth2:abcxyz@gitlab.com/owner/repo",
+        ),
+    ],
+)
+def test_construct_clone_url_with_token(repo_url: str, clone_url: str) -> None:
+    """Test if the ``construct_clone_url`` method produces proper clone URLs with the access token."""
+    with mock.patch.dict(os.environ, {"MCN_PUBLIC_GITLAB_TOKEN": "abcxyz"}):
+        gitlab = PublicGitLab()
+        gitlab.load_defaults()
+        assert gitlab.construct_clone_url(repo_url) == clone_url

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -4,7 +4,6 @@
 """This module tests the generic actions on Git repositories."""
 
 import os
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -53,13 +52,6 @@ def test_get_repo_name_from_url() -> None:
     # Test get repo full name
     assert all(git_url.get_repo_full_name_from_url(url) == repo_full_name for url in valid_git_urls)
     assert not any(git_url.get_repo_full_name_from_url(url) for url in invalid_git_urls)
-
-
-def test_clone_remote_repo() -> None:
-    """
-    Test the clone remote repository method
-    """
-    assert not git_url.clone_remote_repo(str(Path(__file__).parent), "")
 
 
 def test_is_remote_repo() -> None:

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -202,9 +202,9 @@ def test_get_remote_vcs_url_with_user_defined_allowed_domains(tmp_path: Path) ->
     with open(user_config_path, "w", encoding="utf-8") as user_config_file:
         user_config_file.write(
             """
-                               [git_service.gitlab.private]
-                               domain = internal.gitlab.org
-                               """
+            [git_service.gitlab.private]
+            domain = internal.gitlab.org
+            """
         )
     # We don't have to worry about modifying the ``defaults`` object causing test
     # pollution here, since we reload the ``defaults`` object before every test with the


### PR DESCRIPTION
Closes #301.

# Description

This PR adds support for cloning GitLab repositories in Macaron. Specifically, GitLab repositories can now be cloned as either main targets or dependencies in a `macaron analyze` run.

This feature comes with the following additions/changes:

## `.ini` configuration

* The old `[git]` section in the `.ini` configuration will now be replaced by the new `[git_service.*]`  sections.
* Each `[git_service]` section corresponds to a different git service with a `domain` key. This domain is used to determine if a Git service hosts a repo given the repo's Git URL.
* If the `domain` key is not found in any `[git_service.*]`  section, the command `macaron analyze`  will error right away before any analysis is done.
* Users can configure 2 different GitLab services in the `[git_service.gitlab.*]`  sections: a public one and a private one. The domain of the public GitLab service is `gitlab.com` by default.

## Access Token Environment Variables

An access token for the public GitLab service is not required when it is enabled. However, an access token for the private GitLab service is always required when it is enabled.

We accept two environment variables storing the access tokens that correspond to the two GitLab services:
  * `MCN_PUBLIC_GITLAB_TOKEN`  for the public GitLab service.
  * `MCN_PRIVATE_GITLAB_TOKEN`  for the private GitLab service.

The `MCN_PRIVATE_GITLAB_TOKEN` environment variable must be set when the `[git_service.gitlab.private]` section is enabled in the `.ini` config. If this is not the case, the command `macaron analyze`  will error right away before any analysis is done.