### PR TITLE
fix: update justifications to be complete for multi build tool projects

### DIFF
--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -366,19 +366,22 @@ class BuildAsCodeCheck(BaseCheck):
         ci_services = ctx.dynamic_data["ci_services"]
 
         # Check if "build as code" holds for each build tool.
+        overall_res = CheckResultType.FAILED
+
         for tool in build_tools:
             res = self._check_build_tool(tool, ctx, ci_services, check_result)
 
             if res == CheckResultType.PASSED:
-                # Since the check passing is contingent on at least one passing,
-                # short-circuit if we do get a pass
+                # The check passing is contingent on at least one passing, if
+                # one passes treat whole check as passing. We do still need to
+                # run the others for justifications though to report multiple
+                # build tool usage.
                 # TODO: When more sophisticated build tool detection is
                 # implemented, consider whether this should be one fail = whole
                 # check fails instead
-                return CheckResultType.PASSED
+                overall_res = CheckResultType.PASSED
 
-        # No passes, so overall fail
-        return CheckResultType.FAILED
+        return overall_res
 
 
 registry.register(BuildAsCodeCheck())

--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -127,21 +127,6 @@ class BuildAsCodeCheck(BaseCheck):
                         return str(com)
         return ""
 
-    def _add_to_result_table(self, facts: BuildAsCodeFacts, check_result: CheckResult) -> None:
-        """Add to the check result result tables, creating the list if it doesn't yet exist.
-
-        Parameters
-        ----------
-        facts : BuildAsCodeFacts
-            Facts to add to the result tables.
-        check_result : CheckResult
-            The object containing result data of a check.
-        """
-        if "result_tables" in check_result.keys():
-            check_result["result_tables"].append(facts)
-        else:
-            check_result["result_tables"] = [facts]
-
     def _check_build_tool(
         self, build_tool: BaseBuildTool, ctx: AnalyzeContext, ci_services: list[CIInfo], check_result: CheckResult
     ) -> CheckResultType | None:
@@ -236,15 +221,14 @@ class BuildAsCodeCheck(BaseCheck):
                                 ] = ctx.component.repository.commit_sha
                                 predicate["invocation"]["configSource"]["entryPoint"] = trigger_link
                                 predicate["metadata"]["buildInvocationId"] = html_url
-                            self._add_to_result_table(
+                            check_result["result_tables"].append(
                                 BuildAsCodeFacts(
                                     build_tool_name=build_tool.name,
                                     ci_service_name=ci_service.name,
                                     build_trigger=trigger_link,
                                     deploy_command=workflow_name,
                                     build_status_url=html_url,
-                                ),
-                                check_result,
+                                )
                             )
                             return CheckResultType.PASSED
 
@@ -300,15 +284,14 @@ class BuildAsCodeCheck(BaseCheck):
                             ] = ctx.component.repository.commit_sha
                             predicate["invocation"]["configSource"]["entryPoint"] = trigger_link
                             predicate["metadata"]["buildInvocationId"] = html_url
-                        self._add_to_result_table(
+                        check_result["result_tables"].append(
                             BuildAsCodeFacts(
                                 build_tool_name=build_tool.name,
                                 ci_service_name=ci_service.name,
                                 build_trigger=trigger_link,
                                 deploy_command=deploy_cmd,
                                 build_status_url=html_url,
-                            ),
-                            check_result,
+                            )
                         )
 
                         return CheckResultType.PASSED
@@ -344,13 +327,12 @@ class BuildAsCodeCheck(BaseCheck):
                                     "sha1"
                                 ] = ctx.component.repository.commit_sha
                                 predicate["invocation"]["configSource"]["entryPoint"] = config_name
-                            self._add_to_result_table(
+                            check_result["result_tables"].append(
                                 BuildAsCodeFacts(
                                     build_tool_name=build_tool.name,
                                     ci_service_name=ci_service.name,
                                     deploy_command=deploy_kw,
-                                ),
-                                check_result,
+                                )
                             )
                             return CheckResultType.PASSED
 

--- a/src/macaron/slsa_analyzer/checks/build_service_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_service_check.py
@@ -117,21 +117,6 @@ class BuildServiceCheck(BaseCheck):
                         return str(com)
         return ""
 
