### PR TITLE
fix: add timeout to Gradle Group ID detection

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -118,7 +118,6 @@ deploy_arg =
     org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged-repository
     # See https://help.sonatype.com/repomanager3/integrations/nexus-repository-maven-plugin.
     nxrm3:staging-deploy
-
 build_log = Apache Maven
 wrapper_files =
     .mvn/wrapper/maven-wrapper.jar
@@ -242,6 +241,10 @@ jenkins =
     gradle-git-publish
     gitPublishPush
 
+[builder.gradle.runtime]
+# This is the timeout (in seconds) to run the build tool.
+build_timeout = 600
+
 # This is the spec for trusted Pip packaging tools.
 [builder.pip]
 entry_conf =
@@ -271,6 +274,7 @@ build_arg =
 deploy_arg =
     publish
     upload
+
 [builder.pip.ci.deploy]
 github_actions = pypa/gh-action-pypi-publish
 
@@ -292,6 +296,7 @@ build_arg =
     build
 deploy_arg =
     publish
+
 [builder.poetry.ci.deploy]
 github_actions = pypa/gh-action-pypi-publish
 

--- a/src/macaron/slsa_analyzer/build_tool/base_build_tool.py
+++ b/src/macaron/slsa_analyzer/build_tool/base_build_tool.py
@@ -43,8 +43,11 @@ def file_exists(path: str, file_name: str) -> bool:
 
 
 @dataclass
-class RuntimeConfig:
-    """The class for build tool runtime configuration read from `defaults.ini`."""
+class RuntimeOptions:
+    """The class for build tool runtime configurations read from `defaults.ini`.
+
+    Note that Macaron uses the options in this class to "run" a build tool.
+    """
 
     #: The timeout used for running the build tool commands.
     build_timeout: float = 600
@@ -88,7 +91,7 @@ class BaseBuildTool(ABC):
         }
         self.build_log: list[str] = []
         self.wrapper_files: list[str] = []
-        self.runtime_config = RuntimeConfig()
+        self.runtime_options = RuntimeOptions()
 
     def __str__(self) -> str:
         return self.name

--- a/src/macaron/slsa_analyzer/build_tool/base_build_tool.py
+++ b/src/macaron/slsa_analyzer/build_tool/base_build_tool.py
@@ -8,6 +8,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from macaron.dependency_analyzer import DependencyAnalyzer
@@ -39,6 +40,14 @@ def file_exists(path: str, file_name: str) -> bool:
         return True
     except StopIteration:
         return False
+
+
+@dataclass
+class RuntimeConfig:
+    """The class for build tool runtime configuration read from `defaults.ini`."""
+
+    #: The timeout used for running the build tool commands.
+    build_timeout: float = 600
 
 
 class BaseBuildTool(ABC):
@@ -79,6 +88,7 @@ class BaseBuildTool(ABC):
         }
         self.build_log: list[str] = []
         self.wrapper_files: list[str] = []
+        self.runtime_config = RuntimeConfig()
 
     def __str__(self) -> str:
         return self.name

--- a/src/macaron/slsa_analyzer/build_tool/gradle.py
+++ b/src/macaron/slsa_analyzer/build_tool/gradle.py
@@ -45,6 +45,19 @@ class Gradle(BaseBuildTool):
                 if item in self.ci_deploy_kws:
                     self.ci_deploy_kws[item] = defaults.get_list("builder.gradle.ci.deploy", item)
 
+        if "builder.gradle.runtime" in defaults:
+            try:
+                self.runtime_config.build_timeout = defaults.getfloat(
+                    "builder.gradle.runtime", "build_timeout", fallback=self.runtime_config.build_timeout
+                )
+            except ValueError as error:
+                logger.error(
+                    "Failed to validate builder.gradle.runtime.build_timeout in defaults.ini. "
+                    "Falling back to the default build timeout %s seconds: %s",
+                    self.runtime_config.build_timeout,
+                    error,
+                )
+
     def is_detected(self, repo_path: str) -> bool:
         """Return True if this build tool is used in the target repo.
 
@@ -217,13 +230,17 @@ class Gradle(BaseBuildTool):
             The group id of the project, if exists.
         """
         try:
+            logger.debug(
+                "Identifying the group ID for the artifact. This can take a while if Gradle needs to be downloaded."
+            )
             result = subprocess.run(  # nosec B603
                 [gradle_exec, "properties"],
                 capture_output=True,
                 cwd=project_path,
                 check=False,
+                timeout=self.runtime_config.build_timeout,
             )
