### PR TITLE
chore: fix black and flake8 issues for the new versions of the tools

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ html_theme_options = {
 }
 html_static_path = ["_static"]
 
+
 # We add the docstrings for class constructors in the `__init__` methods.
 def skip(app, what, name, obj, would_skip, options):
     if name == "__init__":

--- a/src/macaron/parsers/bashparser.py
+++ b/src/macaron/parsers/bashparser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module is a Python wrapper for the compiled bashparser binary.
@@ -157,7 +157,6 @@ def extract_bash_from_ci(
     # Parse the bash script files called from the current script.
     if recursive and repo_path:
         for cmd in caller_commands:
-
             # Parse the scripts that end with `.sh`.
             # We only parse recursively at depth 1, so don't set the recursive argument in parse_file().
             # TODO: parse Makefiles for bash commands.

--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -70,7 +70,6 @@ class BuildAsCodeCheck(BaseCheck):
         # Account for Python projects having separate tools for packaging and publishing.
         deploy_tool = build_tool.publisher if build_tool.publisher else build_tool.builder
         for com in commands:
-
             # Check for empty or invalid commands.
             if not com or not com[0]:
                 continue

--- a/src/macaron/slsa_analyzer/checks/provenance_l3_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_l3_check.py
@@ -351,7 +351,6 @@ class ProvenanceL3Check(BaseCheck):
                 with tempfile.TemporaryDirectory() as temp_path:
                     downloaded_provs = []
                     for prov_asset in prov_assets:
-
                         # Check the size before downloading.
                         if self._size_large(prov_asset["size"]):
                             logger.info("Skip verifying the provenance %s: asset size too large.", prov_asset["name"])

--- a/src/macaron/slsa_analyzer/database_store.py
+++ b/src/macaron/slsa_analyzer/database_store.py
@@ -50,7 +50,6 @@ def store_analyze_context_to_db(db_man: DatabaseManager, analysis: AnalysisTable
 
     # Store check result table
     for check in analyze_ctx.check_results.values():
-
         check_table = CheckResultTable()
         check_table.check_id = check["check_id"]
         check_table.repository = analyze_ctx.repository_table.id

--- a/tests/slsa_analyzer/checks/base_check/test_base_check.py
+++ b/tests/slsa_analyzer/checks/base_check/test_base_check.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the tests for BaseCheck."""
@@ -12,8 +12,10 @@ from macaron.slsa_analyzer.checks.base_check import BaseCheck
 class TestConfiguration(TestCase):
     """This class contains the tests for BaseCheck."""
 
+    # Disable flake8's D202 check: "No blank lines allowed after function docstring"
     def test_raise_implementation_error(self) -> None:
-        """Test raising errors if child class does not override abstract method(s)."""
+        """Test raising errors if child class does not override abstract method(s)."""  # noqa: D202
+
         # pylint: disable=abstract-method
         class ChildCheck(BaseCheck):
             """This class is a child class that does not implement abstract methods in Base Check."""


### PR DESCRIPTION
This PR addresses the `flake8` and `black` issues [raised](https://github.com/oracle/macaron/pull/360) after updating `pre-commit` tools.