### PR TITLE
test: fail on unraisable exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,3 +235,8 @@ testpaths = [
 env = [
     "PYTHONWARNINGS=always::DeprecationWarning",
 ]
+filterwarnings = [
+    # https://docs.pytest.org/en/latest/how-to/failures.html#warning-about-unraisable-exceptions-and-unhandled-thread-exceptions
+    "error::pytest.PytestUnraisableExceptionWarning",
+    "error::pytest.PytestUnhandledThreadExceptionWarning",
+]


### PR DESCRIPTION
See https://docs.pytest.org/en/latest/how-to/failures.html#warning-about-unraisable-exceptions-and-unhandled-thread-exceptions

Unraisable exceptions and unhandled thread exceptions are normally considered bugs, but may go unnoticed because they don’t cause the program itself to crash. Pytest detects these conditions and issues a warning that is visible in the test run summary. This PR changes the warnings to errors instead.