### PR TITLE
ci(integration-tests): update expected results for micronaut-core

### DIFF
--- a/tests/e2e/expected_results/micronaut-core/micronaut-core.json
+++ b/tests/e2e/expected_results/micronaut-core/micronaut-core.json
@@ -1,6 +1,6 @@
 {
     "metadata": {
-        "timestamps": "2023-09-01 13:27:44"
+        "timestamps": "2023-09-13 08:44:28"
     },
     "target": {
         "info": {
@@ -12,45 +12,736 @@
             "commit_date": "2023-01-28T08:54:51+00:00"
         },
         "provenances": {
-            "is_inferred": true,
+            "is_inferred": false,
             "content": {
                 "github_actions": [
                     {
                         "_type": "https://in-toto.io/Statement/v0.1",
-                        "subject": [],
                         "predicateType": "https://slsa.dev/provenance/v0.2",
+                        "subject": [
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-aop/4.1.5/micronaut-aop-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "73802ebdf244ba4a614e5e7d026c00e25e6fc718bd927a8dae4a49f36d41c878"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-aop/4.1.5/micronaut-aop-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "2e2ce2ec9c717bfcd7382e204e075dc7f7e2c36a8355b50083492ae88e936cec"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-buffer-netty/4.1.5/micronaut-buffer-netty-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "cd97191240ed8d454d6d781118afa62723d4495a7a0f968f91e4de1480b61740"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-buffer-netty/4.1.5/micronaut-buffer-netty-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "71461285342a72a609847631546cfe0f5be06b2c85f908823a299d66efe3ece6"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-context-propagation/4.1.5/micronaut-context-propagation-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "eeb9c121c6d775c96a0fe59940f912a5166c99dea1c91b0543c299e838382919"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-context-propagation/4.1.5/micronaut-context-propagation-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "fd584c1e901b9ffbacbc40099a8b4feecb34e947d5021f74deba5500357c2896"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-context/4.1.5/micronaut-context-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "247700e354746733ed8333fa4d498d157fca38d2570d7d8ca88fe4792c0eb39e"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-context/4.1.5/micronaut-context-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "8a6cfa79fbba8abcd8d234298a2d919016ada8fee686fb1e59395c66e25081a7"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core-bom/4.1.5/micronaut-core-bom-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "2e2ffdd880006aeb3cd8919ca567f1677da872c8d4122a2fa3031673a5f6a380"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core-processor/4.1.5/micronaut-core-processor-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "f583e864c961919a8694c46cc7722a8f61b5d320f2b5e25e0e04392e519881d2"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core-processor/4.1.5/micronaut-core-processor-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "0c073217c3904f0952abb2133cf3e1b07793134d66c6ed01764bc000ff6f4a1e"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core-reactive/4.1.5/micronaut-core-reactive-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "717cccd4a147d03d7d39588e91f7efdf537c93271687183358a007e7e4e4dab3"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core-reactive/4.1.5/micronaut-core-reactive-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "75f1f0e86d7b6b630c3d5ef74d61070b4d767414d6c8db8f2c13fb63c295eefa"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core/4.1.5/micronaut-core-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "20deddcb13c9861d9134bb1aeb1a4c654f479430bbd8e82db1f10539bac80680"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-core/4.1.5/micronaut-core-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "bb3fb4b4f770b22a539e6ddb904c3fdead1fe1b9faf0bfe4a77ad79dba5f361e"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-discovery-core/4.1.5/micronaut-discovery-core-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "72d4761f50b813397eaea8d86e30e0ca9831421912076fec0c034a6a88455624"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-discovery-core/4.1.5/micronaut-discovery-core-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "54c7ecfbb43baf81889f2b940bd62572ed1177ca00adbac360f587e384869f9d"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-function-client/4.1.5/micronaut-function-client-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "a4326b92bd6834bfa509b83a4c835169823f4c9cc98979ac66271c2bc8fccb35"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-function-client/4.1.5/micronaut-function-client-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "700eb2ccdb9e4ac5a7534236e9f59ed70dba702107b620478e2d3d08625d772e"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-function-web/4.1.5/micronaut-function-web-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "0dac163a6bc4f3ad018a882641cc03f8ff8cc831599925628034669e36659d45"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-function-web/4.1.5/micronaut-function-web-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "03f3c7227c71f756029e188d2d880b02bfb12b3441bd4e3540fe26129f09b257"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-function/4.1.5/micronaut-function-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "ac43bedc4f66837515efc974556da3a0aacbdb0c7b3b3e72bd04f5bcda6e0862"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-function/4.1.5/micronaut-function-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "e88f360a124512b37df7a05f3cab2832dd3d518f54e3f39bd6e7b58db2425c05"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-graal/4.1.5/micronaut-graal-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "118be909e46f27c99ff3a5d731c199103e92f8432b76d31e0eb2f21d430d901f"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-graal/4.1.5/micronaut-graal-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "fa6732db0961ce05f5aa863a2f4009b8e1623670b2d67c9750fea814a25072f9"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client-core/4.1.5/micronaut-http-client-core-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "5c93939d5bf0db8a2c37ec8d38fb7685bf48f3a3751d30959e6e9a29b582b79d"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client-core/4.1.5/micronaut-http-client-core-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "fdf1597373951c1b788a432bd5f2d51e7318b5cda8c266436b3cbabeb8b21f91"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client-jdk/4.1.5/micronaut-http-client-jdk-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "003a217ecb74e8d01c78994b8e94489a740573dbe8d7b0548647c650fb97152c"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client-jdk/4.1.5/micronaut-http-client-jdk-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "fe076caedff9e4b283c4020646090d815dc96cfd01cb8e0bd2171750aa3d5895"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client-tck/4.1.5/micronaut-http-client-tck-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "dc8a0720d4b01228bfc4363ac613135128d9a68b75ea3da6d4cb22769ea3e1c5"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client-tck/4.1.5/micronaut-http-client-tck-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "c9f5167b5f0b4c5ce872ecb73acea46a011a8416c6dcb5035a003b5e6669c75a"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client/4.1.5/micronaut-http-client-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "7a9aaae999986d0d0a3e7d4d1cd250aff0d1a7620d89fa6096520b031c981a00"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-client/4.1.5/micronaut-http-client-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "34cf5b7855a3cfa376dd3c98e25dc346896354ad444a1053e35b5bba2f477bae"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-netty/4.1.5/micronaut-http-netty-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "708f7e31d84ad54b28f60c3a4fe88c310d6edb3395c63fd39b8f9ad64f0fedef"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-netty/4.1.5/micronaut-http-netty-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "d9b875cbffd3eb41a0423bcd0ca89f89989315211a409fe0cdf5f44a0625babf"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-server-netty/4.1.5/micronaut-http-server-netty-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "c5aceb034eb90a45f4db0735e613abc239dc9017dd1144cafd4a65ffaf92cd8e"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-server-netty/4.1.5/micronaut-http-server-netty-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "e146b69ec34542914add5150c5fbcd51d5af65f9c9d4477abdb0b2388672edb3"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-server-tck/4.1.5/micronaut-http-server-tck-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "0093d9bc21b4f8d2bb8e21d497cc584407a899a8328945a1498a509c9f2edba2"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-server-tck/4.1.5/micronaut-http-server-tck-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "4fc2d9ca9c4f924c7c0bb39fa21f5e629723c653acab387d45b4b2db4c7e8784"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-server/4.1.5/micronaut-http-server-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "f123492ebe049f1c21e8b354101b33f2ae98f77ede238b45c4a334aca005f4b4"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-server/4.1.5/micronaut-http-server-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "72f777b45d0f87e2335e32fe738b2dc4ba399c6a3d3b2ea700012eab6ae7338d"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-tck/4.1.5/micronaut-http-tck-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "00a332006e434e527d1b66d77fb5767e33d76eabc79da33c8aa57ab0d38910a3"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-tck/4.1.5/micronaut-http-tck-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "a9b81430a409d72f485f55a48837e80d32cc1c94e49b10590691c6301ca0ef76"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-validation/4.1.5/micronaut-http-validation-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "897cc4cd6c3550d1f729d0376f588f47751d412d9d29f545abf1f06135fb09cd"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http-validation/4.1.5/micronaut-http-validation-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "8cbd5710c992d520e8f7323c22b92ab6fb250405a43697bc61353f002fb71e14"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http/4.1.5/micronaut-http-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "dd1f8853b1ede7f8b140069070870fbc86347163e3fbdb325be523e57eb7cf84"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-http/4.1.5/micronaut-http-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "e25c7daee0271119c4a19efed90e20c76ec42ac34635db359d37cad362cddf5f"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-groovy-test/4.1.5/micronaut-inject-groovy-test-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "afcbccb1c91dd062ebdc42fc920730dbf13724dbd0196935f6afeecf04a9106f"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-groovy-test/4.1.5/micronaut-inject-groovy-test-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "d2f02d1e9348bf22a7e8ed2f3e93b4be2d481dd9b4a8fb20b26ec4b6d36e759b"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-groovy/4.1.5/micronaut-inject-groovy-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "323544d892cf168d85c2ad76153dd165c612483b0b33e699e42a512b84d53923"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-groovy/4.1.5/micronaut-inject-groovy-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "553493dc236be3e226fa6613d147ad148c37442bd4b99ce5c84364650ae5f384"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-java-test/4.1.5/micronaut-inject-java-test-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "d508cf025a119434e0da49f6c27e4bc0fdb933db5b153725c32fd44996569d42"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-java-test/4.1.5/micronaut-inject-java-test-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "9e50f80f1f455ef5e85c7cc40d5178c2e469e998a1800527a8308904b6c8dc8c"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-java/4.1.5/micronaut-inject-java-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "81f5b9e12f18539034a367268897df2b7becac8bf06b33803f9ba695a9beaad6"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-java/4.1.5/micronaut-inject-java-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "25bf28b2b5451248e5ecc969be482aa4c97b482805b639dac7be8cb471fc2cbc"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-kotlin-test/4.1.5/micronaut-inject-kotlin-test-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "8c11ac52c0f6c9b21be5effb00303e3ed4a817467a43d4e421aaf1bb7e194cc6"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-kotlin-test/4.1.5/micronaut-inject-kotlin-test-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "824e67fe23ef390a4b9e9275e2e3cd117007b67655a16e89ccd1e571210c0ef5"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-kotlin/4.1.5/micronaut-inject-kotlin-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "6d60ba5b91f3209c71bc8dc7ad8cb2a22c388fef32adea2fd21b635eee45fb8b"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject-kotlin/4.1.5/micronaut-inject-kotlin-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "d17568bb093af3b7c0ecff064f87d78550d5ced2b2916f021839e24d1ab2d53b"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject/4.1.5/micronaut-inject-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "4d4c7416ac866a40c7ce2f5924187c552888d794955390b38ec04b9cf6110651"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-inject/4.1.5/micronaut-inject-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "2c2cab2680c47d9fd11a9784247e8bd83743152394322200f4e101d8cc166cfa"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-jackson-core/4.1.5/micronaut-jackson-core-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "c672fd1a288558aec6f7698b2ef35715692ef8daba004c3f8c67998d7017c7bc"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-jackson-core/4.1.5/micronaut-jackson-core-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "5323189bd40f3cb040a7bf41dd920dd1f1b1eef91f8a7e1b14e3010649838a4a"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-jackson-databind/4.1.5/micronaut-jackson-databind-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "4aac98efd029e8826c1ee6e1a469f9879ab24407aa447fe8e7fed65e8b7bc90e"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-jackson-databind/4.1.5/micronaut-jackson-databind-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "5dd35a71c760c3097ed2620840cddc5ee7e20268438bc0acfc5e9698168e2111"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-json-core/4.1.5/micronaut-json-core-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "f1e507f157f0b9805359c6596473abf85ec76df6fe43c23ba5d9b19207997a33"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-json-core/4.1.5/micronaut-json-core-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "8402a208c777ea46ace9d59b80e6ef8da6c4016bd0ca029903f1809110e8f0d1"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-management/4.1.5/micronaut-management-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "dd1d9a8a9b00aa08de751cbab603529e3bc35f1c35e12b4cf7c9b4c3e0a100d5"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-management/4.1.5/micronaut-management-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "cd783ff62dff58d3234af80c35f75bb898817564f9c5da3d0b9dffdba7ea2a4b"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-messaging/4.1.5/micronaut-messaging-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "48a14233d59963213c6f93d5a7400ecda026ec04cf5bf88a63f381f5242d13dc"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-messaging/4.1.5/micronaut-messaging-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "49450d09fc51ee0d7f2a66cb40f653773b36aa8fbe5cf4a2c0acf6ba0a703e71"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-retry/4.1.5/micronaut-retry-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "bbc1ad254026e8bd769e10012c626a232e77c24be2448c1b3175ee9ad74ac51f"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-retry/4.1.5/micronaut-retry-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "7ab9fd386c84eb6de27c585b8b8ef9bec1362d40f1f1c6cd2bcc426ca251efb4"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-router/4.1.5/micronaut-router-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "1fc941814d7c5cc32e3b4f3c48a23cdec4faf06bd8b9f0929dcc001f236b997d"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-router/4.1.5/micronaut-router-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "f62489a3346d0a19e2363077f164738aab8e3458b68c9b56d48cfea69b1eaebe"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-runtime-osx/4.1.5/micronaut-runtime-osx-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "426b65799e02e851e6694cdf4edc9f3ffb606634ce010618693f69b3d713e58b"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-runtime-osx/4.1.5/micronaut-runtime-osx-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "f7fcab413f5ee9b742d58f2815251a7c4d0cfbfad9fd0f93b83746c92f7690c5"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-runtime/4.1.5/micronaut-runtime-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "c1abaf8e7009e3b86aba492de6f2624ba553c5120d24112f408707e29f2bcaa7"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-runtime/4.1.5/micronaut-runtime-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "a3ce6a796903dd9a9b85a9a4622ab5033af30bc7b6626c30c7746dd72bde60c3"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-websocket/4.1.5/micronaut-websocket-4.1.5.jar",
+                                "digest": {
+                                    "sha256": "b1ce53a93bd25aa7513d35c22e8df6e606320fe35b10cdb68ab5b7b9cfb1383a"
+                                }
+                            },
+                            {
+                                "name": "build/repo/io/micronaut/micronaut-websocket/4.1.5/micronaut-websocket-4.1.5.pom",
+                                "digest": {
+                                    "sha256": "28defaf1e40c353139166ca1e078464c17f18096339da99e2d80a5c5cb0e78ee"
+                                }
+                            }
+                        ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/micronaut-projects/micronaut-core/blob/68f9bb0a78fa930865d37fca39252b9ec66e4a43/.github/workflows/gradle.yml"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0"
                             },
-                            "buildType": "Custom github_actions",
+                            "buildType": "https://github.com/slsa-framework/slsa-github-generator/generic@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "https://github.com/micronaut-projects/micronaut-core@refs/heads/3.8.x",
+                                    "uri": "git+https://github.com/micronaut-projects/micronaut-core@refs/tags/v4.1.5",
                                     "digest": {
-                                        "sha1": "68f9bb0a78fa930865d37fca39252b9ec66e4a43"
+                                        "sha1": "3c6605283d2f6290321b581afa8c56a34659e324"
                                     },
-                                    "entryPoint": "https://github.com/micronaut-projects/micronaut-core/blob/68f9bb0a78fa930865d37fca39252b9ec66e4a43/.github/workflows/gradle.yml"
+                                    "entryPoint": ".github/workflows/release.yml"
                                 },
                                 "parameters": {},
-                                "environment": {}
+                                "environment": {
+                                    "github_actor": "sdelamo",
+                                    "github_actor_id": "864788",
+                                    "github_base_ref": "",
+                                    "github_event_name": "release",
+                                    "github_event_payload": {
+                                        "action": "published",
+                                        "organization": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/u/36880643?v=4",
+                                            "description": "",
+                                            "events_url": "https://api.github.com/orgs/micronaut-projects/events",
+                                            "hooks_url": "https://api.github.com/orgs/micronaut-projects/hooks",
+                                            "id": 36880643,
+                                            "issues_url": "https://api.github.com/orgs/micronaut-projects/issues",
+                                            "login": "micronaut-projects",
+                                            "members_url": "https://api.github.com/orgs/micronaut-projects/members{/member}",
+                                            "node_id": "MDEyOk9yZ2FuaXphdGlvbjM2ODgwNjQz",
+                                            "public_members_url": "https://api.github.com/orgs/micronaut-projects/public_members{/member}",
+                                            "repos_url": "https://api.github.com/orgs/micronaut-projects/repos",
+                                            "url": "https://api.github.com/orgs/micronaut-projects"
+                                        },
+                                        "release": {
+                                            "assets": [],
+                                            "assets_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/releases/120862600/assets",
+                                            "author": {
+                                                "avatar_url": "https://avatars.githubusercontent.com/u/864788?v=4",
+                                                "events_url": "https://api.github.com/users/sdelamo/events{/privacy}",
+                                                "followers_url": "https://api.github.com/users/sdelamo/followers",
+                                                "following_url": "https://api.github.com/users/sdelamo/following{/other_user}",
+                                                "gists_url": "https://api.github.com/users/sdelamo/gists{/gist_id}",
+                                                "gravatar_id": "",
+                                                "html_url": "https://github.com/sdelamo",
+                                                "id": 864788,
+                                                "login": "sdelamo",
+                                                "node_id": "MDQ6VXNlcjg2NDc4OA==",
+                                                "organizations_url": "https://api.github.com/users/sdelamo/orgs",
+                                                "received_events_url": "https://api.github.com/users/sdelamo/received_events",
+                                                "repos_url": "https://api.github.com/users/sdelamo/repos",
+                                                "site_admin": false,
+                                                "starred_url": "https://api.github.com/users/sdelamo/starred{/owner}{/repo}",
+                                                "subscriptions_url": "https://api.github.com/users/sdelamo/subscriptions",
+                                                "type": "User",
+                                                "url": "https://api.github.com/users/sdelamo"
+                                            },
+                                            "body": "<!-- Release notes generated using configuration in .github/release.yml at 4.1.x -->\r\n\r\n## What's Changed\r\n### Bug Fixes \ud83d\udc1e\r\n* Fix logging with logger.config and no levels by @timyates in https://github.com/micronaut-projects/micronaut-core/pull/9859\r\n### Dependency Upgrade \ud83d\ude80\r\n* Upgraded logback to 1.4.11 by @msupic in https://github.com/micronaut-projects/micronaut-core/pull/9857\r\n### Tests \u2705\r\n* test: GraalVM logging by @sdelamo in https://github.com/micronaut-projects/micronaut-core/pull/9858\r\n\r\n**Full Changelog**: https://github.com/micronaut-projects/micronaut-core/compare/v4.1.4...v4.1.5",
+                                            "created_at": "2023-09-12T15:47:52Z",
+                                            "draft": false,
+                                            "html_url": "https://github.com/micronaut-projects/micronaut-core/releases/tag/v4.1.5",
+                                            "id": 120862600,
+                                            "mentions_count": 3,
+                                            "name": "Micronaut Core 4.1.5",
+                                            "node_id": "RE_kwDOB2eaPM4HNDeI",
+                                            "prerelease": false,
+                                            "published_at": "2023-09-12T20:42:13Z",
+                                            "tag_name": "v4.1.5",
+                                            "tarball_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/tarball/v4.1.5",
+                                            "target_commitish": "4.1.x",
+                                            "upload_url": "https://uploads.github.com/repos/micronaut-projects/micronaut-core/releases/120862600/assets{?name,label}",
+                                            "url": "https://api.github.com/repos/micronaut-projects/micronaut-core/releases/120862600",
+                                            "zipball_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/zipball/v4.1.5"
+                                        },
+                                        "repository": {
+                                            "allow_forking": true,
+                                            "archive_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/{archive_format}{/ref}",
+                                            "archived": false,
+                                            "assignees_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/assignees{/user}",
+                                            "blobs_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/git/blobs{/sha}",
+                                            "branches_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/branches{/branch}",
+                                            "clone_url": "https://github.com/micronaut-projects/micronaut-core.git",
+                                            "collaborators_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/collaborators{/collaborator}",
+                                            "comments_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/comments{/number}",
+                                            "commits_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/commits{/sha}",
+                                            "compare_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/compare/{base}...{head}",
+                                            "contents_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/contents/{+path}",
+                                            "contributors_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/contributors",
+                                            "created_at": "2018-03-07T12:05:08Z",
+                                            "default_branch": "4.1.x",
+                                            "deployments_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/deployments",
+                                            "description": "Micronaut Application Framework",
+                                            "disabled": false,
+                                            "downloads_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/downloads",
+                                            "events_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/events",
+                                            "fork": false,
+                                            "forks": 996,
+                                            "forks_count": 996,
+                                            "forks_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/forks",
+                                            "full_name": "micronaut-projects/micronaut-core",
+                                            "git_commits_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/git/commits{/sha}",
+                                            "git_refs_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/git/refs{/sha}",
+                                            "git_tags_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/git/tags{/sha}",
+                                            "git_url": "git://github.com/micronaut-projects/micronaut-core.git",
+                                            "has_discussions": true,
+                                            "has_downloads": true,
+                                            "has_issues": true,
+                                            "has_pages": true,
+                                            "has_projects": true,
+                                            "has_wiki": true,
+                                            "homepage": "http://micronaut.io",
+                                            "hooks_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/hooks",
+                                            "html_url": "https://github.com/micronaut-projects/micronaut-core",
+                                            "id": 124230204,
+                                            "is_template": false,
+                                            "issue_comment_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/issues/comments{/number}",
+                                            "issue_events_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/issues/events{/number}",
+                                            "issues_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/issues{/number}",
+                                            "keys_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/keys{/key_id}",
+                                            "labels_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/labels{/name}",
+                                            "language": "Java",
+                                            "languages_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/languages",
+                                            "license": {
+                                                "key": "apache-2.0",
+                                                "name": "Apache License 2.0",
+                                                "node_id": "MDc6TGljZW5zZTI=",
+                                                "spdx_id": "Apache-2.0",
+                                                "url": "https://api.github.com/licenses/apache-2.0"
+                                            },
+                                            "merges_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/merges",
+                                            "milestones_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/milestones{/number}",
+                                            "mirror_url": null,
+                                            "name": "micronaut-core",
+                                            "node_id": "MDEwOlJlcG9zaXRvcnkxMjQyMzAyMDQ=",
+                                            "notifications_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/notifications{?since,all,participating}",
+                                            "open_issues": 647,
+                                            "open_issues_count": 647,
+                                            "owner": {
+                                                "avatar_url": "https://avatars.githubusercontent.com/u/36880643?v=4",
+                                                "events_url": "https://api.github.com/users/micronaut-projects/events{/privacy}",
+                                                "followers_url": "https://api.github.com/users/micronaut-projects/followers",
+                                                "following_url": "https://api.github.com/users/micronaut-projects/following{/other_user}",
+                                                "gists_url": "https://api.github.com/users/micronaut-projects/gists{/gist_id}",
+                                                "gravatar_id": "",
+                                                "html_url": "https://github.com/micronaut-projects",
+                                                "id": 36880643,
+                                                "login": "micronaut-projects",
+                                                "node_id": "MDEyOk9yZ2FuaXphdGlvbjM2ODgwNjQz",
+                                                "organizations_url": "https://api.github.com/users/micronaut-projects/orgs",
+                                                "received_events_url": "https://api.github.com/users/micronaut-projects/received_events",
+                                                "repos_url": "https://api.github.com/users/micronaut-projects/repos",
+                                                "site_admin": false,
+                                                "starred_url": "https://api.github.com/users/micronaut-projects/starred{/owner}{/repo}",
+                                                "subscriptions_url": "https://api.github.com/users/micronaut-projects/subscriptions",
+                                                "type": "Organization",
+                                                "url": "https://api.github.com/users/micronaut-projects"
+                                            },
+                                            "private": false,
+                                            "pulls_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/pulls{/number}",
+                                            "pushed_at": "2023-09-12T20:42:13Z",
+                                            "releases_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/releases{/id}",
+                                            "size": 99112,
+                                            "ssh_url": "git@github.com:micronaut-projects/micronaut-core.git",
+                                            "stargazers_count": 5806,
+                                            "stargazers_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/stargazers",
+                                            "statuses_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/statuses/{sha}",
+                                            "subscribers_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/subscribers",
+                                            "subscription_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/subscription",
+                                            "svn_url": "https://github.com/micronaut-projects/micronaut-core",
+                                            "tags_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/tags",
+                                            "teams_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/teams",
+                                            "topics": [
+                                                "cloudnative",
+                                                "groovy",
+                                                "java",
+                                                "kotlin",
+                                                "microservices",
+                                                "serverless"
+                                            ],
+                                            "trees_url": "https://api.github.com/repos/micronaut-projects/micronaut-core/git/trees{/sha}",
+                                            "updated_at": "2023-09-12T18:43:57Z",
+                                            "url": "https://api.github.com/repos/micronaut-projects/micronaut-core",
+                                            "visibility": "public",
+                                            "watchers": 5806,
+                                            "watchers_count": 5806,
+                                            "web_commit_signoff_required": false
+                                        },
+                                        "sender": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/u/864788?v=4",
+                                            "events_url": "https://api.github.com/users/sdelamo/events{/privacy}",
+                                            "followers_url": "https://api.github.com/users/sdelamo/followers",
+                                            "following_url": "https://api.github.com/users/sdelamo/following{/other_user}",
+                                            "gists_url": "https://api.github.com/users/sdelamo/gists{/gist_id}",
+                                            "gravatar_id": "",
+                                            "html_url": "https://github.com/sdelamo",
+                                            "id": 864788,
+                                            "login": "sdelamo",
+                                            "node_id": "MDQ6VXNlcjg2NDc4OA==",
+                                            "organizations_url": "https://api.github.com/users/sdelamo/orgs",
+                                            "received_events_url": "https://api.github.com/users/sdelamo/received_events",
+                                            "repos_url": "https://api.github.com/users/sdelamo/repos",
+                                            "site_admin": false,
+                                            "starred_url": "https://api.github.com/users/sdelamo/starred{/owner}{/repo}",
+                                            "subscriptions_url": "https://api.github.com/users/sdelamo/subscriptions",
+                                            "type": "User",
+                                            "url": "https://api.github.com/users/sdelamo"
+                                        }
+                                    },
+                                    "github_head_ref": "",
+                                    "github_ref": "refs/tags/v4.1.5",
+                                    "github_ref_type": "tag",
+                                    "github_repository_id": "124230204",
+                                    "github_repository_owner": "micronaut-projects",
+                                    "github_repository_owner_id": "36880643",
+                                    "github_run_attempt": "1",
+                                    "github_run_id": "6164653256",
+                                    "github_run_number": "162",
+                                    "github_sha1": "3c6605283d2f6290321b581afa8c56a34659e324"
+                                }
                             },
-                            "buildConfig": {},
                             "metadata": {
-                                "buildInvocationId": "",
-                                "buildStartedOn": "<TIMESTAMP>",
-                                "buildFinishedOn": "<TIMESTAMP>",
+                                "buildInvocationID": "6164653256-1",
                                 "completeness": {
-                                    "parameters": "false",
-                                    "environment": "false",
-                                    "materials": "false"
+                                    "parameters": true,
+                                    "environment": false,
+                                    "materials": false
                                 },
-                                "reproducible": "false"
+                                "reproducible": false
                             },
                             "materials": [
                                 {
-                                    "uri": "<URI>",
-                                    "digest": {}
+                                    "uri": "git+https://github.com/micronaut-projects/micronaut-core@refs/tags/v4.1.5",
+                                    "digest": {
+                                        "sha1": "3c6605283d2f6290321b581afa8c56a34659e324"
+                                    }
                                 }
                             ]
                         }
