### PR TITLE
chore: remove logging in clone_remote_repo function

### DIFF
--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -413,8 +413,8 @@ docker run \
     -e "USER_UID=${USER_UID}" \
     -e "USER_GID=${USER_GID}" \
     -e "GITHUB_TOKEN=${GITHUB_TOKEN}" \
-    -e "MCN_PUBLIC_GITLAB_TOKEN=${MCN_PUBLIC_GITLAB_TOKEN}" \
-    -e "MCN_PRIVATE_GITLAB_TOKEN=${MCN_PRIVATE_GITLAB_TOKEN}" \
+    -e "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}" \
+    -e "MCN_SELF_HOSTED_GITLAB_TOKEN=${MCN_SELF_HOSTED_GITLAB_TOKEN}" \
     "${proxy_vars[@]}" \
     "${prod_vars[@]}" \
     "${mounts[@]}" \

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -67,16 +67,16 @@ artifact_ignore_list =
 domain = github.com
 
 # Access to public GitLab (gitlab.com).
-# An optional access token can be provided through the `MCN_PUBLIC_GITLAB_TOKEN` environment variable.
+# An optional access token can be provided through the `MCN_GITLAB_TOKEN` environment variable.
 # This access token is optional, only necessary when you need to clone private repositories.
 # The `read_repository` permission is required for this token.
-[git_service.gitlab.public]
+[git_service.gitlab.publicly_hosted]
 domain = gitlab.com
 
-# Access to a private GitLab instance (e.g. your organization's self-hosted GitLab instance).
-# If this section is enabled, an access token must be provided through the `MCN_PRIVATE_GITLAB_TOKEN` environment variable.
+# Access to a self-hosted GitLab instance (e.g. your organization's self-hosted GitLab instance).
+# If this section is enabled, an access token must be provided through the `MCN_PUBLICLY_HOSTED_GITLAB_TOKEN` environment variable.
 # The `read_repository` permission is required for this token.
-# [git_service.gitlab.private]
+# [git_service.gitlab.self_hosted]
 # domain = example.org
 
 # This is the spec for trusted Maven build tools.

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -532,6 +532,7 @@ class Analyzer:
             git_service = self.get_git_service(resolved_remote_path)
             repo_unique_path = git_url.get_repo_dir_name(resolved_remote_path)
             resolved_local_path = os.path.join(target_dir, repo_unique_path)
+            logger.info("Cloning the repository.")
             try:
                 git_service.clone_repo(resolved_local_path, resolved_remote_path)
             except CloneError as error:

--- a/src/macaron/slsa_analyzer/git_service/__init__.py
+++ b/src/macaron/slsa_analyzer/git_service/__init__.py
@@ -6,8 +6,8 @@
 from .base_git_service import BaseGitService
 from .bitbucket import BitBucket
 from .github import GitHub
-from .gitlab import PrivateGitLab, PublicGitLab
+from .gitlab import PubliclyHostedGitLab, SelfHostedGitLab
 
 # The list of supported git services. The order of the list determines the order
 # in which each git service is checked against the target repository.
-GIT_SERVICES: list[BaseGitService] = [GitHub(), PublicGitLab(), PrivateGitLab(), BitBucket()]
+GIT_SERVICES: list[BaseGitService] = [GitHub(), PubliclyHostedGitLab(), SelfHostedGitLab(), BitBucket()]

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -4,18 +4,18 @@
 """This module contains the spec for the GitLab service.
 
 Note: We are making the assumption that we are only supporting two different GitLab
-services: one is called ``public`` and the other is called ``private``.
+services: one is called ``publicly_hosted`` and the other is called ``self_hosted``.
 
 The corresponding access tokens are stored in the environment variables
-``MCN_PUBLIC_GITLAB_TOKEN`` and ``MCN_PRIVATE_GITLAB_TOKEN``, respectively.
+``MCNGITLAB_TOKEN`` and ``MCN_SELF_HOSTED_GITLAB_TOKEN``, respectively.
 
 Reason for this is mostly because of our assumption that Macaron is used as a
 container. Fixing static names for the environment variables allows for easier
 propagation of these variables into the container.
 
-In the ini configuration file, settings for the ``public`` GitLab service is in the
-``[git_service.gitlab.public]`` section; settings for the ``private`` GitLab service
-is in the ``[git_service.gitlab.private]`` section.
+In the ini configuration file, settings for the ``publicly_hosted`` GitLab service is in the
+``[git_service.gitlab.publicly_hosted]`` section; settings for the ``self_hosted`` GitLab service
+is in the ``[git_service.gitlab.self_hosted]`` section.
 """
 
 import logging
