### PR TITLE
fix: fix `run_macaron.sh` script to handle action arguments correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,6 @@ integration-test:
 .PHONY: integration-test-docker
 integration-test-docker:
 	scripts/dev_scripts/integration_tests_docker.sh $(REPO_PATH) scripts/release_scripts/run_macaron.sh
-	scripts/dev_scripts/test_run_macaron_sh.py
 
 # Build a source distribution package and a binary wheel distribution artifact.
 # When building these artifacts, we need the environment variable SOURCE_DATE_EPOCH

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ integration-test:
 .PHONY: integration-test-docker
 integration-test-docker:
 	scripts/dev_scripts/integration_tests_docker.sh $(REPO_PATH) scripts/release_scripts/run_macaron.sh
+	scripts/dev_scripts/test_run_macaron_sh.py
 
 # Build a source distribution package and a binary wheel distribution artifact.
 # When building these artifacts, we need the environment variable SOURCE_DATE_EPOCH

--- a/scripts/dev_scripts/integration_tests_docker.sh
+++ b/scripts/dev_scripts/integration_tests_docker.sh
@@ -15,6 +15,7 @@ RUN_MACARON_SCRIPT=$2
 # The scripts to compare the results of the integration tests.
 COMPARE_DEPS=$WORKSPACE/tests/dependency_analyzer/compare_dependencies.py
 COMPARE_JSON_OUT=$WORKSPACE/tests/e2e/compare_e2e_result.py
+UNIT_TEST_SCRIPT=$WORKSPACE/scripts/dev_scripts/test_run_macaron_sh.py
 
 RESULT_CODE=0
 
@@ -22,6 +23,11 @@ function log_fail() {
     printf "Error: FAILED integration test (line ${BASH_LINENO}) %s\n" $@
     RESULT_CODE=1
 }
+
+echo -e "\n----------------------------------------------------------------------------------"
+echo "Run unit tests for the run_macaron.sh script"
+$UNIT_TEST_SCRIPT || log_fail
+echo -e "\n----------------------------------------------------------------------------------"
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "timyarkov/multibuild_test: Analyzing the repo path, the branch name and the commit digest"

--- a/scripts/dev_scripts/test_run_macaron_sh.py
+++ b/scripts/dev_scripts/test_run_macaron_sh.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Tests for the ``run_macaron.sh`` script.
+
+Note: this script is compatible with python >=3.6.
+"""
+
+import subprocess
+import sys
+from collections import namedtuple
+
+
+def test_macaron_command() -> int:
+    """Test if the ``macaron`` command in the container receives the correct arguments."""
+
+    TestCase = namedtuple("TestCase", ["name", "script_args", "expected_macaron_args"])
+
+    test_cases = [
+        TestCase(
+            name="'-h' as main argument",
+            script_args=["-h"],
+            expected_macaron_args=["-h"],
+        ),
+        TestCase(
+            name="'-h' as action argument for 'analyze'",
+            script_args=["analyze", "-h"],
+            expected_macaron_args=["analyze", "-h"],
+        ),
+        TestCase(
+            name="'-h' as action argument for 'verify-policy'",
+            script_args=["verify-policy", "-h"],
+            expected_macaron_args=["verify-policy", "-h"],
+        ),
+    ]
+
+    exit_code = 0
+
+    for test_case in test_cases:
+        name, script_args, expected_macaron_args = test_case
+        result = subprocess.run(
+            [
+                "scripts/release_scripts/run_macaron.sh",
+                *script_args,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={"MCN_DEBUG_ARGS": "1"},
+            check=True,
+        )
+        resulting_macaron_args = list(result.stderr.decode("utf-8").split())
+
+        print(f"test_macaron_command[{name}]:", end=" ")
+
+        if resulting_macaron_args != expected_macaron_args:
+            print("FAILED")
+            print("  script args           : %s", str(script_args))
+            print("  expected macaron args : %s", str(expected_macaron_args))
+            print("  resulting macaron args: %s", str(resulting_macaron_args))
+            exit_code = 1
+        else:
+            print("PASSED")
+
+    return exit_code
+
+
+def main() -> int:
+    """Run all tests."""
+    return test_macaron_command()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #460.

# Summary

* Fix the `run_macaron.sh` script to handle action arguments correctly.
* Add a test script to check for the arguments that are actually passed to the `macaron` command in the Macaron container.