-        except (subprocess.CalledProcessError, OSError) as error:
+        except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired) as error:
             logger.debug("Could not capture the group id of the Gradle project at %s", project_path)
             logger.debug("Error: %s", error)
             return None

--- a/src/macaron/slsa_analyzer/build_tool/gradle.py
+++ b/src/macaron/slsa_analyzer/build_tool/gradle.py
@@ -47,14 +47,14 @@ class Gradle(BaseBuildTool):
 
         if "builder.gradle.runtime" in defaults:
             try:
-                self.runtime_config.build_timeout = defaults.getfloat(
-                    "builder.gradle.runtime", "build_timeout", fallback=self.runtime_config.build_timeout
+                self.runtime_options.build_timeout = defaults.getfloat(
+                    "builder.gradle.runtime", "build_timeout", fallback=self.runtime_options.build_timeout
                 )
             except ValueError as error:
                 logger.error(
                     "Failed to validate builder.gradle.runtime.build_timeout in defaults.ini. "
                     "Falling back to the default build timeout %s seconds: %s",
-                    self.runtime_config.build_timeout,
+                    self.runtime_options.build_timeout,
                     error,
                 )
 
@@ -230,7 +230,7 @@ class Gradle(BaseBuildTool):
             The group id of the project, if exists.
         """
         try:
-            logger.debug(
+            logger.info(
                 "Identifying the group ID for the artifact. This can take a while if Gradle needs to be downloaded."
             )
             result = subprocess.run(  # nosec B603
@@ -238,7 +238,7 @@ class Gradle(BaseBuildTool):
                 capture_output=True,
                 cwd=project_path,
                 check=False,
-                timeout=self.runtime_config.build_timeout,
+                timeout=self.runtime_options.build_timeout,
             )
         except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired) as error:
             logger.debug("Could not capture the group id of the Gradle project at %s", project_path)

--- a/tests/slsa_analyzer/build_tool/test_gradle.py
+++ b/tests/slsa_analyzer/build_tool/test_gradle.py
@@ -89,10 +89,7 @@ def test_get_group_ids_separate_projects(tmp_path: Path, gradle_tool: Gradle) ->
     }
 
 
-@pytest.mark.parametrize(
-    ("timeout", "expected"),
-    [("0", set()), ("invalid", {"io.micronaut"})],
-)
+@pytest.mark.parametrize(("timeout", "expected"), [("0", set()), ("invalid", {"io.micronaut"})])
 def test_get_group_ids_timeout(tmp_path: Path, gradle_tool: Gradle, timeout: str, expected: set) -> None:
     """Test the timeout configuration on ``get_group_ids`` method."""
     repo_dir = tmp_path.joinpath("repo")

--- a/tests/slsa_analyzer/build_tool/test_gradle.py
+++ b/tests/slsa_analyzer/build_tool/test_gradle.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from macaron.config.defaults import load_defaults
 from macaron.slsa_analyzer.build_tool.gradle import Gradle
 from tests.slsa_analyzer.mock_git_utils import prepare_repo_for_testing
 
@@ -86,3 +87,32 @@ def test_get_group_ids_separate_projects(tmp_path: Path, gradle_tool: Gradle) ->
         "io.micronaut.foo",
         "io.micronaut.bar",
     }
+
+
+@pytest.mark.parametrize(
+    ("timeout", "expected"),
+    [("0", set()), ("invalid", {"io.micronaut"})],
+)
+def test_get_group_ids_timeout(tmp_path: Path, gradle_tool: Gradle, timeout: str, expected: set) -> None:
+    """Test the timeout configuration on ``get_group_ids`` method."""
+    repo_dir = tmp_path.joinpath("repo")
+    repo_dir.mkdir()
+
+    with open(repo_dir.joinpath("build.gradle"), "w", encoding="utf-8") as file:
+        file.write('group = "io.micronaut"')
+
+    user_config_path = str(tmp_path.joinpath("config.ini"))
+    user_config_input = f"""
+        [builder.gradle.runtime]
+        build_timeout = {timeout}
+    """
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+
+    # We don't have to worry about modifying the ``defaults`` object causing test
+    # pollution here, since we reload the ``defaults`` object before every test with the
+    # ``setup_test`` fixture.
+    load_defaults(user_config_path)
+    gradle_tool.load_defaults()
+
+    assert set(gradle_tool.get_group_ids(str(repo_dir))) == expected


### PR DESCRIPTION
This PR sets a timeout on the `subprocess.run()` call that runs `gradlew properties` to detect the group ID of a Gradle project. The `timout` is read from `build_timeout` in `defaults.ini` for the detected build tool.