### PR TITLE
test: improve expectation regex value to better match usage in urllib3

### DIFF
--- a/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/urllib3_PASS.cue
+++ b/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/urllib3_PASS.cue
@@ -3,7 +3,7 @@
     predicate: {
         invocation: {
             configSource: {
-                uri: =~"^git\\+https://github.com/urllib3/urllib3@refs/tags/[0-9]+.[0-9]+.[0-9a-z]+$"
+                uri: =~"^git\\+https://github.com/urllib3/urllib3@refs/tags/v?[0-9]+.[0-9]+.[0-9a-z]+$"
                 entryPoint: ".github/workflows/publish.yml"
             }
         }


### PR DESCRIPTION
Closes #479 
Regex value in expectation file is adjusted slightly so as to account for the urllib3 version branch name / tag sometimes starting with a `v`.