### PR TITLE
chore: return the runner back to runner queue on check exception

### DIFF
--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -450,6 +450,7 @@ class Registry:
                                 logger.error("Exception in check %s: %s.", current_check_id, current_future.exception())
                                 logger.info("Check %s has failed.", current_check_id)
                                 current_future.cancel()
+                                self.runner_queue.put(current_runner)
                                 return results
                         except concurrent.futures.TimeoutError:
                             # The check is still running, put the future back into the queue.


### PR DESCRIPTION
Similar to https://github.com/oracle/macaron/pull/216 . But in https://github.com/oracle/macaron/pull/216 I missed one case, which is addressed in this PR. 