### PR TITLE
fix: rename `domain` to `hostname` in Git service configuration

### DIFF
--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -78,7 +78,7 @@ Analyzing a repository on a self-hosted GitLab instance
 
 To analyze a repository on a self-hosted GitLab instance, you need to do the following:
 
-- Add the following ``[git_service.gitlab.self_hosted]`` section into your ``.ini`` config. In the default .ini configuration (generated using ``macaron dump-default`` -- :ref:`see instructions <action_dump_defaults>`), there is already this section commented out. You can start by un-commenting this section and modifying the ``domain`` value with the domain of your self-hosted GitLab instance.
+- Add the following ``[git_service.gitlab.self_hosted]`` section into your ``.ini`` config. In the default .ini configuration (generated using ``macaron dump-default`` -- :ref:`see instructions <action_dump_defaults>`), there is already this section commented out. You can start by un-commenting this section and modifying the ``hostname`` value with the hostname of your self-hosted GitLab instance.
 
 .. code-block:: ini
 
@@ -86,7 +86,7 @@ To analyze a repository on a self-hosted GitLab instance, you need to do the fol
     # If this section is enabled, an access token must be provided through the ``MCN_SELF_HOSTED_GITLAB_TOKEN`` environment variable.
     # The `read_repository` permission is required for this token.
     [git_service.gitlab.self_hosted]
-    domain = internal.gitlab.org
+    hostname = internal.gitlab.org
 
 - Obtain a GitLab access token having at least the ``read_repository`` permission and store it into the ``MCN_SELF_HOSTED_GITLAB_TOKEN`` environment variable. For more detailed instructions, see `GitLab documentation <https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token>`_.
 
@@ -100,7 +100,7 @@ To simplify the examples, we use the same configurations as above if needed (e.g
 
 .. code-block::
 
-  pkg:<git_service_domain>/<organization>/<name>
+  pkg:<git_service_hostname>/<organization>/<name>
 
 The list bellow shows examples for the corresponding PURL strings for different git repositories:
 

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -59,25 +59,25 @@ parent_limit = 10
 artifact_ignore_list =
 
 # Git services that Macaron has access to clone repositories.
-# For security purposes, Macaron will only clone repositories from the domains specified.
+# For security purposes, Macaron will only clone repositories from the hostnames specified.
 
 # Access to GitHub is required in most case for Macaron to analyse not only the main
 # repo but also its dependencies.
 [git_service.github]
-domain = github.com
+hostname = github.com
 
 # Access to public GitLab (gitlab.com).
 # An optional access token can be provided through the `MCN_GITLAB_TOKEN` environment variable.
 # This access token is optional, only necessary when you need to clone private repositories.
 # The `read_repository` permission is required for this token.
 [git_service.gitlab.publicly_hosted]
-domain = gitlab.com
+hostname = gitlab.com
 
 # Access to a self-hosted GitLab instance (e.g. your organization's self-hosted GitLab instance).
 # If this section is enabled, an access token must be provided through the `MCN_SELF_HOSTED_GITLAB_TOKEN` environment variable.
 # The `read_repository` permission is required for this token.
 # [git_service.gitlab.self_hosted]
-# domain = example.org
+# hostname = example.org
 
 # This is the spec for trusted Maven build tools.
 [builder.maven]

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -624,7 +624,7 @@ class Analyzer:
             The component is already analyzed in the same session.
         """
         # Note: the component created in this function will be added to the database.
-        available_domains = [git_service.domain for git_service in GIT_SERVICES if git_service.domain]
+        available_domains = [git_service.hostname for git_service in GIT_SERVICES if git_service.hostname]
         try:
             analysis_target = Analyzer.to_analysis_target(config, available_domains)
         except InvalidPURLError as error:

--- a/src/macaron/slsa_analyzer/git_service/base_git_service.py
+++ b/src/macaron/slsa_analyzer/git_service/base_git_service.py
@@ -24,20 +24,20 @@ class BaseGitService:
             The name of the git service.
         """
         self.name = name
-        self.domain: str | None = None
+        self.hostname: str | None = None
 
     @abstractmethod
     def load_defaults(self) -> None:
         """Load the values for this git service from the ini configuration."""
 
-    def load_domain(self, section_name: str) -> str | None:
-        """Load the domain of the git service from the ini configuration section ``section_name``.
+    def load_hostname(self, section_name: str) -> str | None:
+        """Load the hostname of the git service from the ini configuration section ``section_name``.
 
         The section may or may not be available in the configuration. In both cases,
         the method should not raise ``ConfigurationError``.
 
         Meanwhile, if the section is present but there is a schema violation (e.g. a key such as
-        ``domain`` is missing), this method will raise a ``ConfigurationError``.
+        ``hostname`` is missing), this method will raise a ``ConfigurationError``.
 
         Parameters
         ----------
@@ -47,7 +47,7 @@ class BaseGitService:
         Returns
         -------
         str | None