-    def _add_to_result_table(self, facts: BuildServiceFacts, check_result: CheckResult) -> None:
-        """Add to the check result result tables, creating the list if it doesn't yet exist.
-
-        Parameters
-        ----------
-        facts : BuildServiceFacts
-            Facts to add to the result tables.
-        check_result : CheckResult
-            The object containing result data of a check.
-        """
-        if "result_tables" in check_result.keys():
-            check_result["result_tables"].append(facts)
-        else:
-            check_result["result_tables"] = [facts]
-
     def _check_build_tool(
         self, build_tool: BaseBuildTool, ctx: AnalyzeContext, check_result: CheckResult, ci_services: list[CIInfo]
     ) -> CheckResultType | None:
@@ -192,13 +177,12 @@ class BuildServiceCheck(BaseCheck):
                         else "However, could not find a passing workflow run.",
                     ]
                     check_result["justification"].extend(justification)
-                    self._add_to_result_table(
+                    check_result["result_tables"].append(
                         BuildServiceFacts(
                             build_tool_name=build_tool.name,
                             build_trigger=trigger_link,
                             ci_service_name=ci_service.name,
-                        ),
-                        check_result,
+                        )
                     )
 
                     if (
@@ -234,12 +218,11 @@ class BuildServiceCheck(BaseCheck):
                             f"build tool {build_tool.name} in {ci_service.name} to "
                             f"build."
                         )
