### PR TITLE
fix: always pull latest docker image in run_macaron.sh

### DIFF
--- a/.github/workflows/_build_docker.yaml
+++ b/.github/workflows/_build_docker.yaml
@@ -58,5 +58,6 @@ jobs:
       env:
         # This environment variable will be picked up by run_macaron.sh.
         MACARON_IMAGE_TAG: test
+        DOCKER_PULL: never
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make integration-test-docker

--- a/docs/source/pages/cli_usage/index.rst
+++ b/docs/source/pages/cli_usage/index.rst
@@ -49,6 +49,13 @@ Common Options
 
 	The directory where Macaron looks for already cloned repositories.
 
+-----------
+Common Environment
+-----------
+
+``MACARON_IMAGE_TAG`` – The tag to use for the Macaron docker image
+``DOCKER_PULL`` – Whether to pull docker image from registry, must be one of: always, missing, never (default: always)
+
 ---------------
 Action Commands
 ---------------

--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -45,6 +45,8 @@ To verify your setup, go to the directory containing the downloaded ``run_macaro
 
 .. note:: By default, ``latest`` is used as the tag for the downloaded image. You can choose a specific tag by assigning the environment variable ``MACARON_IMAGE_TAG``. For example to run Macaron v0.1.0 run: ``MACARON_IMAGE_TAG=v0.1.0 ./run_macaron.sh --help``
 
+.. note:: By default, the script will always check the docker registry to ensure the docker image is up-to-date. This can be overridden if necessary (e.g. if running offline with a pre-installed image) by assigning the environment variable ``DOCKER_PULL``. For example: ``DOCKER_PULL=never ./run_macaron.sh --help``
+
 .. _prepare-github-token:
 
 ---------------------------

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -420,9 +420,19 @@ then
     entrypoint=("macaron")
 fi
 
+if [[ -n "${DOCKER_PULL}" ]]; then
+    if [[ "${DOCKER_PULL}" != @(always|missing|never) ]]; then
+        echo "DOCKER_PULL must be one of: always, missing, never (default: always)"
+        exit 1
+    fi
+else
+    DOCKER_PULL="always"
+fi
+
 echo "Running ${IMAGE}:${MACARON_IMAGE_TAG}"
 
 docker run \
+    --pull ${DOCKER_PULL} \
     --network=host \
     --rm -i "${tty[@]}" \
     -e "USER_UID=${USER_UID}" \

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -36,7 +36,7 @@ argv_main=()
 
 # These are the sub-commands for a specific action.
 # macaron
-#   analzye:
+#   analyze:
 #       -g/--template-path TEMPLATE_PATH: The path to the Jinja2 html template (please make sure to use .html or .j2 extensions).
 #       -c/--config-path CONFIG_PATH: The path to the user configuration.
 #       -pe/--provenance-expectation POLICY: The path to provenance expectation file or directory.


### PR DESCRIPTION
Closes #438

By default, always pull latest version of docker image, but allow this behaviour to be overidden by setting the DOCKER_PULL env var.