### PR TITLE
docs: adjust the Makefile target `docs` to include untracked files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt:
 	echo $(SOURCE_DATE_EPOCH) > dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
 
 # Build the HTML documentation from the package's source.
-DOCS_SOURCE := $(shell git ls-files docs/source)
+DOCS_SOURCE := $(shell git ls-files --cached --others --exclude-standard docs/source)
 .PHONY: docs
 docs: docs/_build/.built-on
 docs/_build/.built-on: $(DOCS_SOURCE)

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,10 @@ dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt:
 	echo $(SOURCE_DATE_EPOCH) > dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
 
 # Build the HTML documentation from the package's source.
+# We use the `git ls-files` command with the following flags to get the source files for docs:
+# * `--cached|-c` to include tracked files (Note: this flag is on by default but is off if the flags below are enabled).
+# * `--others|-o` to include untracked files.
+# * `--exclude-standard` to prevent listing files excluded by .gitignore.
 DOCS_SOURCE := $(shell git ls-files --cached --others --exclude-standard docs/source)
 .PHONY: docs
 docs: docs/_build/.built-on


### PR DESCRIPTION
In #370, I forgot that `git ls-files` does not include untracked files by default. This means newly created source files that have not been staged using `git add` are not included in the dependencies of `make docs`.

This PR is to fix the issue.

We use these flags with `git ls-files`:
* [`-c|--cached`](https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---cached) to include tracked files (Note: this flag is on by default but is off if the flags below are enabled).
* [`-o|--others`](https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---others) to include untracked files.
* [`--exclude-standard`](https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---exclude-standard) to prevent listing files excluded by `.gitignore`.