### PR TITLE
chore(deps): use CVE-2023-40267 alias for the audit check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,14 +225,14 @@ requirements.txt: pyproject.toml
 # editable mode (like the one in development here) because they may not have
 # a PyPI entry; also print out CVE description and potential fixes if audit
 # found an issue.
-# TODO: do not ignore GHSA-pr76-5cm5-w9cj once the patch is out.
+# TODO: do not ignore CVE-2023-40267 once the patch is out.
 # See: https://github.com/ishepard/pydriller/issues/280
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-pr76-5cm5-w9cj
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln CVE-2023-40267
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint


### PR DESCRIPTION
Looks like `pip-audit` [is not ](https://github.com/oracle/macaron/actions/runs/5888771799/job/15970639825?pr=409) recognizing `PYSEC-2023-137` as an alias for `GHSA-pr76-5cm5-w9cj`. Switching to `CVE-2023-40267` ID instead which is recognized by `pip-audit`.

Missing alias for `GHSA-pr76-5cm5-w9cj` in `PYSEC-2023-137`: https://github.com/pypa/advisory-database/issues/142
GitHub Advisory: https://github.com/advisories/GHSA-pr76-5cm5-w9cj
PYSEC Advisory: https://github.com/pypa/advisory-database/blob/a3bd5be966a999b065ac798d13795760c2e13d43/vulns/gitpython/PYSEC-2023-137.yaml

Note: even though Macaron uses PyDriller and GitPython, it is not vulnerable to this CVE because it does not set the [`allow_unsafe_options`](https://github.com/gitpython-developers/GitPython/commit/ca965ecc81853bca7675261729143f54e5bf4cdd) argument to `True` and [sanitizes](https://github.com/oracle/macaron/blob/add-CVE-2023-40267-alias/src/macaron/slsa_analyzer/git_url.py#L551-L677) the repository paths before cloning.