### PR TITLE
docs: remove manual modifications to generated rst files

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ autodoc_member_order = "bysource"
 numpydoc_show_class_members = False
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/pages/apidoc/macaron.code_analyzer.rst
+++ b/docs/source/pages/apidoc/macaron.code_analyzer.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.code\_analyzer package
 ==============================
 

--- a/docs/source/pages/apidoc/macaron.config.rst
+++ b/docs/source/pages/apidoc/macaron.config.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.config package
 ======================
 

--- a/docs/source/pages/apidoc/macaron.database.rst
+++ b/docs/source/pages/apidoc/macaron.database.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.database package
 ========================
 
@@ -12,28 +9,34 @@ macaron.database package
 Submodules
 ----------
 
+macaron.database.database\_manager module
+-----------------------------------------
+
+.. automodule:: macaron.database.database_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+macaron.database.rfc3339\_datetime module
+-----------------------------------------
+
+.. automodule:: macaron.database.rfc3339_datetime
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.database.table\_definitions module
 ------------------------------------------
-
-.. figure:: /assets/er-diagram.svg
-
-Diagram generated using `eralchemy <https://pypi.org/project/ERAlchemy/>`_.
-
-
-.. code-block:: sh
-
-    eralchemy -i 'sqlite:///output/macaron.db' -o docs/source/assets/er-diagram.svg
 
 .. automodule:: macaron.database.table_definitions
    :members:
    :undoc-members:
    :show-inheritance:
 
+macaron.database.views module
+-----------------------------
 
-macaron.database.database\_manager module
------------------------------------------
-
-.. automodule:: macaron.database.database_manager
-   :members: DatabaseManager
+.. automodule:: macaron.database.views
+   :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/pages/apidoc/macaron.dependency_analyzer.rst
+++ b/docs/source/pages/apidoc/macaron.dependency_analyzer.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.dependency\_analyzer package
 ====================================
 

--- a/docs/source/pages/apidoc/macaron.output_reporter.rst
+++ b/docs/source/pages/apidoc/macaron.output_reporter.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.output\_reporter package
 ================================
 

--- a/docs/source/pages/apidoc/macaron.parsers.rst
+++ b/docs/source/pages/apidoc/macaron.parsers.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.parsers package
 =======================
 

--- a/docs/source/pages/apidoc/macaron.parsers.yaml.rst
+++ b/docs/source/pages/apidoc/macaron.parsers.yaml.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.parsers.yaml package
 ============================
 

--- a/docs/source/pages/apidoc/macaron.policy_engine.rst
+++ b/docs/source/pages/apidoc/macaron.policy_engine.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.policy\_engine package
 ==============================
 

--- a/docs/source/pages/apidoc/macaron.rst
+++ b/docs/source/pages/apidoc/macaron.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron package
 ===============
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.build_tool.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.build_tool.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.build\_tool package
 ==========================================
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.checks.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.checks.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.checks package
 =====================================
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.ci_service.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.ci_service.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.ci\_service package
 ==========================================
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.git_service.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.git_service.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.git\_service package
 ===========================================
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.provenance.expectations.cue.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.provenance.expectations.cue.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.provenance.expectations.cue package
 ==========================================================
 
@@ -12,17 +9,16 @@ macaron.slsa\_analyzer.provenance.expectations.cue package
 Submodules
 ----------
 
-macaron.slsa\_analyzer.provenance.expectations.cue.cue_expectation module
--------------------------------------------------------------------------
+macaron.slsa\_analyzer.provenance.expectations.cue.cue\_expectation module
+--------------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.cue.cue_expectation
    :members:
    :undoc-members:
    :show-inheritance:
 
-
-macaron.slsa\_analyzer.provenance.expectations.cue.cue_validator module
------------------------------------------------------------------------
+macaron.slsa\_analyzer.provenance.expectations.cue.cue\_validator module
+------------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.cue.cue_validator
    :members:

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.provenance.expectations.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.provenance.expectations.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.provenance.expectations package
 ======================================================
 
@@ -24,6 +21,14 @@ macaron.slsa\_analyzer.provenance.expectations.expectation module
 -----------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.expectation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+macaron.slsa\_analyzer.provenance.expectations.expectation\_registry module
+---------------------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.provenance.expectations.expectation_registry
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.provenance.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.provenance.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.provenance package
 =========================================
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer package
 ==============================
 

--- a/docs/source/pages/apidoc/macaron.slsa_analyzer.specs.rst
+++ b/docs/source/pages/apidoc/macaron.slsa_analyzer.specs.rst
@@ -1,6 +1,3 @@
-.. Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
-.. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
 macaron.slsa\_analyzer.specs package
 ====================================
 

--- a/src/macaron/database/table_definitions.py
+++ b/src/macaron/database/table_definitions.py
@@ -4,6 +4,10 @@
 """
 ORM Table definitions used by macaron internally.
 
+The current ERD of Macaron is shown below:
+
+.. figure:: /assets/er-diagram.svg
+
 For tables associated with checks see base_check.py.
 """
 from datetime import datetime

--- a/src/macaron/slsa_analyzer/provenance/expectations/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/expectations/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.

--- a/src/macaron/slsa_analyzer/provenance/expectations/cue/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/expectations/cue/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.


### PR DESCRIPTION
We should not manually modify the automatically generated rst files. Otherwise, generating documentation using docstrings gets very tricky. This changeset also adds missing `__init__.py` modules due to which a warning was raised by Sphinx.