-            The domain. This can be ``None`` if the git service section is not found in
+            The hostname. This can be ``None`` if the git service section is not found in
             the ini configuration file, meaning the user does not enable the
             corresponding git service.
 
@@ -61,17 +61,17 @@ class BaseGitService:
             # to have all available git services in the ini config.
             return None
         section = defaults[section_name]
-        domain = section.get("domain")
-        if not domain:
+        hostname = section.get("hostname")
+        if not hostname:
             raise ConfigurationError(
-                f'The "domain" key is missing in section [{section_name}] of the .ini configuration file.'
+                f'The "hostname" key is missing in section [{section_name}] of the .ini configuration file.'
             )
-        return domain
+        return hostname
 
     def is_detected(self, url: str) -> bool:
         """Check if the remote repo at the given ``url`` is hosted on this git service.
 
-        This check is done by checking the URL of the repo against the domain of this
+        This check is done by checking the URL of the repo against the hostname of this
         git service.
 
         Parameters
@@ -84,12 +84,12 @@ class BaseGitService:
         bool
             True if the repo is indeed hosted on this git service.
         """
-        if self.domain is None:
+        if self.hostname is None:
             return False
         return (
             git_url.parse_remote_url(
                 url,
-                allowed_git_service_domains=[self.domain],
+                allowed_git_service_hostnames=[self.hostname],
             )
             is not None
         )

--- a/src/macaron/slsa_analyzer/git_service/github.py
+++ b/src/macaron/slsa_analyzer/git_service/github.py
@@ -29,7 +29,7 @@ class GitHub(BaseGitService):
             If there is an error loading the configuration.
         """
         try:
-            self.domain = self.load_domain(section_name="git_service.github")
+            self.hostname = self.load_hostname(section_name="git_service.github")
         except ConfigurationError as error:
             raise error
 

--- a/src/macaron/slsa_analyzer/git_service/gitlab.py
+++ b/src/macaron/slsa_analyzer/git_service/gitlab.py
@@ -65,14 +65,14 @@ class GitLab(BaseGitService):
         CloneError
             If there is an error parsing the URL.
         """
-        if not self.domain:
+        if not self.hostname:
             # This should not happen.
