### PR TITLE
fix(orm): serialize datetime object’s timezone instead of always coercing to UTC when persisting to the SQLite db

### DIFF
--- a/src/macaron/database/rfc3339_datetime.py
+++ b/src/macaron/database/rfc3339_datetime.py
@@ -4,7 +4,7 @@
 """This module implements SQLAlchemy type for converting date format to RFC3339 string representation."""
 
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from sqlalchemy import String, TypeDecorator
 
@@ -14,34 +14,41 @@ class RFC3339DateTime(TypeDecorator):  # pylint: disable=W0223
     SQLAlchemy column type to serialise datetime objects for SQLite in consistent format matching in-toto.
 
     https://docs.sqlalchemy.org/en/20/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc
+    https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlalchemy.dialects.sqlite.DATETIME
     """
 
     # It is stored in the database as a string
     impl = String
     cache_ok = True
 
-    def process_bind_param(self, value: Optional[Any], dialect: Any) -> None | str:
-        """Process when storing.
+    def process_bind_param(self, value: None | Any, dialect: Any) -> None | str:
+        """Process when storing a ``datetime`` object to the SQLite db.
+
+        If the timezone of the serialized ``datetime`` object is provided, this function preserves it. Otherwise,
+        if the provided ``datetime`` is a naive ``datetime`` object then UTC is added.
 
         value: None | datetime.datetime
             The value being stored
         """
-        result = None
-        if value is not None:
-            if not value.tzinfo:
-                raise TypeError("tzinfo is required")
-            value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
-            result = value.isoformat(sep="T", timespec="seconds") + "Z"
-        return result
+        if value is None:
+            return None
+        if not isinstance(value, datetime.datetime):
+            raise TypeError("RFC3339DateTime type expects a datetime object")
+        if not value.tzinfo:
+            value = value.astimezone(datetime.timezone.utc)  # Consider coercing to host timezone.
+        return value.isoformat(timespec="seconds")
 
-    def process_result_value(self, value: Optional[Any], dialect: Any) -> None | datetime.datetime:
-        """Process when loading.
+    def process_result_value(self, value: None | str, dialect: Any) -> None | datetime.datetime:
+        """Process when loading a ``datetime`` object from the SQLite db.
+
+        If the deserialized ``datetime`` has a timezone then return it, otherwise add UTC as its timezone.
 
         value: None | str
             The value being loaded
         """
-        result = None
-        if value is not None:
-            result = datetime.datetime.fromisoformat(value)
-            result = result.astimezone(datetime.timezone.utc)
-        return result
+        if value is None:
+            return None
+        result = datetime.datetime.fromisoformat(value)
+        if result.tzinfo:
+            return result
+        return result.astimezone(datetime.timezone.utc)  # Consider coercing to host timezone.


### PR DESCRIPTION
Fixes https://github.com/oracle/macaron/issues/378

The existing code doesn’t ensure that the serialized object is a `datetime` and it always coerces the timezone to UTC; the docstring seems to indicate that serialized `datetime` objects are stored as “[naive](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects)” strings but that’s not the case because `Z` is appended to the serialized string which indicated [Zulu](https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)) time (GMT).

This change preserves the timezone of the serialized `datetime` objects, and adds UTC for naive `datetime` objects before serializing to string. Always deserializes to the original timezone.