### PR TITLE
fix: do not use git set-branches if the target branch is not currently available in the repository

### DIFF
--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -109,7 +109,7 @@ def check_out_repo_target(git_obj: Git, branch_name: str = "", digest: str = "",
 
     if not offline_mode:
         # Fetch from remote by running ``git fetch`` inside the target repository.
-        # We don't specify any remote name (e.g. origin) is because we want git to resolve the default fetching
+        # We don't specify any remote name (e.g. origin) because we want git to resolve the default fetching
         # target by itself.
         # For example, the user runs Macaron on a local repository where the remote is set to have name "foo_origin"
         # instead.
@@ -117,7 +117,7 @@ def check_out_repo_target(git_obj: Git, branch_name: str = "", digest: str = "",
         try:
             git_obj.repo.git.fetch()
         except GitCommandError as error:
-            logger.error("Cannot perform fetching on this repository. Error: %s", error)
+            logger.error("Unable to fetch from the remote repository. Error: %s", error)
             return False
 
     try:
@@ -183,7 +183,7 @@ def get_default_branch(git_obj: Git) -> str:
     branch of the remote repository and it's usually set when the repository is first cloned with
     ``git clone <url>``.
     Therefore, this method will fail to obtain the default branch name if ``origin/HEAD`` is not
-    available. An example of this case is when a repository is shallow-cloned with a non-default the branch
+    available. An example of this case is when a repository is shallow-cloned from a non-default branch
     (e.g. ``git clone --depth=1 <url> -b some_branch``).
 
     Parameters

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -76,8 +76,6 @@ def check_out_repo_target(git_obj: Git, branch_name: str = "", digest: str = "",
     This method supports repositories which are cloned from existing remote repositories.
     Other scenarios are not covered (e.g. a newly initiated repository).
 
-    This method will not try to un-shallow an existing shallow-clone repository.
-
     If ``offline_mode`` is set, this method will not pull/fetch from remote while checking out the branch or commit.
 
     Parameters


### PR DESCRIPTION
Closes #486 

## Bug description

This bug happened because of the way branch check out is handling in this [method](https://github.com/oracle/macaron/blob/71accbf81e849947ca238ebfa3a9a6ef88fd01f6/src/macaron/slsa_analyzer/git_url.py#L65).

At the moment, the process Macaron in which Macaron tries to checkout the correct branch and commit for the analysis is as follows:
- The branch to checkout is either the value provided by the user (via `--branch` in the CLI) or the default branch of the repository ([implementation](https://github.com/oracle/macaron/blob/71accbf81e849947ca238ebfa3a9a6ef88fd01f6/src/macaron/slsa_analyzer/git_url.py#L251)):
  - We are using `git rev-parse --abbrev-ref origin/HEAD` to obtain the value `origin/<default_branch_name>` ([references](https://stackoverflow.com/questions/28666357/git-how-to-get-default-branch)).

- Macaron try to check out that branch (implementation [here](https://github.com/oracle/macaron/blob/71accbf81e849947ca238ebfa3a9a6ef88fd01f6/src/macaron/slsa_analyzer/git_url.py#L109-L141))..
  - The way we check if a given branch exists in the repository:
    - `res_branch in [os.path.basename(ref.name) for ref in org_remote.refs]`
    - The `refs` in `org_remote` instance would return `git.RemoteReference` instances (according to gitpython [documentation](https://gitpython.readthedocs.io/en/stable/reference.html?highlight=Reference#git.remote.Remote.refs)).
    - The documentation for git remote references can be seen [here](https://git-scm.com/book/en/v2/Git-Internals-Git-References).
    - Therefore, each `git.RemoteReference` can be considered a reference to the latest commit of a remote branch (**from the last time we communicate with remote**). Therefore, `org_remote.refs` will return an iterator of remote references that this local repository currently have (which mean that it could be missing any new remote branches, etc.).
    - I have manually check in a shallow clone, a call to `org_remote.refs` does not return all available remote branches. It only contains: 1. `refs/remotes/origin/<branch_name>` which point to the branch which we shallow clone (if no branch is provided e.g. `git clone --depth=1 <url>`), this will be `refs/remotes/origin/<default_branch>`. 2. if it's a shallow clone of the default branch, there will be also a `refs/remotes/origin/HEAD`.

- If Macaron cannot find the target branch from `org_remote.refs`, Macaron will try to setup a local branch that track that branch from origin remote (implementation [here](https://github.com/oracle/macaron/blob/71accbf81e849947ca238ebfa3a9a6ef88fd01f6/src/macaron/slsa_analyzer/git_url.py#L133-L138)). 
  - The full command is: `git remote set-branches --add origin '<target_branch>'` ([references](https://stackoverflow.com/questions/23708231/git-shallow-clone-clone-depth-misses-remote-branches.)) What this command do is that it setup the branch list to track a branch `<target_branch>` from the remote. The `--add` will make sure that we only add the new tracked branch into the list of tracked branches. The next time we fetch, git will also try to fetch this branch from the remote repository. The reason I did it this way is to make sure that *we only need to fetch the branch that we are interested in when working with shallow clones*.

  - This is the command that causes the bug in https://github.com/oracle/macaron/issues/486:
    - This command this will update the `.git/config` file in the target repository with `<target_branch>`. Therefore, if the branch doesn't exist, subsequent fetching/pulling will always fail because git will try to ask the remote for this non-exist branch and return error everytime.
    - The second issue: there is a fetching operation happened [here](https://github.com/oracle/macaron/blob/71accbf81e849947ca238ebfa3a9a6ef88fd01f6/src/macaron/slsa_analyzer/git_url.py#L137) without checking if `offline_mode` is set or not.
    - The third issue is that we don't have a good way to revert the effect of set-branches (https://stackoverflow.com/questions/47726087/undo-set-branches-on-git-remote). Overall, it's not a good idea to perform git operations that alter `.git/config`.

## Solution.
To resolve this bug, I simplify the logic for checkout branch and commit for a target repository with the following goals:
- Remove any conditional logic for handling shallow-clone repositories:
  - The usage of `git remote set-branches --add origin '<target_branch>'`
  - Unshallow when trying to pull from latest (note [here](https://github.com/oracle/macaron/pull/491/files#r1340879300)).
- Make sure that the only online operations included in the `check_out_repo_target` method are:
  - `git fetch`: happen before checkout branch.
  - `git pull --ff-only` before checkout a specific commit.

If the checkout operation fails for either branch or commit, we return errors.