### PR TITLE
test: adjust flaky test which relies on filesystem permissions

### DIFF
--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -31,6 +31,15 @@ def test_create_defaults() -> None:
     assert create_defaults(output_dir, global_config.macaron_path) is True
 
 
+@pytest.mark.xfail(
+    os.geteuid() == 0,
+    reason="Only effective for non-root users",
+)
+def test_create_defaults_without_permission() -> None:
+    """Test dumping default config in cases where the user does not have write permission to the output location."""
+    assert create_defaults(output_path="/", cwd_path="/") is False
+
+
 @pytest.mark.parametrize(
     ("section", "item", "delimiter", "strip", "duplicated_ok", "expect"),
     [

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -29,7 +29,6 @@ def test_create_defaults() -> None:
     """Test dumping the default values."""
     output_dir = os.path.dirname(os.path.abspath(__file__))
     assert create_defaults(output_dir, global_config.macaron_path) is True
-    assert create_defaults("/", "/") is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I am removing a test that fails in environments where the user running the test actually has write access to the `/` directory.
This may happen in, for example, a test environment inside a container where the user is `root`, which is quite common in CI systems (e.g. [GitLab Runner with docker executor](https://docs.gitlab.com/runner/executors/docker.html), or [Jenkins docker pipelines](https://www.jenkins.io/doc/book/pipeline/docker/)).