### PR TITLE
fix(proxy): use the host proxy settings for Maven and Gradle

### DIFF
--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -44,6 +44,11 @@ RUN : \
 
 COPY --chown=macaron:macaron docker/user.sh $HOME/user.sh
 
+# Prepare the container for Maven and Gradle builds.
+RUN : \
+    && mkdir -p $HOME/.m2 \
+    && mkdir -p $HOME/.gradle
+
 # We enable the root user here so that the user.sh script can modify the
 # GID and UID of user macaron at startup to match the GID and UID
 # of the current user in the host machine.

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -44,11 +44,6 @@ RUN : \
 
 COPY --chown=macaron:macaron docker/user.sh $HOME/user.sh
 
-# Prepare the container for Maven and Gradle builds.
-RUN : \
-    && mkdir -p $HOME/.m2 \
-    && mkdir -p $HOME/.gradle
-
 # We enable the root user here so that the user.sh script can modify the
 # GID and UID of user macaron at startup to match the GID and UID
 # of the current user in the host machine.

--- a/docker/user.sh
+++ b/docker/user.sh
@@ -29,6 +29,22 @@ then
     cp "$PACKAGE_PATH"/resources/settings.xml "$HOME"/.m2/
 fi
 
+# Overwrite $HOME/.m2/settings.xml if the global settings.xml file is mounted from the host machine.
+if [[ -f "$HOME/settings.xml" ]];
+then
+    cp "$HOME/settings.xml" "$HOME/.m2/settings.xml"
+fi
+
+# Create $HOME/.gradle/gradle.properties if the global gradle.properties file is mounted from the host machine.
+if [[ ! -d "$HOME/.gradle" ]];
+then
+    mkdir --parents "$HOME"/.gradle
+fi
+if [[ -f "$HOME/gradle.properties" ]];
+then
+    cp "$HOME"/gradle.properties "$HOME/.gradle/gradle.properties"
+fi
+
 # Prepare the output directory. The output directory will be already existed
 # if we mount from the host machine.
 if [[ ! -d "$HOME/output" ]];
@@ -39,10 +55,10 @@ fi
 # The directory that could be mounted to the host machine file systems should
 # have the owner as the current user in the host machine.
 chown --recursive macaron:macaron "$HOME"/.m2
+chown --recursive macaron:macaron "$HOME"/.gradle
 chown --recursive macaron:macaron "$HOME"/output
 
 # Run the provided Macaron command with the user macaron.
-# TODO: add macaron entrypoint back in when we merge policy_engine with macaron entrypoint.
 MACARON_PARAMS=( "$@" )
 COMMAND="cd /home/macaron && . .venv/bin/activate && ${MACARON_PARAMS[*]}"
 su macaron --preserve-environment --command "$COMMAND"

--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -67,3 +67,11 @@ Ideally, the GitHub token must have **read** permissions for the repositories th
 After generating a GitHub personal-access token, please store its value in an environment variable called ``GITHUB_TOKEN``. This environment variable will be read by Macaron for its **analyze** command.
 
 Now that you have successfully downloaded and installed Macaron, please refer to :ref:`Using Macaron <using-macaron>` for the instructions on how to use Macaron.
+
+.. _proxy_configuration:
+
+-------------------
+Proxy Configuration
+-------------------
+
+TODO

--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -74,4 +74,7 @@ Now that you have successfully downloaded and installed Macaron, please refer to
 Proxy Configuration
 -------------------
 
-TODO
+set MAVEN_OPTS
+use ~/.m2/settings.xml
+use ~/.gradle/gradle.properties
+GRADLE_OPTS or JAVA_OPTS: https://riptutorial.com/gradle/example/17338/using-the-gradle-wrapper-behind-a-proxy

--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -74,7 +74,60 @@ Now that you have successfully downloaded and installed Macaron, please refer to
 Proxy Configuration
 -------------------
 
