### PR TITLE
chore(deps): address pip-audit report for CVE-2023-41040

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,12 +228,16 @@ requirements.txt: pyproject.toml
 # TODO: do not ignore CVE-2023-40590 once the patch is out.
 # This CVE does not affect Macaron because we do not support Windows systems.
 # See: https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-wfm5-v35h-vwf4
+# TODO: do not ignore CVE-2023-41040 once the patch is out.
+# Macaron is not affected by this CVE because it does not call the problematic functions like `commit`
+# and sanitizes arguments before calling GitPython APIs.
+# See: https://osv.dev/vulnerability/GHSA-cwvm-v4w8-q58c
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln CVE-2023-40590
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln CVE-2023-40590 --ignore-vuln CVE-2023-41040
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint


### PR DESCRIPTION
This PR adds CVE-2023-41040 reported against GitPython 3.1.32 to the ignore list until the patch is out.

Note that Macaron is not affected by this CVE because it does not call the problematic functions like `commit` and sanitizes arguments before calling GitPython APIs.

See: https://osv.dev/vulnerability/GHSA-cwvm-v4w8-q58c