@@ -120,17 +120,17 @@ class GitLab(BaseGitService):
         git_url.clone_remote_repo(clone_dir, clone_url)
 
 
-class PrivateGitLab(GitLab):
-    """The private GitLab instance."""
+class SelfHostedGitLab(GitLab):
+    """The self-hosted GitLab instance."""
 
     def __init__(self) -> None:
         """Initialize instance."""
-        super().__init__("MCN_PRIVATE_GITLAB_TOKEN")
+        super().__init__("MCN_SELF_HOSTED_GITLAB_TOKEN")
 
     def load_defaults(self) -> None:
         """Load the values for this git service from the ini configuration and environment variables.
 
-        In this case, the environment variable ``MCN_PRIVATE_GITLAB_TOKEN`` holding
+        In this case, the environment variable ``MCN_SELF_HOSTED_GITLAB_TOKEN`` holding
         the access token for the private GitLab service is expected.
 
         Raises
@@ -139,7 +139,7 @@ class PrivateGitLab(GitLab):
             If there is an error loading the configuration.
         """
         try:
-            self.domain = self.load_domain(section_name="git_service.gitlab.private")
+            self.domain = self.load_domain(section_name="git_service.gitlab.self_hosted")
         except ConfigurationError as error:
             raise error
 
@@ -153,17 +153,17 @@ class PrivateGitLab(GitLab):
             )
 
 
-class PublicGitLab(GitLab):
-    """The public GitLab instance."""
+class PubliclyHostedGitLab(GitLab):
+    """The publicly-hosted GitLab instance."""
 
     def __init__(self) -> None:
         """Initialize instance."""
-        super().__init__("MCN_PUBLIC_GITLAB_TOKEN")
+        super().__init__("MCN_GITLAB_TOKEN")
 
     def load_defaults(self) -> None:
         """Load the values for this git service from the ini configuration and environment variables.
 
-        In this case, the environment variable ``MCN_PUBLIC_GITLAB_TOKEN`` holding
+        In this case, the environment variable ``MCN_GITLAB_TOKEN`` holding
         the access token for the public GitLab service is optional.
 
         Raises
@@ -172,6 +172,6 @@ class PublicGitLab(GitLab):
             If there is an error loading the configuration.
         """
         try:
-            self.domain = self.load_domain(section_name="git_service.gitlab.public")
+            self.domain = self.load_domain(section_name="git_service.gitlab.publicly_hosted")
         except ConfigurationError as error:
             raise error

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -7,7 +7,7 @@ Note: We are making the assumption that we are only supporting two different Git
 services: one is called ``publicly_hosted`` and the other is called ``self_hosted``.
 
 The corresponding access tokens are stored in the environment variables
-``MCNGITLAB_TOKEN`` and ``MCN_SELF_HOSTED_GITLAB_TOKEN``, respectively.
+``MCN_GITLAB_TOKEN`` and ``MCN_SELF_HOSTED_GITLAB_TOKEN``, respectively.
 
 Reason for this is mostly because of our assumption that Macaron is used as a
 container. Fixing static names for the environment variables allows for easier

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -329,7 +329,13 @@ def clone_remote_repo(clone_dir: str, url: str) -> Repo | None:
     if os.path.isdir(clone_dir):
         try:
             os.rmdir(clone_dir)
+            logger.debug("The clone dir %s is empty. It has been deleted for cloning the repo.", clone_dir)
         except OSError:
+            logger.debug(
+                "The clone dir %s is not empty. This probably means the repo has already been clone. "
+                "No cloning is proceeded.",
+                clone_dir,
+            )
             return None
 
     try:

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -332,8 +332,7 @@ def clone_remote_repo(clone_dir: str, url: str) -> Repo | None:
             logger.debug("The clone dir %s is empty. It has been deleted for cloning the repo.", clone_dir)
         except OSError:
             logger.debug(
-                "The clone dir %s is not empty. This probably means the repo has already been clone. "
-                "No cloning is proceeded.",
+                "The clone dir %s is not empty. Cloning will not be proceeded.",
                 clone_dir,
             )
             return None

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -327,24 +327,10 @@ def clone_remote_repo(clone_dir: str, url: str) -> Repo | None:
     # Macaron attempting to clone a repository multiple times.
     # In these cases, we should not error since it may interrupt the analysis.
     if os.path.isdir(clone_dir):
