### PR TITLE
chore(deps): address pip-audit reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,14 +225,15 @@ requirements.txt: pyproject.toml
 # editable mode (like the one in development here) because they may not have
 # a PyPI entry; also print out CVE description and potential fixes if audit
 # found an issue.
-# TODO: do not ignore CVE-2023-40267 once the patch is out.
-# See: https://github.com/ishepard/pydriller/issues/280
+# TODO: do not ignore CVE-2023-40590 once the patch is out.
+# This CVE does not affect Macaron because we do not support Windows systems.
+# See: https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-wfm5-v35h-vwf4
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln CVE-2023-40267
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln CVE-2023-40590
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint


### PR DESCRIPTION
This PR adds `CVE-2023-40590` to `pip-audit`'s ignore list until it is resolved. Macaron does not support Windows systems, so it is not affected. See https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-wfm5-v35h-vwf4

This PR also removes CVE-2023-40267 from the ignored CVEs because PyDriller 2.5.1 no longer pins GitPython to the vulnerable version. See https://github.com/ishepard/pydriller/issues/280