### PR TITLE
fix: resolve podman compatibility issues

### DIFF
--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -157,7 +157,7 @@ function create_dir_if_not_exists() {
     fi
 }
 
-# Add a directory to the list of volume mounts.
+# Add a directory to the list of volume mounts stored in the ``mounts`` global variable.
 #
 # Arguments:
 #   $1: The macaron argument from which the directory is passed into this script.
@@ -165,8 +165,6 @@ function create_dir_if_not_exists() {
 #   $3: The path to the directory inside the container.
 #   $4: Mount option. Note: this MUST be either `ro,Z` for readonly volume mounts,
 #       or `rw,Z` otherwise.
-# Globals:
-#   mounts: the volume mount is added to this array
 function mount_dir() {
     arg_name=$1
     dir_on_host=$2
@@ -188,7 +186,7 @@ function mount_dir() {
     mounts+=("-v" "${dir_on_host}:${dir_in_container}:${mount_option}")
 }
 
-# Add a file to the list of volume mounts.
+# Add a file to the list of volume mounts stored in the ``mounts`` global variable.
 #
 # Arguments:
 #   $1: The macaron argument from which the file is passed into this script.
@@ -196,8 +194,6 @@ function mount_dir() {
 #   $3: The path to the file inside the container.
 #   $4: Mount option. Note: this MUST be either `ro,Z` for readonly volumes,
 #       or `rw,Z` otherwise.
-# Globals:
-#   mounts: the volume mount is added to this array
 function mount_file() {
     arg_name=$1
     file_on_host=$2

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -419,8 +419,15 @@ if [[ -n ${MCN_DEBUG_ARGS:-} ]]; then
     exit 0
 fi
 
-docker run \
-    --pull ${DOCKER_PULL} \
+# By default
+# - docker maps the host user $UID to a user with the same $UID in the container.
+# - podman maps the host user $UID to the root user in the container.
+# To make podman behave similarly to docker, we need to set the following env var.
+# Reference: https://docs.podman.io/en/v4.4/markdown/options/userns.container.html.
+export PODMAN_USERNS=keep-id
+
+${DOCKER_EXEC} run \
+    --pull "${DOCKER_PULL}" \
     --network=host \
     --rm -i "${tty[@]}" \
     -e "USER_UID=${USER_UID}" \


### PR DESCRIPTION
This PR adds support for Podman as an alternative container engine to run the Macaron image.

The current `run_macaron.sh` script is not fully compatible with Podman, due to known cases where Docker and Podman behave differently. Changes in this PR address these cases.

## Volume-mounting non-existing directories on host

Podman completely bans volume-mounting non-existing directories on the host into the container. See https://github.com/containers/podman/issues/6234 for more details.

Meanwhile, mounting a non-existing directory on the host into a container is allowed in Docker. There is a peculiar behavior: the non-existing directory is owned by `root` both inside and outside the container.

**Solution**: Before volume-mounting a directory, we can either (1) create that directory if it does not exist, or (2) error. The choice should be consistent with how the Macaron Python package behaves. 

## UID mapping and Volume mount owner

By default
* `docker run` maps the host user `$UID` to a user with the same `$UID` in the container.
* `podman run` maps the host user `$UID` to the `root` user in the container.

**Solution**: To make sure Podman behaves exactly like docker w.r.t. volume mount owner, we can set the environment variable `PODMAN_USERNS` to `keep-id`. For more details, see https://docs.podman.io/en/v4.4/markdown/options/userns.container.html#userns-mode.

Example (Note that in the following example, you must create the `$PWD/d` directory on host beforehand):

```bash
$ id -u
1000

# Case 1: docker run with volume mount
$ docker run --rm -it -v $PWD/d:/tmp/d localhost/myimage:latest bash -c "ls -ln /tmp"
total 4 drwxrwxr-x 2 1000 1000 4096 Sep 17 16:24 d

# Case 2: podman run with volume mount and `--userns` not set
$ podman run --rm -it -v $PWD/d:/tmp/d localhost/myimage:latest bash -c "ls -ln /tmp"
total 4 drwxrwxr-x 2 0 0 4096 Sep 17 16:24 d

# Case 3: podman run with volume mount and`--userns=keep-id`
$ podman run --rm -it --userns=keep-id -v $PWD/d:/tmp/d localhost/myimage:latest bash -c "ls -ln /tmp"
total 4 drwxrwxr-x 2 1000 1000 4096 Sep 17 16:24 d
```

## Mount option `:Z`

At the moment, when the Macaron container starts up, the UID of the user `macaron` in the container gets changed to match the UID of the user on the host. This is done with the `usermod` command. Consequently, the owner UID of the `/home/macaron` directory in the container gets changed.

There has not been any issue with Docker so far. However, Podman errors in cases where we mount any volume under `/home/macaron` in the container without the `:Z` option.

Here is how to reproduce.

* We have the following `Dockerfile`.

```Dockerfile
FROM <base image>

RUN : \
    && groupadd --gid 43147 macaron \
    && useradd --uid 43147 --create-home --gid 43147 macaron

USER root
```

* Build this image and give it the name `localhost/foobar`:

```bash
$ podman build . -t localhost/foobar
```

* Create a subdirectory `d` in the current working directory and mount it into the container.

```bash
$ podman run --rm -ti -v $PWD/d:/home/macaron/d localhost/foobar bash
```

* Run the following commands in the container:

```
[root@26dab0c2dee7 /]# groupmod --non-unique --gid 1000 macaron
[root@26dab0c2dee7 /]# usermod --non-unique --uid 1000 --gid 1000 macaron
usermod: Failed to change ownership of the home directory[root@26dab0c2dee7 /]#
```

* Now try `docker run` again, this time with the `:Z` mount option. The `usermod` error should be gone.

**Solution**: For all volume mounts under `/home/macaron`, we need to provide the `:Z` mount option to tell Podman that the volume is not shared with any other container, and thus modifying the owner of `/home/macaron` is safe.