-                        self._add_to_result_table(
+                        check_result["result_tables"].append(
                             BuildServiceFacts(
                                 build_tool_name=build_tool.name,
                                 ci_service_name=ci_service.name,
-                            ),
-                            check_result,
+                            )
                         )
 
                         if (

--- a/src/macaron/slsa_analyzer/checks/build_service_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_service_check.py
@@ -277,9 +277,10 @@ class BuildServiceCheck(BaseCheck):
             res = self._check_build_tool(tool, ctx, check_result, ci_services)
 
             if res == CheckResultType.PASSED:
-                # Pass at some point so treat as entire check pass; short-circuit
+                # Pass at some point so treat as entire check pass; we don't
+                # short-circuit for the sake of full justification reporting
+                # though.
                 all_passing = True
-                break
 
         if not all_passing or not build_tools:
             fail_msg = "The target repository does not have a build service for at least one build tool."

--- a/tests/e2e/expected_results/multibuild_test/multibuild_test.json
+++ b/tests/e2e/expected_results/multibuild_test/multibuild_test.json
@@ -1,6 +1,6 @@
 {
     "metadata": {
-        "timestamps": "2023-07-08 03:15:03"
+        "timestamps": "2023-08-23 18:31:55"
     },
     "target": {
         "info": {
@@ -81,7 +81,8 @@
                         "Deploy command: ['gradle', 'publish']",
                         {
                             "The status of the build can be seen at": "https://github.com/timyarkov/multibuild_test/actions/runs/5097947450"
-                        }
+                        },
+                        "The target repository does not use maven to deploy."
                     ],
                     "result_type": "PASSED"
                 },
@@ -211,6 +212,10 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_witness_level_one_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
@@ -220,10 +225,6 @@
             },
             {
                 "check_id": "mcn_provenance_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_witness_level_one_1",
                 "num_deps_pass": 0
             },
             {

--- a/tests/slsa_analyzer/checks/test_build_as_code_check.py
+++ b/tests/slsa_analyzer/checks/test_build_as_code_check.py
@@ -280,7 +280,7 @@ def test_travis_ci_deploy(
         latest_release={},
         provenances=[],
     )
-    check_result = CheckResult(justification=[])  # type: ignore
+    check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
     gradle_deploy = MockAnalyzeContext(macaron_path=macaron_path, output_dir="")
     gradle_deploy.component.repository.fs_path = str(repo_path.absolute())
     gradle_deploy.dynamic_data["build_spec"]["tools"] = [gradle_tool]
@@ -289,28 +289,13 @@ def test_travis_ci_deploy(
     assert check.run_check(gradle_deploy, check_result) == expect_result
 
 
-@pytest.mark.parametrize(
-    "check_result",
-    [
-        (CheckResult(justification=[])),  # type: ignore
-        (CheckResult(justification=[], result_tables=[])),  # type: ignore
-    ],
-)
 def test_multibuild_facts_saved(
     macaron_path: Path,
     gradle_tool: Gradle,
     maven_tool: Maven,
     github_actions_service: GitHubActions,
-    check_result: CheckResult,
-):
-    """Test that facts for all build tools are saved in the results tables in multi-build tool scenarios.
-
-    Parameters
-    ----------
-    check_result : CheckResult
-        Dictionary for check results; parameterised for cases where result_tables
-        is and isn't initialised.
-    """
+) -> None:
+    """Test that facts for all build tools are saved in the results tables in multi-build tool scenarios."""
     check = BuildAsCodeCheck()
     bash_commands = BashCommands(
         caller_path="source_file",
@@ -318,6 +303,7 @@ def test_multibuild_facts_saved(
         CI_type="github_actions",
         commands=[["./gradlew", "publishToSonatype"], ["mvn", "deploy"]],
     )
+    check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
     ci_info = CIInfo(
         service=github_actions_service,
         bash_commands=[bash_commands],
@@ -333,6 +319,6 @@ def test_multibuild_facts_saved(
     assert check.run_check(multi_deploy, check_result) == CheckResultType.PASSED
 
     # Check facts exist for both gradle and maven
-    existing_facts = [f.build_tool_name for f in check_result["result_tables"]]  # type: ignore
+    existing_facts = [f.build_tool_name for f in check_result["result_tables"]]
     assert gradle_tool.name in existing_facts
     assert maven_tool.name in existing_facts

--- a/tests/slsa_analyzer/checks/test_build_service_check.py
+++ b/tests/slsa_analyzer/checks/test_build_service_check.py
@@ -254,23 +254,12 @@ class TestBuildServiceCheck(MacaronTestCase):
             provenances=[],
         )
 
-        gradle_deploy = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
-        gradle_deploy.dynamic_data["build_spec"]["tools"] = [gradle, maven]
-        gradle_deploy.dynamic_data["ci_services"] = [ci_info]
-
-        # With check_result missing result_tables
-        check_result = CheckResult(justification=[])  # type: ignore
-
-        assert check.run_check(gradle_deploy, check_result) == CheckResultType.PASSED
-        # Check facts exist for both gradle and maven
-        existing_facts = [f.build_tool_name for f in check_result["result_tables"]]
-        assert gradle.name in existing_facts
-        assert maven.name in existing_facts
-
-        # With pre-defined result_tables in check_result
+        multi_deploy = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
+        multi_deploy.dynamic_data["build_spec"]["tools"] = [gradle, maven]
+        multi_deploy.dynamic_data["ci_services"] = [ci_info]
         check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
 
-        assert check.run_check(gradle_deploy, check_result) == CheckResultType.PASSED
+        assert check.run_check(multi_deploy, check_result) == CheckResultType.PASSED
         # Check facts exist for both gradle and maven
         existing_facts = [f.build_tool_name for f in check_result["result_tables"]]
         assert gradle.name in existing_facts

--- a/tests/slsa_analyzer/checks/test_build_service_check.py
+++ b/tests/slsa_analyzer/checks/test_build_service_check.py
@@ -3,7 +3,6 @@
 
 """This module contains the tests for the Build Service Check."""
 
-
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
 from macaron.parsers.bashparser import BashCommands
 from macaron.slsa_analyzer.build_tool.gradle import Gradle
@@ -179,24 +178,24 @@ class TestBuildServiceCheck(MacaronTestCase):
         assert check.run_check(no_pip_interpreter_build_ci, check_result) == CheckResultType.FAILED
 
         # Maven and Gradle are both used in CI to build the artifact
-        gradle_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
-        gradle_build_ci.dynamic_data["build_spec"]["tools"] = [gradle, maven]
+        multi_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
+        multi_build_ci.dynamic_data["build_spec"]["tools"] = [gradle, maven]
         bash_commands["commands"] = [["./gradlew", "build"], ["mvn", "package"]]
-        gradle_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(gradle_build_ci, check_result) == CheckResultType.PASSED
+        multi_build_ci.dynamic_data["ci_services"] = [ci_info]
+        assert check.run_check(multi_build_ci, check_result) == CheckResultType.PASSED
 
         # Maven is used in CI to build the artifact, Gradle is not
-        gradle_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
-        gradle_build_ci.dynamic_data["build_spec"]["tools"] = [gradle, maven]
+        maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
+        maven_build_ci.dynamic_data["build_spec"]["tools"] = [gradle, maven]
         bash_commands["commands"] = [["mvn", "package"]]
-        gradle_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(gradle_build_ci, check_result) == CheckResultType.PASSED
+        maven_build_ci.dynamic_data["ci_services"] = [ci_info]
+        assert check.run_check(maven_build_ci, check_result) == CheckResultType.PASSED
 
         # No build tools used
-        gradle_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
-        gradle_build_ci.dynamic_data["build_spec"]["tools"] = []
-        gradle_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(gradle_build_ci, check_result) == CheckResultType.FAILED
+        none_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
+        none_build_ci.dynamic_data["build_spec"]["tools"] = []
+        none_build_ci.dynamic_data["ci_services"] = [ci_info]
+        assert check.run_check(none_build_ci, check_result) == CheckResultType.FAILED
 
         # Test Jenkins.
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
@@ -229,3 +228,50 @@ class TestBuildServiceCheck(MacaronTestCase):
         ci_info["service"] = gitlab_ci
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
         assert check.run_check(maven_build_ci, check_result) == CheckResultType.FAILED
+
+    def test_multibuild_facts_saved(self) -> None:
+        """Test that facts for all build tools are saved in the results tables in multi-build tool scenarios."""
+        check = BuildServiceCheck()
+        maven = Maven()
+        maven.load_defaults()
+        gradle = Gradle()
+        gradle.load_defaults()
+        github_actions = MockGitHubActions()
+        github_actions.load_defaults()
+
+        bash_commands = BashCommands(
+            caller_path="source_file",
+            CI_path="ci_file",
+            CI_type="github_actions",
+            commands=[["./gradlew", "build"], ["mvn", "package"]],
+        )
+        ci_info = CIInfo(
+            service=github_actions,
+            bash_commands=[bash_commands],
+            callgraph=CallGraph(BaseNode(), ""),
+            provenance_assets=[],
+            latest_release={},
+            provenances=[],
+        )
+
+        gradle_deploy = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
+        gradle_deploy.dynamic_data["build_spec"]["tools"] = [gradle, maven]
+        gradle_deploy.dynamic_data["ci_services"] = [ci_info]
+
+        # With check_result missing result_tables
+        check_result = CheckResult(justification=[])  # type: ignore
+
+        assert check.run_check(gradle_deploy, check_result) == CheckResultType.PASSED
+        # Check facts exist for both gradle and maven
+        existing_facts = [f.build_tool_name for f in check_result["result_tables"]]
+        assert gradle.name in existing_facts
+        assert maven.name in existing_facts
+
+        # With pre-defined result_tables in check_result
+        check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
+
+        assert check.run_check(gradle_deploy, check_result) == CheckResultType.PASSED
+        # Check facts exist for both gradle and maven
+        existing_facts = [f.build_tool_name for f in check_result["result_tables"]]
+        assert gradle.name in existing_facts
+        assert maven.name in existing_facts


### PR DESCRIPTION
Right now while projects with multiple build tools are analysed properly, the justifications in the report don't reflect all build tools used due to logic that short-circuits the `build_as_code` and `build_service` checks upon a single tool passing. This is a problem when testing for if certain build tools get picked up in scenarios of multiple other build tools being present, since there is a chance it likely won't get reflected in the report, thus making it difficult to properly test such cases.

- `build_as_code_check.py` and `build_service_check.py` now perform their checks for every single build tool, regardless of if there's a pass or not (still preserving previous one pass = check passed logic however)
- Results for analysis of https://github.com/timyarkov/multibuild_test updated to reflect changes