@@ -61,12 +752,23 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 5,
-                "PASSED": 4,
+                "FAILED": 2,
+                "PASSED": 6,
                 "SKIPPED": 0,
-                "UNKNOWN": 0
+                "UNKNOWN": 1
             },
             "results": [
+                {
+                    "check_id": "mcn_provenance_expectation_1",
+                    "check_description": "Check whether the SLSA provenance for the produced artifact conforms to the expected value.",
+                    "slsa_requirements": [
+                        "Provenance conforms with expectations - SLSA Level 3"
+                    ],
+                    "justification": [
+                        "No expectation defined for this repository."
+                    ],
+                    "result_type": "UNKNOWN"
+                },
                 {
                     "check_id": "mcn_build_as_code_1",
                     "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
@@ -106,6 +808,36 @@
                     "result_type": "PASSED"
                 },
                 {
+                    "check_id": "mcn_provenance_available_1",
+                    "check_description": "Check whether the target has intoto provenance.",
+                    "slsa_requirements": [
+                        "Provenance - Available - SLSA Level 1",
+                        "Provenance content - Identifies build instructions - SLSA Level 1",
+                        "Provenance content - Identifies artifacts - SLSA Level 1",
+                        "Provenance content - Identifies builder - SLSA Level 1"
+                    ],
+                    "justification": [
+                        "Found provenance in release assets:",
+                        "multiple.intoto.jsonl"
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_provenance_level_three_1",
+                    "check_description": "Check whether the target has SLSA provenance level 3.",
+                    "slsa_requirements": [
+                        "Provenance - Non falsifiable - SLSA Level 3",
+                        "Provenance content - Includes all build parameters - SLSA Level 3",
+                        "Provenance content - Identifies entry point - SLSA Level 3",
+                        "Provenance content - Identifies source code - SLSA Level 2"
+                    ],
+                    "justification": [
+                        "Successfully verified level 3: ",
+                        "verify passed : build/repo/micronaut-aop/4.1.5/micronaut-aop-4.1.5.jar,verify passed : build/repo/micronaut-aop/4.1.5/micronaut-aop-4.1.5.pom,verify passed : build/repo/micronaut-buffer-netty/4.1.5/micronaut-buffer-netty-4.1.5.jar,verify passed : build/repo/micronaut-buffer-netty/4.1.5/micronaut-buffer-netty-4.1.5.pom,verify passed : build/repo/micronaut-context-propagation/4.1.5/micronaut-context-propagation-4.1.5.jar,verify passed : build/repo/micronaut-context-propagation/4.1.5/micronaut-context-propagation-4.1.5.pom,verify passed : build/repo/micronaut-context/4.1.5/micronaut-context-4.1.5.jar,verify passed : build/repo/micronaut-context/4.1.5/micronaut-context-4.1.5.pom,verify passed : build/repo/micronaut-core-bom/4.1.5/micronaut-core-bom-4.1.5.pom,verify passed : build/repo/micronaut-core-processor/4.1.5/micronaut-core-processor-4.1.5.jar,verify passed : build/repo/micronaut-core-processor/4.1.5/micronaut-core-processor-4.1.5.pom,verify passed : build/repo/micronaut-core-reactive/4.1.5/micronaut-core-reactive-4.1.5.jar,verify passed : build/repo/micronaut-core-reactive/4.1.5/micronaut-core-reactive-4.1.5.pom,verify passed : build/repo/micronaut-core/4.1.5/micronaut-core-4.1.5.jar,verify passed : build/repo/micronaut-core/4.1.5/micronaut-core-4.1.5.pom,verify passed : build/repo/micronaut-discovery-core/4.1.5/micronaut-discovery-core-4.1.5.jar,verify passed : build/repo/micronaut-discovery-core/4.1.5/micronaut-discovery-core-4.1.5.pom,verify passed : build/repo/micronaut-function-client/4.1.5/micronaut-function-client-4.1.5.jar,verify passed : build/repo/micronaut-function-client/4.1.5/micronaut-function-client-4.1.5.pom,verify passed : build/repo/micronaut-function-web/4.1.5/micronaut-function-web-4.1.5.jar,verify passed : build/repo/micronaut-function-web/4.1.5/micronaut-function-web-4.1.5.pom,verify passed : build/repo/micronaut-function/4.1.5/micronaut-function-4.1.5.jar,verify passed : build/repo/micronaut-function/4.1.5/micronaut-function-4.1.5.pom,verify passed : build/repo/micronaut-graal/4.1.5/micronaut-graal-4.1.5.jar,verify passed : build/repo/micronaut-graal/4.1.5/micronaut-graal-4.1.5.pom,verify passed : build/repo/micronaut-http-client-core/4.1.5/micronaut-http-client-core-4.1.5.jar,verify passed : build/repo/micronaut-http-client-core/4.1.5/micronaut-http-client-core-4.1.5.pom,verify passed : build/repo/micronaut-http-client-jdk/4.1.5/micronaut-http-client-jdk-4.1.5.jar,verify passed : build/repo/micronaut-http-client-jdk/4.1.5/micronaut-http-client-jdk-4.1.5.pom,verify passed : build/repo/micronaut-http-client-tck/4.1.5/micronaut-http-client-tck-4.1.5.jar,verify passed : build/repo/micronaut-http-client-tck/4.1.5/micronaut-http-client-tck-4.1.5.pom,verify passed : build/repo/micronaut-http-client/4.1.5/micronaut-http-client-4.1.5.jar,verify passed : build/repo/micronaut-http-client/4.1.5/micronaut-http-client-4.1.5.pom,verify passed : build/repo/micronaut-http-netty/4.1.5/micronaut-http-netty-4.1.5.jar,verify passed : build/repo/micronaut-http-netty/4.1.5/micronaut-http-netty-4.1.5.pom,verify passed : build/repo/micronaut-http-server-netty/4.1.5/micronaut-http-server-netty-4.1.5.jar,verify passed : build/repo/micronaut-http-server-netty/4.1.5/micronaut-http-server-netty-4.1.5.pom,verify passed : build/repo/micronaut-http-server-tck/4.1.5/micronaut-http-server-tck-4.1.5.jar,verify passed : build/repo/micronaut-http-server-tck/4.1.5/micronaut-http-server-tck-4.1.5.pom,verify passed : build/repo/micronaut-http-server/4.1.5/micronaut-http-server-4.1.5.jar,verify passed : build/repo/micronaut-http-server/4.1.5/micronaut-http-server-4.1.5.pom,verify passed : build/repo/micronaut-http-tck/4.1.5/micronaut-http-tck-4.1.5.jar,verify passed : build/repo/micronaut-http-tck/4.1.5/micronaut-http-tck-4.1.5.pom,verify passed : build/repo/micronaut-http-validation/4.1.5/micronaut-http-validation-4.1.5.jar,verify passed : build/repo/micronaut-http-validation/4.1.5/micronaut-http-validation-4.1.5.pom,verify passed : build/repo/micronaut-http/4.1.5/micronaut-http-4.1.5.jar,verify passed : build/repo/micronaut-http/4.1.5/micronaut-http-4.1.5.pom,verify passed : build/repo/micronaut-inject-groovy-test/4.1.5/micronaut-inject-groovy-test-4.1.5.jar,verify passed : build/repo/micronaut-inject-groovy-test/4.1.5/micronaut-inject-groovy-test-4.1.5.pom,verify passed : build/repo/micronaut-inject-groovy/4.1.5/micronaut-inject-groovy-4.1.5.jar,verify passed : build/repo/micronaut-inject-groovy/4.1.5/micronaut-inject-groovy-4.1.5.pom,verify passed : build/repo/micronaut-inject-java-test/4.1.5/micronaut-inject-java-test-4.1.5.jar,verify passed : build/repo/micronaut-inject-java-test/4.1.5/micronaut-inject-java-test-4.1.5.pom,verify passed : build/repo/micronaut-inject-java/4.1.5/micronaut-inject-java-4.1.5.jar,verify passed : build/repo/micronaut-inject-java/4.1.5/micronaut-inject-java-4.1.5.pom,verify passed : build/repo/micronaut-inject-kotlin-test/4.1.5/micronaut-inject-kotlin-test-4.1.5.jar,verify passed : build/repo/micronaut-inject-kotlin-test/4.1.5/micronaut-inject-kotlin-test-4.1.5.pom,verify passed : build/repo/micronaut-inject-kotlin/4.1.5/micronaut-inject-kotlin-4.1.5.jar,verify passed : build/repo/micronaut-inject-kotlin/4.1.5/micronaut-inject-kotlin-4.1.5.pom,verify passed : build/repo/micronaut-inject/4.1.5/micronaut-inject-4.1.5.jar,verify passed : build/repo/micronaut-inject/4.1.5/micronaut-inject-4.1.5.pom,verify passed : build/repo/micronaut-jackson-core/4.1.5/micronaut-jackson-core-4.1.5.jar,verify passed : build/repo/micronaut-jackson-core/4.1.5/micronaut-jackson-core-4.1.5.pom,verify passed : build/repo/micronaut-jackson-databind/4.1.5/micronaut-jackson-databind-4.1.5.jar,verify passed : build/repo/micronaut-jackson-databind/4.1.5/micronaut-jackson-databind-4.1.5.pom,verify passed : build/repo/micronaut-json-core/4.1.5/micronaut-json-core-4.1.5.jar,verify passed : build/repo/micronaut-json-core/4.1.5/micronaut-json-core-4.1.5.pom,verify passed : build/repo/micronaut-management/4.1.5/micronaut-management-4.1.5.jar,verify passed : build/repo/micronaut-management/4.1.5/micronaut-management-4.1.5.pom,verify passed : build/repo/micronaut-messaging/4.1.5/micronaut-messaging-4.1.5.jar,verify passed : build/repo/micronaut-messaging/4.1.5/micronaut-messaging-4.1.5.pom,verify passed : build/repo/micronaut-retry/4.1.5/micronaut-retry-4.1.5.jar,verify passed : build/repo/micronaut-retry/4.1.5/micronaut-retry-4.1.5.pom,verify passed : build/repo/micronaut-router/4.1.5/micronaut-router-4.1.5.jar,verify passed : build/repo/micronaut-router/4.1.5/micronaut-router-4.1.5.pom,verify passed : build/repo/micronaut-runtime-osx/4.1.5/micronaut-runtime-osx-4.1.5.jar,verify passed : build/repo/micronaut-runtime-osx/4.1.5/micronaut-runtime-osx-4.1.5.pom,verify passed : build/repo/micronaut-runtime/4.1.5/micronaut-runtime-4.1.5.jar,verify passed : build/repo/micronaut-runtime/4.1.5/micronaut-runtime-4.1.5.pom,verify passed : build/repo/micronaut-websocket/4.1.5/micronaut-websocket-4.1.5.jar,verify passed : build/repo/micronaut-websocket/4.1.5/micronaut-websocket-4.1.5.pom"
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
                     "check_id": "mcn_version_control_system_1",
                     "check_description": "Check whether the target repo uses a version control system.",
                     "slsa_requirements": [
@@ -119,45 +851,6 @@
                     "result_type": "PASSED"
                 },
                 {
-                    "check_id": "mcn_provenance_available_1",
-                    "check_description": "Check whether the target has intoto provenance.",
-                    "slsa_requirements": [
-                        "Provenance - Available - SLSA Level 1",
-                        "Provenance content - Identifies build instructions - SLSA Level 1",
-                        "Provenance content - Identifies artifacts - SLSA Level 1",
-                        "Provenance content - Identifies builder - SLSA Level 1"
-                    ],
-                    "justification": [
-                        "Could not find any SLSA provenances."
-                    ],
-                    "result_type": "FAILED"
-                },
-                {
-                    "check_id": "mcn_provenance_expectation_1",
-                    "check_description": "Check whether the SLSA provenance for the produced artifact conforms to the expected value.",
-                    "slsa_requirements": [
-                        "Provenance conforms with expectations - SLSA Level 3"
-                    ],
-                    "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
-                    ],
-                    "result_type": "FAILED"
-                },
-                {
-                    "check_id": "mcn_provenance_level_three_1",
-                    "check_description": "Check whether the target has SLSA provenance level 3.",
-                    "slsa_requirements": [
-                        "Provenance - Non falsifiable - SLSA Level 3",
-                        "Provenance content - Includes all build parameters - SLSA Level 3",
-                        "Provenance content - Identifies entry point - SLSA Level 3",
-                        "Provenance content - Identifies source code - SLSA Level 2"
-                    ],
-                    "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
-                    ],
-                    "result_type": "FAILED"
-                },
-                {
                     "check_id": "mcn_provenance_witness_level_one_1",
                     "check_description": "Check whether the target has a level-1 witness provenance.",
                     "slsa_requirements": [
@@ -167,7 +860,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Failed to discover any witness provenance."
                     ],
                     "result_type": "FAILED"
                 },


### PR DESCRIPTION
The `micronaut-core` [release](https://github.com/micronaut-projects/micronaut-core/releases/tag/v4.1.5) is generating provenances again and our provenance checks should pass again. This PR updates the expected result for `micronaut-core`.