### PR TITLE
feat: support trusted SLSA L3 builders for Maven, Gradle, Node.js, and containers

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -301,8 +301,13 @@ entry_conf =
     .github/workflows
 query_page_threshold = 10
 max_items_num = 100
+# Trusted SLSA builders: https://github.com/slsa-framework/slsa-github-generator/tree/main#builders
 trusted_builders =
     slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml
+    slsa-framework/slsa-github-generator/.github/workflows/builder_gradle_slsa3.yml
+    slsa-framework/slsa-github-generator/.github/workflows/builder_maven_slsa3.yml
+    slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml
+    slsa-framework/slsa-github-generator/.github/workflows/builder_container-based_slsa3.yml
 # The number of days that GitHub Actions persists the workflow run.
 max_workflow_persist = 90
 


### PR DESCRIPTION
The SLSA GitHub Generator repository hosts new trusted builders:

* Maven and Gradle since v1.9.0
* Node.js since v1.6.0
* Container-based since v1.7.0

This PR adds the corresponding reusable workflows to the trusted builders in Macaron.

See https://github.com/slsa-framework/slsa-github-generator/tree/main#builders