-            logger.debug("Cannot clone with a Git service having no domain.")
+            logger.debug("Cannot clone with a Git service having no hostname.")
             raise CloneError(f"Cannot clone the repo '{url}' due to an internal error.")
 
         url_parse_result = git_url.parse_remote_url(
             url,
-            allowed_git_service_domains=[self.domain],
+            allowed_git_service_hostnames=[self.hostname],
         )
         if not url_parse_result:
             raise CloneError(
@@ -83,9 +83,9 @@ class GitLab(BaseGitService):
         # https://docs.gitlab.com/ee/gitlab-basics/start-using-git.html#clone-using-a-token
         access_token = os.environ.get(self.access_token_env_name)
         if access_token:
-            clone_url_netloc = f"oauth2:{access_token}@{self.domain}"
+            clone_url_netloc = f"oauth2:{access_token}@{self.hostname}"
         else:
-            clone_url_netloc = self.domain
+            clone_url_netloc = self.hostname
 
         clone_url = urlunparse(
             ParseResult(
@@ -241,17 +241,17 @@ class SelfHostedGitLab(GitLab):
             If there is an error loading the configuration.
         """
         try:
-            self.domain = self.load_domain(section_name="git_service.gitlab.self_hosted")
+            self.hostname = self.load_hostname(section_name="git_service.gitlab.self_hosted")
         except ConfigurationError as error:
             raise error
 
-        if not self.domain:
+        if not self.hostname:
             return
 
         if not os.environ.get(self.access_token_env_name):
             raise ConfigurationError(
                 f"Environment variable '{self.access_token_env_name}' is not set "
-                + f"for private GitLab service '{self.domain}'."
+                + f"for private GitLab service '{self.hostname}'."
             )
 
 
@@ -274,6 +274,6 @@ class PubliclyHostedGitLab(GitLab):
             If there is an error loading the configuration.
         """
         try:
-            self.domain = self.load_domain(section_name="git_service.gitlab.publicly_hosted")
+            self.hostname = self.load_hostname(section_name="git_service.gitlab.publicly_hosted")
         except ConfigurationError as error:
             raise error

--- a/tests/slsa_analyzer/git_service/test_gitlab.py
+++ b/tests/slsa_analyzer/git_service/test_gitlab.py
@@ -59,7 +59,7 @@ def test_construct_clone_url_with_token(repo_url: str, clone_url: str) -> None:
         pytest.param(
             """
             [git_service.gitlab.self_hosted]
-            domain = internal.gitlab.org
+            hostname = internal.gitlab.org
             """,
             "https://internal.gitlab.org/owner/repo.git",
             "https://oauth2:abcxyz@internal.gitlab.org/owner/repo.git",
@@ -68,7 +68,7 @@ def test_construct_clone_url_with_token(repo_url: str, clone_url: str) -> None:
         pytest.param(
             """
             [git_service.gitlab.self_hosted]
-            domain = internal.gitlab.org
+            hostname = internal.gitlab.org
             """,
             "https://internal.gitlab.org/owner/repo",
             "https://oauth2:abcxyz@internal.gitlab.org/owner/repo",
@@ -98,7 +98,7 @@ def test_self_hosted_gitlab_without_env_set(tmp_path: Path) -> None:
     """Test if the ``load_defaults`` method raises error if the required env variable is not set."""
     user_config_input = """
     [git_service.gitlab.self_hosted]
-    domain = internal.gitlab.org
+    hostname = internal.gitlab.org
     """
     user_config_path = os.path.join(tmp_path, "config.ini")
     with open(user_config_path, "w", encoding="utf-8") as user_config_file:
@@ -178,7 +178,7 @@ def test_origin_remote_url_masking(self_hosted_gitlab: Git, expected_origin_url:
     """
     user_config_input = """
     [git_service.gitlab.self_hosted]
-    domain = internal.gitlab.org
+    hostname = internal.gitlab.org
     """
     user_config_path = os.path.join(tmp_path, "config.ini")
     with open(user_config_path, "w", encoding="utf-8") as user_config_file:

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -143,33 +143,33 @@ def test_get_remote_vcs_url() -> None:
         (
             """
             [git_service.github]
-            domain = github.com
+            hostname = github.com
 
             [git_service.gitlab.public]
-            domain = gitlab.com
+            hostname = gitlab.com
             """,
             {"github.com", "gitlab.com"},
         ),
         (
             """
             [git_service.gitlab.publicly_hosted]
-            domain = gitlab.com
+            hostname = gitlab.com
 
             [git_service.gitlab.self_hosted]
-            domain = internal.gitlab.org
+            hostname = internal.gitlab.org
             """,
             {"gitlab.com", "internal.gitlab.org"},
         ),
     ],
 )
-def test_get_allowed_git_service_domains(
+def test_get_allowed_git_service_hostnames(
     config_input: str,
     expected_allowed_domain_set: set[str],
 ) -> None:
-    """Test the get allowed git service domains function."""
+    """Test the get allowed git service hostnames function."""
     config = configparser.ConfigParser()
     config.read_string(config_input)
-    assert set(git_url.get_allowed_git_service_domains(config)) == expected_allowed_domain_set
+    assert set(git_url.get_allowed_git_service_hostnames(config)) == expected_allowed_domain_set
 
 
 @pytest.mark.parametrize(
@@ -180,25 +180,25 @@ def test_get_allowed_git_service_domains(
             # User config cannot disable either of the two.
             """
             [git_service.github]
-            domain = github.com
+            hostname = github.com
             """,
             {"github.com", "gitlab.com"},
         ),
         (
             """
             [git_service.gitlab.self_hosted]
-            domain = internal.gitlab.org
+            hostname = internal.gitlab.org
             """,
             {"github.com", "gitlab.com", "internal.gitlab.org"},
         ),
     ],
 )
-def test_get_allowed_git_service_domains_with_override(
+def test_get_allowed_git_service_hostnames_with_override(
     user_config_input: str,
     expected_allowed_domain_set: set[str],
     tmp_path: Path,
 ) -> None:
-    """Test the get allowed git service domains function, in multi-config files scenario."""
+    """Test the get allowed git service hostnames function, in multi-config files scenario."""
     user_config_path = os.path.join(tmp_path, "config.ini")
     with open(user_config_path, "w", encoding="utf-8") as user_config_file:
         user_config_file.write(user_config_input)
@@ -207,11 +207,11 @@ def test_get_allowed_git_service_domains_with_override(
     # ``setup_test`` fixture.
     load_defaults(user_config_path)
 
-    assert set(git_url.get_allowed_git_service_domains(defaults)) == expected_allowed_domain_set
+    assert set(git_url.get_allowed_git_service_hostnames(defaults)) == expected_allowed_domain_set
 
 
-def test_get_remote_vcs_url_with_user_defined_allowed_domains(tmp_path: Path) -> None:
-    """Test the vcs URL validator method with user-defined allowed domains."""
+def test_get_remote_vcs_url_with_user_defined_allowed_hostnames(tmp_path: Path) -> None:
+    """Test the vcs URL validator method with user-defined allowed hostnames."""
     url = "https://internal.gitlab.org/org/name"
     assert git_url.get_remote_vcs_url(url) == ""
 
@@ -220,7 +220,7 @@ def test_get_remote_vcs_url_with_user_defined_allowed_domains(tmp_path: Path) ->
         user_config_file.write(
             """
             [git_service.gitlab.self_hosted]
-            domain = internal.gitlab.org
+            hostname = internal.gitlab.org
             """
         )
     # We don't have to worry about modifying the ``defaults`` object causing test


### PR DESCRIPTION
Closes #416.

# Summary

Rename the attribute `domain` to `hostname` in Git service sections in Macaron's `.ini` config.