-set MAVEN_OPTS
-use ~/.m2/settings.xml
-use ~/.gradle/gradle.properties
-GRADLE_OPTS or JAVA_OPTS: https://riptutorial.com/gradle/example/17338/using-the-gradle-wrapper-behind-a-proxy
+Make sure your system proxy is correctly set:
+
+.. code-block:: shell
+
+   $ export {http,https,ftp}_proxy=http://www-example-proxy:80
+   $ export no_proxy=localhost,127.0.0.1
+
+In order to connect to the registry on behalf of the Docker client, the Docker daemon service needs the proxies in order to download images:
+
+.. code-block:: shell
+   :caption:    /etc/systemd/system/docker.service.d/http-proxy.conf
+   :name: docker-proxy-conf-proxies
+
+   [Service]
+   Environment="HTTP_PROXY=http://wwww-example-proxy:80/"
+   Environment="http_proxy=http://www-example-proxy:80/"
+   Environment="HTTPS_PROXY=http://www-example-proxy:80/"
+   Environment="https_proxy=http://www-example-proxy:80/"
+
+The line below shows an example to exclude the proxy intercept:
+
+.. code-block:: shell
+   :caption:    /etc/systemd/system/docker.service.d/http-proxy.conf
+   :name: docker-proxy-conf-no-proxy
+
+   Environment="NO_PROXY=localhost,127.0.0.1"
+
+.. note:: If you update ``/etc/systemd/system/docker.service.d/http-proxy.conf``, you need to reload the daemon and restart the docker service to apply changes.
+
+.. code-block:: shell
+
+  sudo systemctl daemon-reload
+  sudo systemctl restart docker.service
+
+You can run the following command to make sure the proxy settings are updated:
+
+.. code-block:: shell
+
+  sudo systemctl show --property=Environment docker
+
+'''''''''''''''''''''''''''''''
+Maven and Gradle proxy settings
+'''''''''''''''''''''''''''''''
+
+Maven and Gradle do not use the system proxy settings. If the target software component (repository)
+is using either of these build tools, make sure to set up the following environment variables:
+
+.. code-block:: shell
+
+  export MAVEN_OPTS="-Dhttp.proxyHost=wwww-example-proxy -Dhttp.proxyPort=80 -Dhttps.proxyHost=wwww-example-proxy -Dhttps.proxyPort=80"
+  export GRADLE_OPTS="-Dhttp.proxyHost=wwww-example-proxy -Dhttp.proxyPort=80 -Dhttps.proxyHost=wwww-example-proxy -Dhttps.proxyPort=80"
+
+In addition, Macaron uses the global settings files for Maven and Gradle if present on the host machine and copies them to
+the Docker container. You can set up your proxy settings in the following files:
+
+* ``~/.m2/settings.xml``
+* ``~/.gradle/gradle.properties``

--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -74,7 +74,7 @@ Now that you have successfully downloaded and installed Macaron, please refer to
 Proxy Configuration
 -------------------
 
-Make sure your system proxy is correctly set:
+Make sure your system proxy is correctly set. These environment variables are read from the host machine and set in the Macaron container automatically.
 
 .. code-block:: shell
 
@@ -131,3 +131,5 @@ the Docker container. You can set up your proxy settings in the following files:
 
 * ``~/.m2/settings.xml``
 * ``~/.gradle/gradle.properties``
+
+See the `Maven <https://maven.apache.org/settings.html#proxies>`_ and `Gradle <https://docs.gradle.org/current/userguide/build_environment.html#sec:accessing_the_web_via_a_proxy>`_ documentations for more information on setting up proxies.

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -367,6 +367,16 @@ if [[ -n "${datalog_policy_file}" ]]; then
     mounts+=("-v" "${datalog_policy_file}:${MACARON_WORKSPACE}/policy/${file_name}:ro")
 fi
 
+# Determine that ~/.gradle/gradle.properties exists to be mounted into ${MACARON_WORKSPACE}/gradle.properties
+if [[ -f "$HOME/.gradle/gradle.properties" ]]; then
+    mounts+=("-v" "$HOME/.gradle/gradle.properties":"${MACARON_WORKSPACE}/gradle.properties:ro")
+fi
+
+# Determine that ~/.m2/settings.xml exists to be mounted into ${MACARON_WORKSPACE}/settings.xml
+if [[ -f "$HOME/.m2/settings.xml" ]]; then
+    mounts+=("-v" "$HOME/.m2/settings.xml":"${MACARON_WORKSPACE}/settings.xml:ro")
+fi
+
 # Set up proxy.
 # We respect the host machine's proxy environment variables.
 proxy_var_names=(
@@ -378,6 +388,7 @@ proxy_var_names=(
     "HTTPS_PROXY"
     "FTP_PROXY"
     "NO_PROXY"
+    "MAVEN_OPTS"
 )
 
 for v in "${proxy_var_names[@]}"; do

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -379,6 +379,9 @@ fi
 
 # Set up proxy.
 # We respect the host machine's proxy environment variables.
+# For Maven and Gradle projects that Macaron needs to analyzes, the proxy configuration
+# for Maven wrapper `mvnw` and Gradle wrapper `gradlew` are set using `MAVEN_OPTS` and
+# `GRADLE_OPTS` environment variables.
 proxy_var_names=(
     "http_proxy"
     "https_proxy"

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -389,6 +389,7 @@ proxy_var_names=(
     "FTP_PROXY"
     "NO_PROXY"
     "MAVEN_OPTS"
+    "GRADLE_OPTS"
 )
 
 for v in "${proxy_var_names[@]}"; do


### PR DESCRIPTION
Maven and Gradle do not use the systems proxy settings and support custom files `~/.m2/settings.xml` and `~/.gradle/gradle.properties` or other mechanisms for proxy configuration.

This PR uses the global settings files from the host machine to setup the proxy for Maven and Gradle in the Docker container.