### PR TITLE
feat: allow excluding paths in build tool detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,7 +171,6 @@ cdx_debug.json
 sbom_debug.json
 golang/internal/filewriter/mock_dir/result.json
 tests/config/defaults.ini
-tests/defaults.ini
 tests/slsa_analyzer/build_tool/mock_repos/gradle_repos/no_gradle/
 tests/slsa_analyzer/build_tool/mock_repos/maven_repos/no_pom/
 tests/slsa_analyzer/checks/mock_repos/**

--- a/src/macaron/slsa_analyzer/build_tool/base_build_tool.py
+++ b/src/macaron/slsa_analyzer/build_tool/base_build_tool.py
@@ -15,7 +15,7 @@ from macaron.dependency_analyzer import DependencyAnalyzer
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def file_exists(path: str, file_name: str) -> bool:
+def file_exists(path: str, file_name: str, exclude_paths: list[str] | None = None) -> bool:
     """Return True if a file exists in a directory.
 
     This method searches in the directory recursively.
@@ -26,6 +26,8 @@ def file_exists(path: str, file_name: str) -> bool:
         The path to search for the file.
     file_name : str
         The name of the file to search.
+    exclude_paths: list[str] | None
+        The list of sub-paths that should be ignored.
 
     Returns
     -------
@@ -35,7 +37,9 @@ def file_exists(path: str, file_name: str) -> bool:
     pattern = os.path.join(path, "**", file_name)
     files_detected = glob.iglob(pattern, recursive=True)
     try:
-        next(files_detected)
+        path = next(files_detected)
+        if exclude_paths and any(exc in path.lower() for exc in exclude_paths):
+            return False
         return True
     except StopIteration:
         return False
@@ -53,6 +57,7 @@ class BaseBuildTool(ABC):
             The name of this build tool.
         """
         self.name = name
+        self.exclude_paths: list[str] = []
         self.entry_conf: list[str] = []
         self.build_configs: list[str] = []
         self.package_lock: list[str] = []

--- a/src/macaron/slsa_analyzer/build_tool/gradle.py
+++ b/src/macaron/slsa_analyzer/build_tool/gradle.py
@@ -58,7 +58,7 @@ class Gradle(BaseBuildTool):
         """
         gradle_config_files = self.build_configs + self.entry_conf
         for file in gradle_config_files:
-            if file_exists(repo_path, file):
+            if file_exists(repo_path, file, self.exclude_paths):
                 return True
 
         return False

--- a/src/macaron/slsa_analyzer/build_tool/maven.py
+++ b/src/macaron/slsa_analyzer/build_tool/maven.py
@@ -66,7 +66,7 @@ class Maven(BaseBuildTool):
             return False
         maven_config_files = self.build_configs
         for file in maven_config_files:
-            if file_exists(repo_path, file):
+            if file_exists(repo_path, file, self.exclude_paths):
                 return True
 
         return False

--- a/src/macaron/slsa_analyzer/build_tool/pip.py
+++ b/src/macaron/slsa_analyzer/build_tool/pip.py
@@ -48,7 +48,7 @@ class Pip(BaseBuildTool):
             True if this build tool is detected, else False.
         """
         for file in self.build_configs:
-            if file_exists(repo_path, file):
+            if file_exists(repo_path, file, self.exclude_paths):
                 return True
         return False
 

--- a/src/macaron/slsa_analyzer/build_tool/poetry.py
+++ b/src/macaron/slsa_analyzer/build_tool/poetry.py
@@ -53,7 +53,7 @@ class Poetry(BaseBuildTool):
         """
         package_lock_exists = ""
         for file in self.package_lock:
-            if file_exists(repo_path, file):
+            if file_exists(repo_path, file, self.exclude_paths):
                 package_lock_exists = file
                 break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,13 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Fixtures for tests."""
+import os
 from pathlib import Path
 from typing import NoReturn
 
 import pytest
 
-from macaron.config.defaults import create_defaults, defaults, load_defaults
+from macaron.config.defaults import defaults, load_defaults
 from macaron.slsa_analyzer.build_tool.gradle import Gradle
 from macaron.slsa_analyzer.build_tool.maven import Maven
 from macaron.slsa_analyzer.build_tool.pip import Pip
@@ -47,7 +48,7 @@ def macaron_path() -> Path:
 
 
 @pytest.fixture(autouse=True)
-def setup_test(test_dir: Path, macaron_path: Path) -> NoReturn:  # type: ignore
+def setup_test(test_dir: Path) -> NoReturn:  # type: ignore
     """Set up the necessary values for the tests.
 
     Parameters
@@ -62,10 +63,7 @@ def setup_test(test_dir: Path, macaron_path: Path) -> NoReturn:  # type: ignore
     NoReturn
     """
     # Load values from defaults.ini.
-    if not test_dir.joinpath("defaults.ini").exists():
-        create_defaults(str(test_dir), str(macaron_path))
-
-    load_defaults(str(macaron_path))
+    load_defaults(os.path.join(str(test_dir), "defaults.ini"))
     yield
     defaults.clear()
 

--- a/tests/defaults.ini
+++ b/tests/defaults.ini
@@ -1,0 +1,14 @@
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+[builder.maven]
+exclude_paths =
+
+[builder.gradle]
+exclude_paths =
+
+[builder.pip]
+exclude_paths =
+
+[builder.poetry]
+exclude_paths =

--- a/tests/e2e/configurations/macaron_defaults.ini
+++ b/tests/e2e/configurations/macaron_defaults.ini
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 [runner]
@@ -173,6 +173,7 @@ jenkins =
 [builder.gradle]
 exclude_paths =
     test
+    resources
 entry_conf =
     settings.gradle
     settings.gradle.kts

--- a/tests/e2e/expected_results/macaron/macaron.json
+++ b/tests/e2e/expected_results/macaron/macaron.json
@@ -1,0 +1,216 @@
+{
+    "metadata": {
+        "timestamps": "2023-06-20 11:43:45"
+    },
+    "target": {
+        "info": {
+            "full_name": "oracle/macaron",
+            "local_cloned_path": "git_repos/github_com/oracle/macaron",
+            "remote_path": "https://github.com/oracle/macaron",
+            "branch": "main",
+            "commit_hash": "c1b5435961e2b61f5377f0cc8a441c0fff28aa55",
+            "commit_date": "2023-06-14T06:40:52+00:00"
+        },
+        "provenances": {
+            "is_inferred": true,
+            "content": {
+                "github_actions": [
+                    {
+                        "_type": "https://in-toto.io/Statement/v0.1",
+                        "subject": [],
+                        "predicateType": "https://slsa.dev/provenance/v0.2",
+                        "predicate": {
+                            "builder": {
+                                "id": "https://github.com/oracle/macaron/blob/c1b5435961e2b61f5377f0cc8a441c0fff28aa55/.github/workflows/pr-conventional-commits.yaml"
+                            },
+                            "buildType": "Custom github_actions",
+                            "invocation": {
+                                "configSource": {
+                                    "uri": "https://github.com/oracle/macaron@refs/heads/main",
+                                    "digest": {
+                                        "sha1": "c1b5435961e2b61f5377f0cc8a441c0fff28aa55"
+                                    },
+                                    "entryPoint": "https://github.com/oracle/macaron/blob/c1b5435961e2b61f5377f0cc8a441c0fff28aa55/.github/workflows/pr-conventional-commits.yaml"
+                                },
+                                "parameters": {},
+                                "environment": {}
+                            },
+                            "buildConfig": {},
+                            "metadata": {
+                                "buildInvocationId": "",
+                                "buildStartedOn": "<TIMESTAMP>",
+                                "buildFinishedOn": "<TIMESTAMP>",
+                                "completeness": {
+                                    "parameters": "false",
+                                    "environment": "false",
+                                    "materials": "false"
+                                },
+                                "reproducible": "false"
+                            },
+                            "materials": [
+                                {
+                                    "uri": "<URI>",
+                                    "digest": {}
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "checks": {
+            "summary": {
+                "DISABLED": 0,
+                "FAILED": 5,
+                "PASSED": 3,
+                "SKIPPED": 0,
+                "UNKNOWN": 0
+            },
+            "results": [
+                {
+                    "check_id": "mcn_build_script_1",
+                    "check_description": "Check if the target repo has a valid build script.",
+                    "slsa_requirements": [
+                        "Scripted Build - SLSA Level 1"
+                    ],
+                    "justification": [
+                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_build_service_1",
+                    "check_description": "Check if the target repo has a valid build service.",
+                    "slsa_requirements": [
+                        "Build service - SLSA Level 2"
+                    ],
+                    "justification": [
+                        {
+                            "The target repository uses build tool pip to deploy": "https://github.com/oracle/macaron/blob/c1b5435961e2b61f5377f0cc8a441c0fff28aa55/.github/workflows/pr-conventional-commits.yaml",
+                            "The build is triggered by": "https://github.com/oracle/macaron/blob/c1b5435961e2b61f5377f0cc8a441c0fff28aa55/.github/workflows/pr-conventional-commits.yaml"
+                        },
+                        "Build command: ['pip', 'install', '--upgrade', 'pip', 'wheel']",
+                        "However, could not find a passing workflow run."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_version_control_system_1",
+                    "check_description": "Check whether the target repo uses a version control system.",
+                    "slsa_requirements": [
+                        "Version controlled - SLSA Level 2"
+                    ],
+                    "justification": [
+                        {
+                            "This is a Git repository": "https://github.com/oracle/macaron"
+                        }
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_build_as_code_1",
+                    "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
+                    "slsa_requirements": [
+                        "Build as code - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "The target repository does not use pip to deploy."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_available_1",
+                    "check_description": "Check whether the target has intoto provenance.",
+                    "slsa_requirements": [
+                        "Provenance - Available - SLSA Level 1",
+                        "Provenance content - Identifies build instructions - SLSA Level 1",
+                        "Provenance content - Identifies artifacts - SLSA Level 1",
+                        "Provenance content - Identifies builder - SLSA Level 1"
+                    ],
+                    "justification": [
+                        "Could not find any SLSA provenances."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_expectation_1",
+                    "check_description": "Check whether the SLSA provenance for the produced artifact conforms to the expected value.",
+                    "slsa_requirements": [
+                        "Provenance conforms with expectations - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_level_three_1 FAILED."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_level_three_1",
+                    "check_description": "Check whether the target has SLSA provenance level 3.",
+                    "slsa_requirements": [
+                        "Provenance - Non falsifiable - SLSA Level 3",
+                        "Provenance content - Includes all build parameters - SLSA Level 3",
+                        "Provenance content - Identifies entry point - SLSA Level 3",
+                        "Provenance content - Identifies source code - SLSA Level 2"
+                    ],
+                    "justification": [
+                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_trusted_builder_level_three_1",
+                    "check_description": "Check whether the target uses a trusted SLSA level 3 builder.",
+                    "slsa_requirements": [
+                        "Hermetic - SLSA Level 4",
+                        "Isolated - SLSA Level 3",
+                        "Parameterless - SLSA Level 4",
+                        "Ephemeral environment - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                    ],
+                    "result_type": "FAILED"
+                }
+            ]
+        }
+    },
+    "dependencies": {
+        "analyzed_deps": 0,
+        "unique_dep_repos": 0,
+        "checks_summary": [
+            {
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_available_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            }
+        ],
+        "dep_status": []
+    }
+}


### PR DESCRIPTION
Closes #323 

The build tool detection can produce false positives if a project contains build metadata files as part of its tests. Macaron itself is such a project that contains files, such as settings.gradle, etc. even though it uses pip to install.

To configure excluding such paths, this PR allows adding `exclude_paths` to defaults.ini, e.g.,

```
[builder.gradle]
exclude_paths =
    test
```