-        logger.info("Checking if the repo %s needs cloning.", url)
         try:
             os.rmdir(clone_dir)
-            logger.info(
-                "The clone dir %s is empty. It has been deleted for cloning the repo %s.",
-                clone_dir,
-                url,
-            )
         except OSError:
-            logger.info(
-                "The clone dir %s is not empty. This probably means the repo %s has already been clone. "
-                "No cloning is proceeded.",
-                clone_dir,
-                url,
-            )
             return None
-
-    logger.info("Cloning the repo %s to %s.", url, clone_dir)
 
     try:
         # The Repo.clone_from method handles creating intermediate dirs.

--- a/tests/slsa_analyzer/git_service/test_gitlab.py
+++ b/tests/slsa_analyzer/git_service/test_gitlab.py
@@ -4,11 +4,14 @@
 """Tests for the GitLab git service."""
 
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from macaron.slsa_analyzer.git_service.gitlab import PubliclyHostedGitLab
+from macaron.config.defaults import load_defaults
+from macaron.errors import ConfigurationError
+from macaron.slsa_analyzer.git_service.gitlab import PubliclyHostedGitLab, SelfHostedGitLab
 
 
 @pytest.mark.parametrize(
@@ -45,3 +48,66 @@ def test_construct_clone_url_with_token(repo_url: str, clone_url: str) -> None:
         gitlab = PubliclyHostedGitLab()
         gitlab.load_defaults()
         assert gitlab.construct_clone_url(repo_url) == clone_url
+
+
+@pytest.mark.parametrize(
+    ("user_config_input", "repo_url", "clone_url"),
+    [
+        pytest.param(
+            """
+            [git_service.gitlab.self_hosted]
+            domain = internal.gitlab.org
+            """,
+            "https://internal.gitlab.org/owner/repo.git",
+            "https://oauth2:abcxyz@internal.gitlab.org/owner/repo.git",
+            id="Self-hosted GitLab is set in user config.",
+        ),
+        pytest.param(
+            """
+            [git_service.gitlab.self_hosted]
+            domain = internal.gitlab.org
+            """,
+            "https://internal.gitlab.org/owner/repo",
+            "https://oauth2:abcxyz@internal.gitlab.org/owner/repo",
+            id="Self-hosted GitLab is set in user config.",
+        ),
+    ],
+)
+def test_construct_clone_url_for_self_hosted_gitlab(
+    user_config_input: str, repo_url: str, clone_url: str, tmp_path: Path
+) -> None:
+    """Test if the ``construct_clone_url`` method produces proper clone URLs with the access token."""
+    user_config_path = os.path.join(tmp_path, "config.ini")
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+    # We don't have to worry about modifying the ``defaults`` object causing test
+    # pollution here, since we reload the ``defaults`` object before every test with the
+    # ``setup_test`` fixture.
+    load_defaults(user_config_path)
+
+    with mock.patch.dict(os.environ, {"MCN_SELF_HOSTED_GITLAB_TOKEN": "abcxyz"}):
+        gitlab = SelfHostedGitLab()
+        gitlab.load_defaults()
+        assert gitlab.construct_clone_url(repo_url) == clone_url
+
+
+def test_self_hosted_gitlab_without_env_set(tmp_path: Path) -> None:
+    """Test if the ``load_defaults`` method raises error if the required env variable is not set."""
+    user_config_input = """
+    [git_service.gitlab.self_hosted]
+    domain = internal.gitlab.org
+    """
+    user_config_path = os.path.join(tmp_path, "config.ini")
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+
+    # We don't have to worry about modifying the ``defaults`` object causing test
+    # pollution here, since we reload the ``defaults`` object before every test with the
+    # ``setup_test`` fixture.
+    load_defaults(user_config_path)
+
+    with mock.patch.dict(os.environ, {"MCN_SELF_HOSTED_GITLAB_TOKEN": ""}):
+        gitlab = SelfHostedGitLab()
+
+        with pytest.raises(ConfigurationError):
+            gitlab.load_defaults()

--- a/tests/slsa_analyzer/git_service/test_gitlab.py
+++ b/tests/slsa_analyzer/git_service/test_gitlab.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from macaron.slsa_analyzer.git_service.gitlab import PublicGitLab
+from macaron.slsa_analyzer.git_service.gitlab import PubliclyHostedGitLab
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ from macaron.slsa_analyzer.git_service.gitlab import PublicGitLab
 def test_construct_clone_url_without_token(repo_url: str) -> None:
     """Test if the ``construct_clone_url`` method produces proper clone URLs without the access token."""
     clone_url = repo_url
-    gitlab = PublicGitLab()
+    gitlab = PubliclyHostedGitLab()
     gitlab.load_defaults()
     assert gitlab.construct_clone_url(repo_url) == clone_url
 
@@ -41,7 +41,7 @@ def test_construct_clone_url_without_token(repo_url: str) -> None:
 )
 def test_construct_clone_url_with_token(repo_url: str, clone_url: str) -> None:
     """Test if the ``construct_clone_url`` method produces proper clone URLs with the access token."""
