### PR TITLE
chore: do not pass *args to SQLALchemy DeclarativeBase class

### DIFF
--- a/src/macaron/database/table_definitions.py
+++ b/src/macaron/database/table_definitions.py
@@ -287,7 +287,7 @@ class Repository(ORMBase):
     #: The path to the repo on the file system.
     fs_path: Mapped[str] = mapped_column(String, nullable=False)
 
-    def __init__(self, *args: Any, files: list[str] | None = None, **kwargs: Any):
+    def __init__(self, files: list[str] | None = None, **kwargs: Any):
         """Instantiate the repository and set files.
 
         Parameters
@@ -295,7 +295,7 @@ class Repository(ORMBase):
         files: list[str] | None
             The files extracted for this repository.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         # We populate the PURL type, namespace, and name columns using the complete_name.
         # Because locally cloned repositories may miss the namespace, we need to check the length.


### PR DESCRIPTION
The `__init__` function in SQAlchemy's `DeclarativeBase` class [does not take](https://github.com/sqlalchemy/sqlalchemy/blob/a342b3d503f968bbf43f3b2de1f4f623b03a6310/lib/sqlalchemy/orm/decl_api.py#L839) positional arguments. The `Repository` ORM mapping however passes `*args` to `DeclarativeBase`, which is not correct. So far we haven't run into any issues because we always pass keyword arguments while initializing `Repository` instances. 

This PR fixes this issue by not passing ` *args` to the parent `DeclarativeBase` class.