### PR TITLE
chore: add changesets/action for npm release

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -340,6 +340,8 @@ deploy_arg =
 [builder.npm.ci.deploy]
 github_actions =
     JS-DevTools/npm-publish
+    # TODO: check the `publish` input to changesets/action to improve accuracy.
+    changesets/action
 
 # This is the spec for trusted Yarn build tool usages.
 # The entries need to cover both Yarn classic and Yarn modern; namely .yarnrc vs .yarnrc.yml

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -341,6 +341,7 @@ deploy_arg =
 github_actions =
     JS-DevTools/npm-publish
     # TODO: check the `publish` input to changesets/action to improve accuracy.
+    # See https://github.com/changesets/action#inputs
     changesets/action
 
 # This is the spec for trusted Yarn build tool usages.

--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -11,7 +11,6 @@ from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql.sqltypes import String
 
-from macaron.config.defaults import defaults
 from macaron.database.table_definitions import CheckFacts
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool
@@ -156,7 +155,7 @@ class BuildAsCodeCheck(BaseCheck):
                 if isinstance(ci_service, NoneCIService):
                     continue
 
-                trusted_deploy_actions = defaults.get_list("builder.pip.ci.deploy", "github_actions", fallback=[])
+                trusted_deploy_actions = build_tool.ci_deploy_kws["github_actions"] or []
 
                 # Check for use of a trusted Github Actions workflow to publish/deploy.
                 # TODO: verify that deployment is legitimate and not a test

--- a/src/macaron/slsa_analyzer/checks/build_service_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_service_check.py
@@ -169,7 +169,7 @@ class BuildServiceCheck(BaseCheck):
 
                     justification: list[str | dict[str, str]] = [
                         {
-                            f"The target repository uses build tool {build_tool.name} to deploy": bash_source_link,
+                            f"The target repository uses build tool {build_tool.name} to build": bash_source_link,
                             "The build is triggered by": trigger_link,
                         },
                         f"Build command: {build_cmd}",

--- a/tests/e2e/expected_results/sget/sget.json
+++ b/tests/e2e/expected_results/sget/sget.json
@@ -1,6 +1,6 @@
 {
     "metadata": {
-        "timestamps": "2023-09-21 07:29:44"
+        "timestamps": "2023-10-05 10:57:32"
     },
     "target": {
         "info": {
@@ -21,7 +21,7 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/build.yaml"
+                                "id": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml"
                             },
                             "buildType": "Custom github_actions",
                             "invocation": {
@@ -30,7 +30,7 @@
                                     "digest": {
                                         "sha1": "99e7b91204d391ccc76507f7079b6d2a7957489e"
                                     },
-                                    "entryPoint": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/build.yaml"
+                                    "entryPoint": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml"
                                 },
                                 "parameters": {},
                                 "environment": {}
@@ -64,12 +64,28 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 7,
-                "PASSED": 3,
+                "FAILED": 6,
+                "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
             },
             "results": [
+                {
+                    "check_id": "mcn_build_as_code_1",
+                    "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
+                    "slsa_requirements": [
+                        "Build as code - SLSA Level 3"
+                    ],
+                    "justification": [
+                        {
+                            "The target repository uses build tool go to deploy": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml",
+                            "The build is triggered by": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml"
+                        },
+                        "Deploy action: goreleaser/goreleaser-action",
+                        "However, could not find a passing workflow run."
+                    ],
+                    "result_type": "PASSED"
+                },
                 {
                     "check_id": "mcn_build_script_1",
                     "check_description": "Check if the target repo has a valid build script.",
@@ -88,12 +104,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        {
-                            "The target repository uses build tool go to deploy": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/build.yaml",
-                            "The build is triggered by": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/build.yaml"
-                        },
-                        "Build command: ['go', 'build', './...']",
-                        "However, could not find a passing workflow run."
+                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
                     ],
                     "result_type": "PASSED"
                 },
@@ -111,24 +122,13 @@
                     "result_type": "PASSED"
                 },
                 {
-                    "check_id": "mcn_build_as_code_1",
-                    "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
-                    "slsa_requirements": [
-                        "Build as code - SLSA Level 3"
-                    ],
-                    "justification": [
-                        "The target repository does not use go to deploy."
-                    ],
-                    "result_type": "FAILED"
-                },
-                {
                     "check_id": "mcn_infer_artifact_pipeline_1",
                     "check_description": "Detects potential pipelines from which an artifact is published.",
                     "slsa_requirements": [
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Unable to find a publishing timestamp for the artifact."
                     ],
                     "result_type": "FAILED"
                 },
@@ -207,23 +207,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_provenance_expectation_1",
                 "num_deps_pass": 0
             },
             {
@@ -235,7 +219,23 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
@@ -243,7 +243,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             }
         ],


### PR DESCRIPTION
This PR adds [changesets/action](https://github.com/changesets/changesets) to the list of GitHub Actions used to publish npm packages. An example project that uses this Action to automate releases is [sigstore/sigstore-js](https://github.com/sigstore/sigstore-js). Note that there is a TODO to also check the `publish` [input](https://github.com/changesets/action#with-publishing) provided to this Action to improve detection accuracy.

This PR also fixes a bug for using the deploy `github_actions` for build tools. Previously, only the `github_actions` of `pip` build tool was read from `defaults.ini` and used in `build_as_code_check.py`. This fix removes this hard-coded read from `defaults.ini` and makes it applicable to all build tools.