-    with mock.patch.dict(os.environ, {"MCN_PUBLIC_GITLAB_TOKEN": "abcxyz"}):
-        gitlab = PublicGitLab()
+    with mock.patch.dict(os.environ, {"MCN_GITLAB_TOKEN": "abcxyz"}):
+        gitlab = PubliclyHostedGitLab()
         gitlab.load_defaults()
         assert gitlab.construct_clone_url(repo_url) == clone_url

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -133,10 +133,10 @@ def test_get_remote_vcs_url() -> None:
         ),
         (
             """
-            [git_service.gitlab.public]
+            [git_service.gitlab.publicly_hosted]
             domain = gitlab.com
 
-            [git_service.gitlab.private]
+            [git_service.gitlab.self_hosted]
             domain = internal.gitlab.org
             """,
             {"gitlab.com", "internal.gitlab.org"},
@@ -168,11 +168,11 @@ def test_get_allowed_git_service_domains(
         ),
         pytest.param(
             """
-            [git_service.gitlab.private]
+            [git_service.gitlab.self_hosted]
             domain = internal.gitlab.org
             """,
             {"github.com", "gitlab.com", "internal.gitlab.org"},
-            id="Private GitLab in user config",
+            id="Self-hosted GitLab in user config",
         ),
     ],
 )
@@ -202,7 +202,7 @@ def test_get_remote_vcs_url_with_user_defined_allowed_domains(tmp_path: Path) ->
     with open(user_config_path, "w", encoding="utf-8") as user_config_file:
         user_config_file.write(
             """
-            [git_service.gitlab.private]
+            [git_service.gitlab.self_hosted]
             domain = internal.gitlab.org
             """
         )

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -156,7 +156,7 @@ def test_get_allowed_git_service_domains(
 @pytest.mark.parametrize(
     ("user_config_input", "expected_allowed_domain_set"),
     [
-        pytest.param(
+        (
             # The current behavior is: we always enable GitHub and public GitLab by default.
             # User config cannot disable either of the two.
             """
@@ -164,15 +164,13 @@ def test_get_allowed_git_service_domains(
             domain = github.com
             """,
             {"github.com", "gitlab.com"},
-            id="Only GitHub in user config",
         ),
-        pytest.param(
+        (
             """
             [git_service.gitlab.self_hosted]
             domain = internal.gitlab.org
             """,
             {"github.com", "gitlab.com", "internal.gitlab.org"},
-            id="Self-hosted GitLab in user config",
         ),
     ],
 )


### PR DESCRIPTION
This PR is to do the following tasks:

- [x] Remove the logging in the `clone_remote_repo` function.
- [x] Rename the original `public` GitLab instance to `publicly_hosted` GitLab instance
- [x] Rename the original `private` GitLab instance to `self_hosted` GitLab instance 
- [x] Move the logic to get the GitLab access token from environment variable inside `clone_repo` method of `GitLab` class to run it everytime we want to clone a repository instead of storing it in an instance variable.
