### PR TITLE
refactor: refactor interface of base check

### DIFF
--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -180,7 +180,7 @@ class AnalyzeContext:
         # Remove result_tables since we don't have a good json representation for them.
         sorted_on_id = []
         for res in _sorted_on_id:
-            # res is CheckResult(TypedDict)
+            # res is CheckResult
             res_dict: dict = dict(res.get_dict())
             res_dict.pop("result_tables")
             sorted_on_id.append(res_dict)

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -181,7 +181,7 @@ class AnalyzeContext:
         sorted_on_id = []
         for res in _sorted_on_id:
             # res is CheckResult
-            res_dict: dict = dict(res.get_dict())
+            res_dict: dict = dict(res.get_summary())
             res_dict.pop("result_tables")
             sorted_on_id.append(res_dict)
         sorted_results = sorted(sorted_on_id, key=lambda item: item["result_type"], reverse=True)

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -16,7 +16,7 @@ from macaron.slsa_analyzer.git_service import BaseGitService
 from macaron.slsa_analyzer.git_service.base_git_service import NoneGitService
 from macaron.slsa_analyzer.levels import SLSALevels
 from macaron.slsa_analyzer.provenance.expectations.expectation import Expectation
-from macaron.slsa_analyzer.slsa_req import ReqName, SLSAReq, get_requirements_dict
+from macaron.slsa_analyzer.slsa_req import ReqName, SLSAReqStatus, create_requirement_status_dict
 from macaron.slsa_analyzer.specs.build_spec import BuildSpec
 from macaron.slsa_analyzer.specs.ci_spec import CIInfo
 from macaron.slsa_analyzer.specs.package_registry_spec import PackageRegistryInfo
@@ -64,7 +64,7 @@ class AnalyzeContext:
             The output dir.
         """
         self.component = component
-        self.ctx_data: dict[ReqName, SLSAReq] = get_requirements_dict()
+        self.ctx_data: dict[ReqName, SLSAReqStatus] = create_requirement_status_dict()
 
         self.slsa_level = SLSALevels.LEVEL0
         # Indicate whether this repo fully reach a level or
@@ -176,14 +176,14 @@ class AnalyzeContext:
 
     def get_dict(self) -> dict:
         """Return the dictionary representation of the AnalyzeContext instance."""
-        _sorted_on_id = sorted(self.check_results.values(), key=lambda item: item["check_id"])
+        _sorted_on_id = sorted(self.check_results.values(), key=lambda item: item.check.check_id)
         # Remove result_tables since we don't have a good json representation for them.
         sorted_on_id = []
         for res in _sorted_on_id:
             # res is CheckResult(TypedDict)
-            res_copy: dict = dict(res.copy())
-            res_copy.pop("result_tables")
-            sorted_on_id.append(res_copy)
+            res_dict: dict = dict(res.get_dict())
+            res_dict.pop("result_tables")
+            sorted_on_id.append(res_dict)
         sorted_results = sorted(sorted_on_id, key=lambda item: item["result_type"], reverse=True)
         check_summary = {
             result_type.value: len(result_list) for result_type, result_list in self.get_check_summary().items()
@@ -219,7 +219,7 @@ class AnalyzeContext:
         result: dict[CheckResultType, list[CheckResult]] = {result_type: [] for result_type in CheckResultType}
 
         for check_result in self.check_results.values():
-            match check_result["result_type"]:
+            match check_result.result.result_type:
                 case CheckResultType.PASSED:
                     result[CheckResultType.PASSED].append(check_result)
                 case CheckResultType.SKIPPED:
@@ -243,8 +243,8 @@ class AnalyzeContext:
             output = "".join(
                 [
                     output,
-                    f"Check {check_result['check_id']}: {check_result['check_description']}\n",
-                    f"\t{check_result['result_type'].value}\n",
+                    f"Check {check_result.check.check_id}: {check_result.check.check_description}\n",
+                    f"\t{check_result.result.result_type.value}\n",
                 ]
             )
 

--- a/src/macaron/slsa_analyzer/checks/base_check.py
+++ b/src/macaron/slsa_analyzer/checks/base_check.py
@@ -48,16 +48,34 @@ class BaseCheck:
         result_on_skip : CheckResultType
             The status for this check when it's skipped based on another check's result.
         """
-        self.check_info = CheckInfo(
+        self._check_info = CheckInfo(
             check_id=check_id, check_description=description, eval_reqs=eval_reqs if eval_reqs else []
         )
 
         if not depends_on:
-            self.depends_on = []
+            self._depends_on = []
         else:
-            self.depends_on = depends_on
+            self._depends_on = depends_on
 
-        self.result_on_skip = result_on_skip
+        self._result_on_skip = result_on_skip
+
+    @property
+    def check_info(self) -> CheckInfo:
+        """Get the information identifying/describing this check."""
+        return self._check_info
+
+    @property
+    def depends_on(self) -> list[tuple[str, CheckResultType]]:
+        """Get the list of parent checks that this check depends on.
+
+        Each member of the list is a tuple of the parent's id and the status of that parent check.
+        """
+        return self._depends_on
+
+    @property
+    def result_on_skip(self) -> CheckResultType:
+        """Get the status for this check when it's skipped based on another check's result."""
+        return self._result_on_skip
 
     def run(self, target: AnalyzeContext, skipped_info: SkippedInfo | None = None) -> CheckResult:
         """Run the check and return the results.

--- a/src/macaron/slsa_analyzer/checks/check_result.py
+++ b/src/macaron/slsa_analyzer/checks/check_result.py
@@ -33,8 +33,13 @@ class CheckResultType(str, Enum):
 class CheckInfo:
     """This class identifies and describes a check."""
 
+    #: The id of the check.
     check_id: str
+
+    #: The description of the check.
     check_description: str
+
+    #: The list of SLSA requirements that this check addresses.
     eval_reqs: list[ReqName]
 
 
@@ -42,14 +47,16 @@ class CheckInfo:
 class CheckResultData:
     """This class stores the result of a check."""
 
-    # If an element in the justification is a string,
-    # it will be displayed as a string, if it is a mapping,
-    # the value will be rendered as a hyperlink in the html report.
+    #: List of justifications describing the reasons for the check result.
+    #: If an element in the justification is a string,
+    #: it will be displayed as a string, if it is a mapping,
+    #: the value will be rendered as a hyperlink in the html report.
     justification: Justification
-    # human_readable_justification: str
-    # result_values: dict[str, str | float | int] | list[dict[str, str | float | int]]
+
+    #: List of result tables produced by the check.
     result_tables: ResultTables
-    # recommendation: str
+
+    #: Result type of the check (e.g. PASSED).
     result_type: CheckResultType
 
 
@@ -57,7 +64,10 @@ class CheckResultData:
 class CheckResult:
     """This class stores the result of a check, including the description of the check that produced it."""
 
+    #: Info about the check that produced these results.
     check: CheckInfo
+
+    #: The results produced by the check.
     result: CheckResultData
 
     def get_dict(self) -> dict:

--- a/src/macaron/slsa_analyzer/checks/check_result.py
+++ b/src/macaron/slsa_analyzer/checks/check_result.py
@@ -70,8 +70,11 @@ class CheckResult:
     #: The results produced by the check.
     result: CheckResultData
 
-    def get_dict(self) -> dict:
-        """Get a flattened dictionary representation for this CheckResult.
+    def get_summary(self) -> dict:
+        """Get a flattened dictionary representation for this CheckResult, in a format suitable for the output report.
+
+        The SLSA requirements, in particular, are translated into a list of their textual descriptions, to be suitable
+        for display to users in the output report (as opposed to the internal representation as a list of enum identifiers).
 
         Returns
         -------

--- a/src/macaron/slsa_analyzer/checks/check_result.py
+++ b/src/macaron/slsa_analyzer/checks/check_result.py
@@ -29,7 +29,7 @@ class CheckResultType(str, Enum):
     UNKNOWN = "UNKNOWN"
 
 
-@dataclass
+@dataclass(frozen=True)
 class CheckInfo:
     """This class identifies and describes a check."""
 
@@ -43,7 +43,7 @@ class CheckInfo:
     eval_reqs: list[ReqName]
 
 
-@dataclass
+@dataclass(frozen=True)
 class CheckResultData:
     """This class stores the result of a check."""
 
@@ -60,7 +60,7 @@ class CheckResultData:
     result_type: CheckResultType
 
 
-@dataclass
+@dataclass(frozen=True)
 class CheckResult:
     """This class stores the result of a check, including the description of the check that produced it."""
 

--- a/src/macaron/slsa_analyzer/checks/vcs_check.py
+++ b/src/macaron/slsa_analyzer/checks/vcs_check.py
@@ -6,7 +6,7 @@
 
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 from macaron.slsa_analyzer.checks.base_check import BaseCheck, CheckResultType
-from macaron.slsa_analyzer.checks.check_result import CheckResult
+from macaron.slsa_analyzer.checks.check_result import CheckResultData
 from macaron.slsa_analyzer.registry import registry
 from macaron.slsa_analyzer.slsa_req import ReqName
 
@@ -22,29 +22,27 @@ class VCSCheck(BaseCheck):
         eval_reqs = [ReqName.VCS]
         super().__init__(check_id=check_id, description=description, depends_on=depends_on, eval_reqs=eval_reqs)
 
-    def run_check(self, ctx: AnalyzeContext, check_result: CheckResult) -> CheckResultType:
+    def run_check(self, ctx: AnalyzeContext) -> CheckResultData:
         """Implement the check in this method.
 
         Parameters
         ----------
         ctx : AnalyzeContext
             The object containing processed data for the target repo.
-        check_result : CheckResult
-            The object containing result data of a check.
 
         Returns
         -------
-        CheckResultType
-            The result type of the check (e.g. PASSED).
+        CheckResultData
+            The result of the check.
         """
         # TODO: refactor and use the git_service and its API client to create
         # the hyperlink tag to allow validation.
         if not ctx.component.repository:
-            check_result["justification"].append({"This is not a Git repository": ctx.component.purl})
-            return CheckResultType.FAILED
+            failed_msg = {"This is not a Git repository": ctx.component.purl}
+            return CheckResultData(justification=[failed_msg], result_tables=[], result_type=CheckResultType.FAILED)
 
-        check_result["justification"].append({"This is a Git repository": ctx.component.repository.remote_path})
-        return CheckResultType.PASSED
+        passed_msg = {"This is a Git repository": ctx.component.repository.remote_path}
+        return CheckResultData(justification=[passed_msg], result_tables=[], result_type=CheckResultType.PASSED)
 
 
 registry.register(VCSCheck())

--- a/src/macaron/slsa_analyzer/database_store.py
+++ b/src/macaron/slsa_analyzer/database_store.py
@@ -33,16 +33,15 @@ def store_analyze_context_to_db(analyze_ctx: AnalyzeContext) -> None:
     # Store check result table.
     for check_result in analyze_ctx.check_results.values():
         check_result_row = MappedCheckResult(
-            check_id=check_result["check_id"],
+            check_id=check_result.check.check_id,
             component=analyze_ctx.component,
-            passed=check_result["result_type"] == CheckResultType.PASSED,
+            passed=check_result.result.result_type == CheckResultType.PASSED,
         )
 
-        if "result_tables" in check_result:
-            for check_facts in check_result["result_tables"]:
-                if isinstance(check_facts, CheckFacts):
-                    check_facts.checkresult = check_result_row
-                    check_facts.component = check_result_row.component
+        for check_facts in check_result.result.result_tables:
+            if isinstance(check_facts, CheckFacts):
+                check_facts.checkresult = check_result_row
+                check_facts.component = check_result_row.component
 
     # Store SLSA Requirements.
     for key, value in analyze_ctx.ctx_data.items():
@@ -50,6 +49,6 @@ def store_analyze_context_to_db(analyze_ctx: AnalyzeContext) -> None:
             SLSARequirement(
                 component=analyze_ctx.component,
                 requirement_name=key.name,
-                requirement_short_description=value.name,
+                requirement_short_description=key.value,
                 feedback=value.feedback,
             )

--- a/src/macaron/slsa_analyzer/runner.py
+++ b/src/macaron/slsa_analyzer/runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the class Runner for executing checks."""
@@ -54,17 +54,17 @@ class Runner:
         """
         # TODO: Handle exceptions and time out to
         # prevent the runner to keep running indefinitely.
-        logger.debug("Runner %s running check %s", self.runner_id, check.check_id)
+        logger.debug("Runner %s running check %s", self.runner_id, check.check_info.check_id)
 
         skip_info = None
         if skipped_checks:
-            if check.check_id in [skip["check_id"] for skip in skipped_checks]:
+            if check.check_info.check_id in [skip["check_id"] for skip in skipped_checks]:
                 # Get the skip info from the list.
-                skip_info = [skip for skip in skipped_checks if skip["check_id"] == check.check_id][0]
+                skip_info = [skip for skip in skipped_checks if skip["check_id"] == check.check_info.check_id][0]
 
         check_result = check.run(target, skip_info)
 
-        logger.debug("Runner %s finished check %s.", self.runner_id, check.check_id)
+        logger.debug("Runner %s finished check %s.", self.runner_id, check.check_info.check_id)
         self.registry.runner_queue.put(self)
 
         return check_result

--- a/src/macaron/slsa_analyzer/slsa_req.py
+++ b/src/macaron/slsa_analyzer/slsa_req.py
@@ -70,250 +70,6 @@ class Category(Enum):
     """Related to common requirements for every trusted system involved in the supply chain."""
 
 
-# Contains the description, category and level each requirement correspond to.
-BUILD_REQ_DESC: dict[ReqName, tuple[str, Category, SLSALevels]] = {
-    ReqName.VCS: (
-        """
-        Every change to the source is tracked in a version control
-        """,
-        Category.SOURCE,
-        SLSALevels.LEVEL2,
-    ),
-    ReqName.VERIFIED_HISTORY: (
-        """
-        Every change in the revision's history has at least one strongly authenticated actor identity
-        (author, uploader, reviewer, etc.) and timestamp.
-        """,
-        Category.SOURCE,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.RETAINED_INDEFINITELY: (
-        """
-        The revision and its change history are preserved indefinitely and cannot be deleted,
-        except when subject to an established and transparent expectation for obliteration,
-        such as a legal or expectation requirement.
-        """,
-        Category.SOURCE,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.TWO_PERSON_REVIEWED: (
-        """
-        Every change in the revision's history was agreed to by two trusted persons prior to submission,
-        and both of these trusted persons were strongly authenticated.
-        """,
-        Category.SOURCE,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.SCRIPTED_BUILD: (
-        """
-        All build steps were fully defined in some sort of "build script".
-        The only manual command, if any, was to invoke the build script.
-        Examples:
-        - Build script is Makefile, invoked via make all.
-        - Build script is .github/workflows/build.yaml, invoked by GitHub Actions.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL1,
-    ),
-    ReqName.BUILD_SERVICE: (
-        """
-        All build steps ran using some build service, not on a developer's workstation.
-        Examples: GitHub Actions, Google Cloud Build, Travis CI.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL2,
-    ),
-    ReqName.BUILD_AS_CODE: (
-        """
-        The build definition and configuration is defined in source control and is executed by the build service.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.EPHEMERAL_ENVIRONMENT: (
-        """
-        The build service ensured that the build steps ran in an ephemeral environment, such as a container or VM,
-        provisioned solely for this build, and not reused from a prior build.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.ISOLATED: (
-        """
-        The build service ensured that the build steps ran in an isolated environment free of influence
-        from other build instances, whether prior or concurrent.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.PARAMETERLESS: (
-        """
-        The build output cannot be affected by user parameters other than the build entry point
-        and the top-level source location. In other words, the build is fully defined through the build script
-        and nothing else.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.HERMETIC: (
-        """
-        All transitive build steps, sources, and dependencies were fully declared up front with immutable references,
-        and the build steps ran with no network access.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.REPRODUCIBLE: (
-        """
-        Re-running the build steps with identical input artifacts results in bit-for-bit identical output.
-        Builds that cannot meet this MUST provide a justification why the build cannot be made reproducible.
-        """,
-        Category.BUILD,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.PROV_AVAILABLE: (
-        """
-        The provenance is available to the consumer in a format that the consumer accepts.
-        The format SHOULD be in-toto SLSA Provenance, but another format MAY be used if both
-        producer and consumer agree and it meets all the other requirements.
-        """,
-        Category.PROVENANCE,
-        SLSALevels.LEVEL1,
-    ),
-    ReqName.PROV_AUTH: (
-        """
-        The provenance's authenticity and integrity can be verified by the consumer. This SHOULD be through
-        a digital signature from a private key accessible only to the service generating the provenance.
-        """,
-        Category.PROVENANCE,
-        SLSALevels.LEVEL2,
-    ),
-    ReqName.PROV_SERVICE_GEN: (
-        """
-        The data in the provenance MUST be obtained from the build service (either because
-        the generator is the build service or because the provenance generator reads
-        the data directly from the build service).
-        Regular users of the service MUST NOT be able to inject or alter the contents.
-        """,
-        Category.PROVENANCE,
-        SLSALevels.LEVEL2,
-    ),
-    ReqName.PROV_NON_FALSIFIABLE: (
-        """
-        Provenance cannot be falsified by the build service's users.
-        """,
-        Category.PROVENANCE,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.PROV_DEPENDENCIES_COMPLETE: (
-        """
-        Provenance records all build dependencies that were available while running the build steps.
-        """,
-        Category.PROVENANCE,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.PROV_CONT_ARTI: (
-        """
-        The provenance MUST identify the output artifact via at least one cryptographic hash.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL1,
-    ),
-    ReqName.PROV_CONT_BUILDER: (
-        """
-        The provenance identifies the entity that performed the build and generated the provenance.
-        This represents the entity that the consumer must trust.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL1,
-    ),
-    ReqName.PROV_CONT_BUILD_INS: (
-        """
-        The provenance identifies the top-level instructions used to execute the build.
-        The identified instructions SHOULD be at the highest level available to the build.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL1,
-    ),
-    ReqName.PROV_CONT_SOURCE: (
-        """
-        The provenance identifies the repository origin(s) for the source code used in the build.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL2,
-    ),
-    ReqName.PROV_CONT_ENTRY: (
-        """
-        The provenance identifies the “entry point” of the build definition (see build-as-code)
-        used to drive the build including what source repo the configuration was read from.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.PROV_CONT_BUILD_PARAMS: (
-        """
-        The provenance includes all build parameters under a user's control.
-        See Parameterless for details. (At L3, the parameters must be listed; at L4, they must be empty.)
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL3,
-    ),
-    ReqName.PROV_CONT_TRANSITIVE_DEPS: (
-        """
-        The provenance includes all transitive dependencies listed in Provenance: Dependencies Complete requirement.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.PROV_CONT_REPRODUCIBLE_INFO: (
-        """
-        The provenance includes a boolean indicating whether build is intended to be reproducible and, if so,
-        all information necessary to reproduce the build. See Reproducible for more details.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.PROV_CONT_META_DATA: (
-        """
-        The provenance includes metadata to aid debugging and investigations.
-        This SHOULD at least include start and end timestamps and a permalink to debug logs.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL1,
-    ),
-    ReqName.SECURITY: (
-        """
-        The system meets some baseline security standard to prevent compromise.
-        (Patching, vulnerability scanning, user isolation, transport security, secure boot, machine identity, etc.)
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.ACCESS: (
-        """
-        All physical and remote access must be rare, logged, and gated behind multi-party approval.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.SUPERUSERS: (
-        """
-        Only a small number of platform admins may override the guarantees listed here.
-        Doing so MUST require approval of a second platform admin.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL4,
-    ),
-    ReqName.EXPECTATION: (
-        """
-        Check whether the SLSA provenance for the produced artifact conforms to the expectation.
-        """,
-        Category.PROVENANCE_CONTENT,
-        SLSALevels.LEVEL3,
-    ),
-}
-
-
 class SLSAReq:
     """This class represents a SLSA requirement (e.g Version Controlled)."""
 
@@ -334,12 +90,23 @@ class SLSAReq:
         self.name = name
         self.desc = desc
         self.category = category
+        self.min_level_required = req_level
+
+    def __str__(self) -> str:  # pragma: no cover
+        """Return the status of a requirement in printable format."""
+        return f"{self.name} - {self.min_level_required.value}"
+
+
+class SLSAReqStatus:
+    """This class represents the status of a SLSA requirement."""
+
+    def __init__(self) -> None:
+        """Initialize instance."""
         self.is_addressed = False
         self.is_pass = False
         self.feedback = ""
-        self.min_level_required = req_level
 
-    def get_status(self) -> tuple:
+    def get_tuple(self) -> tuple:
         """Return the current feedback of a requirement.
 
         Returns
@@ -351,11 +118,6 @@ class SLSAReq:
         feedback : bool
             The feedback from the analyzer for this requirement.
         """
-        if self.is_addressed:
-            logger.debug("Return the status for requirement %s", self.name)
-        else:
-            logger.debug("Trying to return a feedback of unaddressed requirement %s", self.name)
-
         return self.is_addressed, self.is_pass, self.feedback
 
     def set_status(self, status: bool, fb_content: str) -> None:
@@ -372,34 +134,285 @@ class SLSAReq:
         self.feedback = fb_content
         self.is_addressed = True
 
-    def __str__(self) -> str:  # pragma: no cover
-        """Return the status of a requirement in printable format."""
-        return f"{self.name} - {self.min_level_required.value}"
 
-    def get_dict(self) -> dict:
-        """Get a dictionary representation for this SLSAReq instance.
-
-        Returns
-        -------
-        dict
+# Contains the description, category and level each requirement correspond to.
+_BUILD_REQ_LIST: list[tuple[ReqName, str, Category, SLSALevels]] = [
+    (
+        ReqName.VCS,
         """
-        return {
-            "Name": str(self.name),
-            "Description": " ".join((str(self.desc).replace("\n", "").strip()).split()),
-            "Category": str(self.category.value),
-            "Required from level": str(self.min_level_required.value),
-            "Is passing": str(self.is_pass),
-            "Justification": self.feedback,
-        }
+        Every change to the source is tracked in a version control
+        """,
+        Category.SOURCE,
+        SLSALevels.LEVEL2,
+    ),
+    (
+        ReqName.VERIFIED_HISTORY,
+        """
+        Every change in the revision's history has at least one strongly authenticated actor identity
+        (author, uploader, reviewer, etc.) and timestamp.
+        """,
+        Category.SOURCE,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.RETAINED_INDEFINITELY,
+        """
+        The revision and its change history are preserved indefinitely and cannot be deleted,
+        except when subject to an established and transparent expectation for obliteration,
+        such as a legal or expectation requirement.
+        """,
+        Category.SOURCE,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.TWO_PERSON_REVIEWED,
+        """
+        Every change in the revision's history was agreed to by two trusted persons prior to submission,
+        and both of these trusted persons were strongly authenticated.
+        """,
+        Category.SOURCE,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.SCRIPTED_BUILD,
+        """
+        All build steps were fully defined in some sort of "build script".
+        The only manual command, if any, was to invoke the build script.
+        Examples:
+        - Build script is Makefile, invoked via make all.
+        - Build script is .github/workflows/build.yaml, invoked by GitHub Actions.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL1,
+    ),
+    (
+        ReqName.BUILD_SERVICE,
+        """
+        All build steps ran using some build service, not on a developer's workstation.
+        Examples: GitHub Actions, Google Cloud Build, Travis CI.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL2,
+    ),
+    (
+        ReqName.BUILD_AS_CODE,
+        """
+        The build definition and configuration is defined in source control and is executed by the build service.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.EPHEMERAL_ENVIRONMENT,
+        """
+        The build service ensured that the build steps ran in an ephemeral environment, such as a container or VM,
+        provisioned solely for this build, and not reused from a prior build.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.ISOLATED,
+        """
+        The build service ensured that the build steps ran in an isolated environment free of influence
+        from other build instances, whether prior or concurrent.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.PARAMETERLESS,
+        """
+        The build output cannot be affected by user parameters other than the build entry point
+        and the top-level source location. In other words, the build is fully defined through the build script
+        and nothing else.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.HERMETIC,
+        """
+        All transitive build steps, sources, and dependencies were fully declared up front with immutable references,
+        and the build steps ran with no network access.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.REPRODUCIBLE,
+        """
+        Re-running the build steps with identical input artifacts results in bit-for-bit identical output.
+        Builds that cannot meet this MUST provide a justification why the build cannot be made reproducible.
+        """,
+        Category.BUILD,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.PROV_AVAILABLE,
+        """
+        The provenance is available to the consumer in a format that the consumer accepts.
+        The format SHOULD be in-toto SLSA Provenance, but another format MAY be used if both
+        producer and consumer agree and it meets all the other requirements.
+        """,
+        Category.PROVENANCE,
+        SLSALevels.LEVEL1,
+    ),
+    (
+        ReqName.PROV_AUTH,
+        """
+        The provenance's authenticity and integrity can be verified by the consumer. This SHOULD be through
+        a digital signature from a private key accessible only to the service generating the provenance.
+        """,
+        Category.PROVENANCE,
+        SLSALevels.LEVEL2,
+    ),
+    (
+        ReqName.PROV_SERVICE_GEN,
+        """
+        The data in the provenance MUST be obtained from the build service (either because
+        the generator is the build service or because the provenance generator reads
+        the data directly from the build service).
+        Regular users of the service MUST NOT be able to inject or alter the contents.
+        """,
+        Category.PROVENANCE,
+        SLSALevels.LEVEL2,
+    ),
+    (
+        ReqName.PROV_NON_FALSIFIABLE,
+        """
+        Provenance cannot be falsified by the build service's users.
+        """,
+        Category.PROVENANCE,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.PROV_DEPENDENCIES_COMPLETE,
+        """
+        Provenance records all build dependencies that were available while running the build steps.
+        """,
+        Category.PROVENANCE,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.PROV_CONT_ARTI,
+        """
+        The provenance MUST identify the output artifact via at least one cryptographic hash.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL1,
+    ),
+    (
+        ReqName.PROV_CONT_BUILDER,
+        """
+        The provenance identifies the entity that performed the build and generated the provenance.
+        This represents the entity that the consumer must trust.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL1,
+    ),
+    (
+        ReqName.PROV_CONT_BUILD_INS,
+        """
+        The provenance identifies the top-level instructions used to execute the build.
+        The identified instructions SHOULD be at the highest level available to the build.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL1,
+    ),
+    (
+        ReqName.PROV_CONT_SOURCE,
+        """
+        The provenance identifies the repository origin(s) for the source code used in the build.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL2,
+    ),
+    (
+        ReqName.PROV_CONT_ENTRY,
+        """
+        The provenance identifies the “entry point” of the build definition (see build-as-code)
+        used to drive the build including what source repo the configuration was read from.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.PROV_CONT_BUILD_PARAMS,
+        """
+        The provenance includes all build parameters under a user's control.
+        See Parameterless for details. (At L3, the parameters must be listed; at L4, they must be empty.)
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL3,
+    ),
+    (
+        ReqName.PROV_CONT_TRANSITIVE_DEPS,
+        """
+        The provenance includes all transitive dependencies listed in Provenance: Dependencies Complete requirement.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.PROV_CONT_REPRODUCIBLE_INFO,
+        """
+        The provenance includes a boolean indicating whether build is intended to be reproducible and, if so,
+        all information necessary to reproduce the build. See Reproducible for more details.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.PROV_CONT_META_DATA,
+        """
+        The provenance includes metadata to aid debugging and investigations.
+        This SHOULD at least include start and end timestamps and a permalink to debug logs.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL1,
+    ),
+    (
+        ReqName.SECURITY,
+        """
+        The system meets some baseline security standard to prevent compromise.
+        (Patching, vulnerability scanning, user isolation, transport security, secure boot, machine identity, etc.)
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.ACCESS,
+        """
+        All physical and remote access must be rare, logged, and gated behind multi-party approval.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.SUPERUSERS,
+        """
+        Only a small number of platform admins may override the guarantees listed here.
+        Doing so MUST require approval of a second platform admin.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL4,
+    ),
+    (
+        ReqName.EXPECTATION,
+        """
+        Check whether the SLSA provenance for the produced artifact conforms to the expectation.
+        """,
+        Category.PROVENANCE_CONTENT,
+        SLSALevels.LEVEL3,
+    ),
+]
+
+BUILD_REQ_DESC: dict[ReqName, SLSAReq] = {
+    req[0]: SLSAReq(req[0].value, req[1], req[2], req[3]) for req in _BUILD_REQ_LIST
+}
 
 
-def get_requirements_dict() -> dict:
-    """Get a dictionary that stores the name of each requirement and its details."""
-    result = {}
-    for req_name, req_details in BUILD_REQ_DESC.items():
-        desc = req_details[0]
-        category = req_details[1]
-        min_level = req_details[2]
-        result[req_name] = SLSAReq(req_name.value, desc, category, min_level)
-
-    return result
+def create_requirement_status_dict() -> dict[ReqName, SLSAReqStatus]:
+    """Create a dictionary containing a new, unfilled, SLSA requirement status object for each known SLSA requirement."""
+    return {key: SLSAReqStatus() for key in BUILD_REQ_DESC}

--- a/tests/slsa_analyzer/checks/base_check/test_base_check.py
+++ b/tests/slsa_analyzer/checks/base_check/test_base_check.py
@@ -25,4 +25,4 @@ class TestConfiguration(TestCase):
 
         with self.assertRaises(NotImplementedError):
             check = ChildCheck()  # type: ignore
-            check.run_check(MagicMock(), MagicMock())
+            check.run_check(MagicMock())

--- a/tests/slsa_analyzer/checks/test_build_script_check.py
+++ b/tests/slsa_analyzer/checks/test_build_script_check.py
@@ -5,7 +5,7 @@
 
 from macaron.slsa_analyzer.build_tool.maven import Maven
 from macaron.slsa_analyzer.checks.build_script_check import BuildScriptCheck
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from tests.conftest import MockAnalyzeContext
 
 from ...macaron_testcase import MacaronTestCase
@@ -17,7 +17,6 @@ class TestBuildScriptCheck(MacaronTestCase):
     def test_build_script_check(self) -> None:
         """Test the Build Script Check."""
         check = BuildScriptCheck()
-        check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
         maven = Maven()
         maven.load_defaults()
 
@@ -25,10 +24,10 @@ class TestBuildScriptCheck(MacaronTestCase):
         use_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         use_build_tool.dynamic_data["build_spec"]["tools"] = [maven]
 
-        assert check.run_check(use_build_tool, check_result) == CheckResultType.PASSED
+        assert check.run_check(use_build_tool).result_type == CheckResultType.PASSED
 
         # The target repo does not use a build tool.
         no_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         no_build_tool.dynamic_data["build_spec"]["tools"] = []
 
-        assert check.run_check(no_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_build_tool).result_type == CheckResultType.FAILED

--- a/tests/slsa_analyzer/checks/test_build_service_check.py
+++ b/tests/slsa_analyzer/checks/test_build_service_check.py
@@ -3,14 +3,16 @@
 
 """This module contains the tests for the Build Service Check."""
 
+from typing import cast
+
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
 from macaron.parsers.bashparser import BashCommands
 from macaron.slsa_analyzer.build_tool.gradle import Gradle
 from macaron.slsa_analyzer.build_tool.maven import Maven
 from macaron.slsa_analyzer.build_tool.pip import Pip
 from macaron.slsa_analyzer.build_tool.poetry import Poetry
-from macaron.slsa_analyzer.checks.build_service_check import BuildServiceCheck
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.build_service_check import BuildServiceCheck, BuildServiceFacts
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from macaron.slsa_analyzer.ci_service.circleci import CircleCI
 from macaron.slsa_analyzer.ci_service.github_actions import GitHubActions
 from macaron.slsa_analyzer.ci_service.gitlab_ci import GitLabCI
@@ -37,7 +39,6 @@ class TestBuildServiceCheck(MacaronTestCase):
     def test_build_service_check(self) -> None:
         """Test the Build Service Check."""
         check = BuildServiceCheck()
-        check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
         maven = Maven()
         maven.load_defaults()
         gradle = Gradle()
@@ -77,130 +78,130 @@ class TestBuildServiceCheck(MacaronTestCase):
         # The target repo uses Maven build tool but does not use a service.
         use_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         use_build_tool.dynamic_data["build_spec"]["tools"] = [maven]
-        assert check.run_check(use_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(use_build_tool).result_type == CheckResultType.FAILED
 
         # The target repo uses Gradle build tool but does not use a service.
         use_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         use_build_tool.dynamic_data["build_spec"]["tools"] = [gradle]
-        assert check.run_check(use_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(use_build_tool).result_type == CheckResultType.FAILED
 
         # The target repo uses Poetry build tool but does not use a service.
         use_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         use_build_tool.dynamic_data["build_spec"]["tools"] = [poetry]
-        assert check.run_check(use_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(use_build_tool).result_type == CheckResultType.FAILED
 
         # The target repo uses Pip build tool but does not use a service.
         use_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         use_build_tool.dynamic_data["build_spec"]["tools"] = [pip]
-        assert check.run_check(use_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(use_build_tool).result_type == CheckResultType.FAILED
 
         # The target repo does not use a build tool.
         no_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         no_build_tool.dynamic_data["build_spec"]["tools"] = []
-        assert check.run_check(no_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_build_tool).result_type == CheckResultType.FAILED
 
         # The target repo has multiple build tools, but does not use a service.
         use_build_tool = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         use_build_tool.dynamic_data["build_spec"]["tools"] = [maven, gradle]
-        assert check.run_check(use_build_tool, check_result) == CheckResultType.FAILED
+        assert check.run_check(use_build_tool).result_type == CheckResultType.FAILED
 
         # Use mvn build args in CI to build the artifact.
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         maven_build_ci.dynamic_data["build_spec"]["tools"] = [maven]
         bash_commands["commands"] = [["mvn", "package"]]
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.PASSED
 
         # Use the mvn in CI in the local directory to build the artifact.
         bash_commands["commands"] = [["./mvn", "package"]]
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.PASSED
 
         # Use an invalid build command that has mvn.
         bash_commands["commands"] = [["mvnblah", "package"]]
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.FAILED
 
         # Use mvn but do not use CI to build artifacts.
         no_maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         no_maven_build_ci.dynamic_data["build_spec"]["tools"] = [maven]
         bash_commands["commands"] = [["mvn", "test"]]
         no_maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(no_maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_maven_build_ci).result_type == CheckResultType.FAILED
 
         # Use an invalid goal that has build keyword.
         bash_commands["commands"] = [["mvn", "packageblah"]]
         no_maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(no_maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_maven_build_ci).result_type == CheckResultType.FAILED
 
         # Use gradle in CI to build the artifact.
         gradle_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         gradle_build_ci.dynamic_data["build_spec"]["tools"] = [gradle]
         bash_commands["commands"] = [["./gradlew", "build"]]
         gradle_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(gradle_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(gradle_build_ci).result_type == CheckResultType.PASSED
 
         # Use poetry in CI to build the artifact.
         poetry_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         poetry_build_ci.dynamic_data["build_spec"]["tools"] = [poetry]
         bash_commands["commands"] = [["poetry", "build"]]
         poetry_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(poetry_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(poetry_build_ci).result_type == CheckResultType.PASSED
 
         # Use pip in CI to build the artifact.
         pip_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         pip_build_ci.dynamic_data["build_spec"]["tools"] = [pip]
         bash_commands["commands"] = [["pip", "install"]]
         pip_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(pip_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(pip_build_ci).result_type == CheckResultType.PASSED
 
         # Use flit in CI to build the artifact.
         flit_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         flit_build_ci.dynamic_data["build_spec"]["tools"] = [pip]
         bash_commands["commands"] = [["flit", "build"]]
         flit_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(flit_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(flit_build_ci).result_type == CheckResultType.PASSED
 
         # Use pip as a module in CI to build the artifact.
         pip_interpreter_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         pip_interpreter_build_ci.dynamic_data["build_spec"]["tools"] = [pip]
         bash_commands["commands"] = [["python", "-m", "pip", "install"]]
         pip_interpreter_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(pip_interpreter_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(pip_interpreter_build_ci).result_type == CheckResultType.PASSED
 
         # Use pip as a module incorrectly in CI to build the artifact.
         no_pip_interpreter_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         no_pip_interpreter_build_ci.dynamic_data["build_spec"]["tools"] = [pip]
         bash_commands["commands"] = [["python", "pip", "install"]]
         no_pip_interpreter_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(no_pip_interpreter_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_pip_interpreter_build_ci).result_type == CheckResultType.FAILED
 
         # Use pip as a module in CI with invalid goal to build the artifact.
         no_pip_interpreter_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         no_pip_interpreter_build_ci.dynamic_data["build_spec"]["tools"] = [pip]
         bash_commands["commands"] = [["python", "-m", "pip", "installl"]]
         no_pip_interpreter_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(no_pip_interpreter_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_pip_interpreter_build_ci).result_type == CheckResultType.FAILED
 
         # Maven and Gradle are both used in CI to build the artifact
         multi_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         multi_build_ci.dynamic_data["build_spec"]["tools"] = [gradle, maven]
         bash_commands["commands"] = [["./gradlew", "build"], ["mvn", "package"]]
         multi_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(multi_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(multi_build_ci).result_type == CheckResultType.PASSED
 
         # Maven is used in CI to build the artifact, Gradle is not
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         maven_build_ci.dynamic_data["build_spec"]["tools"] = [gradle, maven]
         bash_commands["commands"] = [["mvn", "package"]]
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.PASSED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.PASSED
 
         # No build tools used
         none_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         none_build_ci.dynamic_data["build_spec"]["tools"] = []
         none_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(none_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(none_build_ci).result_type == CheckResultType.FAILED
 
         # Test Jenkins.
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
@@ -208,7 +209,7 @@ class TestBuildServiceCheck(MacaronTestCase):
         bash_commands["commands"] = []
         ci_info["service"] = jenkins
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.FAILED
 
         # Test Travis.
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
@@ -216,7 +217,7 @@ class TestBuildServiceCheck(MacaronTestCase):
         bash_commands["commands"] = []
         ci_info["service"] = travis
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.FAILED
 
         # Test Circle CI.
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
@@ -224,7 +225,7 @@ class TestBuildServiceCheck(MacaronTestCase):
         bash_commands["commands"] = []
         ci_info["service"] = circle_ci
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.FAILED
 
         # Test GitLab CI.
         maven_build_ci = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
@@ -232,7 +233,7 @@ class TestBuildServiceCheck(MacaronTestCase):
         bash_commands["commands"] = []
         ci_info["service"] = gitlab_ci
         maven_build_ci.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(maven_build_ci, check_result) == CheckResultType.FAILED
+        assert check.run_check(maven_build_ci).result_type == CheckResultType.FAILED
 
     def test_multibuild_facts_saved(self) -> None:
         """Test that facts for all build tools are saved in the results tables in multi-build tool scenarios."""
@@ -264,10 +265,9 @@ class TestBuildServiceCheck(MacaronTestCase):
         multi_deploy = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         multi_deploy.dynamic_data["build_spec"]["tools"] = [gradle, maven]
         multi_deploy.dynamic_data["ci_services"] = [ci_info]
-        check_result = CheckResult(justification=[], result_tables=[])  # type: ignore
-
-        assert check.run_check(multi_deploy, check_result) == CheckResultType.PASSED
+        check_result = check.run_check(multi_deploy)
+        assert check_result.result_type == CheckResultType.PASSED
         # Check facts exist for both gradle and maven
-        existing_facts = [f.build_tool_name for f in check_result["result_tables"]]
+        existing_facts = [cast(BuildServiceFacts, f).build_tool_name for f in check_result.result_tables]
         assert gradle.name in existing_facts
         assert maven.name in existing_facts

--- a/tests/slsa_analyzer/checks/test_infer_artifact_pipeline.py
+++ b/tests/slsa_analyzer/checks/test_infer_artifact_pipeline.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from macaron.database.table_definitions import Repository
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from macaron.slsa_analyzer.checks.infer_artifact_pipeline_check import InferArtifactPipelineCheck
 from tests.conftest import MockAnalyzeContext
 
@@ -23,9 +23,8 @@ from tests.conftest import MockAnalyzeContext
 def test_infer_artifact_pipeline(macaron_path: Path, repository: Repository, expected: str) -> None:
     """Test that the check handles repositories correctly."""
     check = InferArtifactPipelineCheck()
-    check_result = CheckResult(justification=[])  # type: ignore
 
     # Set up the context object with provenances.
     ctx = MockAnalyzeContext(macaron_path=macaron_path, output_dir="")
     ctx.component.repository = repository
-    assert check.run_check(ctx, check_result) == expected
+    assert check.run_check(ctx).result_type == expected

--- a/tests/slsa_analyzer/checks/test_provenance_available_check.py
+++ b/tests/slsa_analyzer/checks/test_provenance_available_check.py
@@ -10,7 +10,7 @@ import pytest
 
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
 from macaron.database.table_definitions import Repository
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from macaron.slsa_analyzer.checks.provenance_available_check import ProvenanceAvailableCheck
 from macaron.slsa_analyzer.ci_service.circleci import CircleCI
 from macaron.slsa_analyzer.ci_service.github_actions import GitHubActions
@@ -60,7 +60,6 @@ class MockGhAPIClient(GhAPIClient):
 def test_provenance_available_check_with_repos(macaron_path: Path, repository: Repository, expected: str) -> None:
     """Test the provenance available check on different types of repositories."""
     check = ProvenanceAvailableCheck()
-    check_result = CheckResult(justification=[])  # type: ignore
     github_actions = MockGitHubActions()
     api_client = MockGhAPIClient({"headers": {}, "query": []})
     github_actions.api_client = api_client
@@ -79,13 +78,12 @@ def test_provenance_available_check_with_repos(macaron_path: Path, repository: R
     ctx = MockAnalyzeContext(macaron_path=macaron_path, output_dir="")
     ctx.component.repository = repository
     ctx.dynamic_data["ci_services"] = [ci_info]
-    assert check.run_check(ctx, check_result) == expected
+    assert check.run_check(ctx).result_type == expected
 
 
 def test_provenance_available_check_on_ci(macaron_path: Path) -> None:
     """Test the provenance available check on different types of CI services."""
     check = ProvenanceAvailableCheck()
-    check_result = CheckResult(justification=[])  # type: ignore
     github_actions = MockGitHubActions()
     api_client = MockGhAPIClient({"headers": {}, "query": []})
     github_actions.api_client = api_client
@@ -114,22 +112,22 @@ def test_provenance_available_check_on_ci(macaron_path: Path) -> None:
 
     # Repo doesn't have a provenance.
     api_client.release = {"assets": [{"name": "attestation.intoto", "url": "URL", "size": 10}]}
-    assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+    assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
     api_client.release = {"assets": [{"name": "attestation.intoto.jsonl", "url": "URL", "size": 10}]}
 
     # Test Jenkins.
     ci_info["service"] = jenkins
-    assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+    assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
     # Test Travis.
     ci_info["service"] = travis
-    assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+    assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
     # Test Circle CI.
     ci_info["service"] = circle_ci
-    assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+    assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
     # Test GitLab CI.
     ci_info["service"] = gitlab_ci
-    assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+    assert check.run_check(ctx).result_type == CheckResultType.FAILED

--- a/tests/slsa_analyzer/checks/test_provenance_l3_check.py
+++ b/tests/slsa_analyzer/checks/test_provenance_l3_check.py
@@ -5,7 +5,7 @@
 
 
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from macaron.slsa_analyzer.checks.provenance_l3_check import ProvenanceL3Check
 from macaron.slsa_analyzer.ci_service.circleci import CircleCI
 from macaron.slsa_analyzer.ci_service.github_actions import GitHubActions
@@ -53,7 +53,6 @@ class TestProvL3Check(MacaronTestCase):
     def test_provenance_l3_check(self) -> None:
         """Test the provenance l3 check."""
         check = ProvenanceL3Check()
-        check_result = CheckResult(justification=[])  # type: ignore
         github_actions = MockGitHubActions()
         api_client = MockGhAPIClient({"headers": {}, "query": []})
         github_actions.api_client = api_client
@@ -96,7 +95,7 @@ class TestProvL3Check(MacaronTestCase):
         }
         ctx = MockAnalyzeContext(macaron_path=MacaronTestCase.macaron_path, output_dir="")
         ctx.dynamic_data["ci_services"] = [ci_info]
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # Attestation size is too large.
         ci_info["provenance_assets"] = []
@@ -116,7 +115,7 @@ class TestProvL3Check(MacaronTestCase):
                 {"name": "artifact.txt", "url": "URL", "size": 10},
             ]
         }
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # No provenance available.
         ci_info["provenance_assets"] = []
@@ -126,7 +125,7 @@ class TestProvL3Check(MacaronTestCase):
                 {"name": "artifact.txt", "url": "URL", "size": 10},
             ]
         }
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # No release available
         ci_info["provenance_assets"] = []
@@ -141,20 +140,20 @@ class TestProvL3Check(MacaronTestCase):
             ]
         )
         ci_info["latest_release"] = {}
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # Test Jenkins.
         ci_info["service"] = jenkins
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # Test Travis.
         ci_info["service"] = travis
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # Test Circle CI.
         ci_info["service"] = circle_ci
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED
 
         # Test GitLab CI.
         ci_info["service"] = gitlab_ci
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED

--- a/tests/slsa_analyzer/checks/test_registry.py
+++ b/tests/slsa_analyzer/checks/test_registry.py
@@ -13,15 +13,15 @@ from hypothesis.strategies import SearchStrategy, binary, booleans, integers, li
 
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 from macaron.slsa_analyzer.checks.base_check import BaseCheck
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType
 from macaron.slsa_analyzer.registry import Registry
 
 
 class MockCheck(BaseCheck):
     """BaseCheck with no-op impl for abstract method"""
 
-    def run_check(self, ctx: AnalyzeContext, check_result: CheckResult) -> CheckResultType:
-        return CheckResultType.UNKNOWN
+    def run_check(self, ctx: AnalyzeContext) -> CheckResultData:
+        return CheckResultData(justification=[], result_tables=[], result_type=CheckResultType.UNKNOWN)
 
 
 # pylint: disable=protected-access

--- a/tests/slsa_analyzer/checks/test_trusted_builder_l3_check.py
+++ b/tests/slsa_analyzer/checks/test_trusted_builder_l3_check.py
@@ -7,7 +7,7 @@ import os
 
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
 from macaron.parsers.actionparser import parse as parse_action
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from macaron.slsa_analyzer.checks.trusted_builder_l3_check import TrustedBuilderL3Check
 from macaron.slsa_analyzer.ci_service.github_actions import GHWorkflowType, GitHubActions, GitHubNode
 from macaron.slsa_analyzer.specs.ci_spec import CIInfo
@@ -31,7 +31,6 @@ class TestTrustedBuilderL3Check(MacaronTestCase):
     def test_trusted_builder_l3_check(self) -> None:
         """Test the Build As Code Check."""
         check = TrustedBuilderL3Check()
-        check_result = CheckResult(justification=[])  # type: ignore
         workflows_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "resources", "github", "workflow_files"
         )
@@ -62,7 +61,7 @@ class TestTrustedBuilderL3Check(MacaronTestCase):
         root.add_callee(callee)
         github_actions.build_call_graph_from_node(callee)
         ci_info["callgraph"] = gh_cg
-        assert check.run_check(ctx, check_result) == CheckResultType.PASSED
+        assert check.run_check(ctx).result_type == CheckResultType.PASSED
 
         # This GitHub Actions workflow is not using a trusted builder.
         root = GitHubNode(name="root", node_type=GHWorkflowType.NONE, source_path="", parsed_obj={}, caller_path="")
@@ -79,4 +78,4 @@ class TestTrustedBuilderL3Check(MacaronTestCase):
         root.add_callee(callee)
         github_actions.build_call_graph_from_node(callee)
         ci_info["callgraph"] = gh_cg
-        assert check.run_check(ctx, check_result) == CheckResultType.FAILED
+        assert check.run_check(ctx).result_type == CheckResultType.FAILED

--- a/tests/slsa_analyzer/checks/test_vcs_check.py
+++ b/tests/slsa_analyzer/checks/test_vcs_check.py
@@ -7,7 +7,7 @@ import os
 
 from macaron.database.table_definitions import Analysis, Component, Repository
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext, ChecksOutputs
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultType
 from macaron.slsa_analyzer.checks.vcs_check import VCSCheck
 from macaron.slsa_analyzer.git_service.base_git_service import NoneGitService
 from macaron.slsa_analyzer.slsa_req import SLSALevels
@@ -49,7 +49,6 @@ class TestVCSCheck(MacaronTestCase):
         """Test the vcs check."""
         check = VCSCheck()
         initiate_repo(REPO_DIR)
-        check_result = CheckResult(justification=[])  # type: ignore
 
         component = Component(
             purl="pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
@@ -57,7 +56,7 @@ class TestVCSCheck(MacaronTestCase):
             repository=Repository(complete_name="github.com/package-url/purl-spec"),
         )
         use_git_repo = AnalyzeContext(component=component, macaron_path=REPO_DIR, output_dir="")
-        assert check.run_check(use_git_repo, check_result) == CheckResultType.PASSED
+        assert check.run_check(use_git_repo).result_type == CheckResultType.PASSED
 
         no_git_repo = MockAnalyzeContext()
-        assert check.run_check(no_git_repo, check_result) == CheckResultType.FAILED
+        assert check.run_check(no_git_repo).result_type == CheckResultType.FAILED

--- a/tests/slsa_analyzer/runner/test_runner.py
+++ b/tests/slsa_analyzer/runner/test_runner.py
@@ -8,7 +8,7 @@ from graphlib import TopologicalSorter
 from macaron.database.table_definitions import Analysis, Component, Repository
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 from macaron.slsa_analyzer.checks.base_check import BaseCheck
-from macaron.slsa_analyzer.checks.check_result import CheckResult, CheckResultType
+from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType
 from macaron.slsa_analyzer.registry import Registry
 
 from ...macaron_testcase import MacaronTestCase
@@ -39,8 +39,8 @@ class EmptyCheck(BaseCheck):
         super().__init__(check_id, "This is an empty check.", parent, [])
         self.should_return = should_return
 
-    def run_check(self, ctx: AnalyzeContext, check_result: CheckResult) -> CheckResultType:
-        return self.should_return
+    def run_check(self, ctx: AnalyzeContext) -> CheckResultData:
+        return CheckResultData(justification=[], result_tables=[], result_type=self.should_return)
 
 
 class TestRunner(MacaronTestCase):
@@ -126,4 +126,4 @@ class TestRunner(MacaronTestCase):
         target = AnalyzeContext(component=component)
         results = registry.scan(target, [])
 
-        assert results["mcn_e_1"]["result_type"] == results["mcn_d_1"]["result_type"] == CheckResultType.SKIPPED
+        assert results["mcn_e_1"].result.result_type == results["mcn_d_1"].result.result_type == CheckResultType.SKIPPED

--- a/tests/slsa_analyzer/test_analyze_context.py
+++ b/tests/slsa_analyzer/test_analyze_context.py
@@ -10,9 +10,8 @@ from unittest.mock import MagicMock
 
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
 from macaron.slsa_analyzer.ci_service.github_actions import GitHubActions
-from macaron.slsa_analyzer.levels import SLSALevels
 from macaron.slsa_analyzer.provenance.intoto import validate_intoto_payload
-from macaron.slsa_analyzer.slsa_req import Category, ReqName, SLSAReq
+from macaron.slsa_analyzer.slsa_req import ReqName, SLSAReqStatus
 from macaron.slsa_analyzer.specs.ci_spec import CIInfo
 from macaron.util import JsonType
 from tests.conftest import MockAnalyzeContext
@@ -24,8 +23,8 @@ class TestAnalyzeContext(TestCase):
     """
 
     MOCK_CTX_DATA = {
-        ReqName.BUILD_SERVICE: SLSAReq("build", "build_desc", Category.BUILD, SLSALevels.LEVEL1),
-        ReqName.VCS: SLSAReq("vcs_name", "vcs_desc", Category.SOURCE, SLSALevels.LEVEL1),
+        ReqName.BUILD_SERVICE: SLSAReqStatus(),
+        ReqName.VCS: SLSAReqStatus(),
     }
 
     MOCK_GIT_OBJ = MagicMock()
@@ -52,12 +51,12 @@ class TestAnalyzeContext(TestCase):
         Test updating one requirement in the context
         """
         self.analyze_ctx.update_req_status(ReqName.BUILD_SERVICE, True, "sample_fb")
-        assert self.analyze_ctx.ctx_data[ReqName.BUILD_SERVICE].get_status() == (
+        assert self.analyze_ctx.ctx_data[ReqName.BUILD_SERVICE].get_tuple() == (
             True,
             True,
             "sample_fb",
         )
-        assert self.analyze_ctx.ctx_data[ReqName.VCS].get_status() != (
+        assert self.analyze_ctx.ctx_data[ReqName.VCS].get_tuple() != (
             True,
             True,
             "sample_fb",
@@ -67,12 +66,12 @@ class TestAnalyzeContext(TestCase):
         assert self.analyze_ctx.ctx_data == self.MOCK_CTX_DATA
 
         self.analyze_ctx.bulk_update_req_status([ReqName.BUILD_SERVICE, ReqName.VCS], False, "bulk_update")
-        assert self.analyze_ctx.ctx_data[ReqName.BUILD_SERVICE].get_status() == (
+        assert self.analyze_ctx.ctx_data[ReqName.BUILD_SERVICE].get_tuple() == (
             True,
             False,
             "bulk_update",
         )
-        assert self.analyze_ctx.ctx_data[ReqName.VCS].get_status() == (
+        assert self.analyze_ctx.ctx_data[ReqName.VCS].get_tuple() == (
             True,
             False,
             "bulk_update",

--- a/tests/slsa_analyzer/test_slsa_requirements.py
+++ b/tests/slsa_analyzer/test_slsa_requirements.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """
@@ -7,8 +7,7 @@ This module test the slsa_analyzer.requirement module
 
 from unittest import TestCase
 
-from macaron.slsa_analyzer.levels import SLSALevels
-from macaron.slsa_analyzer.slsa_req import BUILD_REQ_DESC, Category, SLSAReq, get_requirements_dict
+from macaron.slsa_analyzer.slsa_req import SLSAReqStatus
 
 
 class TestSLSARequirements(TestCase):
@@ -16,32 +15,16 @@ class TestSLSARequirements(TestCase):
     This class provided tests for the Requirement module
     """
 
-    def setUp(self) -> None:
-        """
-        Create a simple requirement
-        """
-        name = "sample_req_name"
-        desc = "sample_req_desc"
-        category = Category.PROVENANCE
-        level = SLSALevels.LEVEL1
-        self.base_req = SLSAReq(name, desc, category, level)
-
     def test_status(self) -> None:
         """
-        Test addressing status in a requirement
+        Test requirement status
         """
-        assert (False, False, "") == self.base_req.get_status()
+        req_status = SLSAReqStatus()
+        assert (False, False, "") == req_status.get_tuple()
 
         feedback = "This repo passes this requirement"
-        self.base_req.set_status(True, feedback)
-        assert self.base_req.is_addressed
-        assert self.base_req.is_pass
-        assert self.base_req.feedback == feedback
-        assert (True, True, feedback) == self.base_req.get_status()
-
-    def test_get_requirements_dict(self) -> None:
-        """
-        Test if all the requirements defined in ReqName class are included in the returned dictionary.
-        """
-        all_reqs = get_requirements_dict()
-        assert all(req in all_reqs for req in BUILD_REQ_DESC)
+        req_status.set_status(True, feedback)
+        assert req_status.is_addressed
+        assert req_status.is_pass
+        assert req_status.feedback == feedback
+        assert (True, True, feedback) == req_status.get_tuple()

--- a/tests/slsa_analyzer/test_slsa_requirements.py
+++ b/tests/slsa_analyzer/test_slsa_requirements.py
@@ -5,26 +5,19 @@
 This module test the slsa_analyzer.requirement module
 """
 
-from unittest import TestCase
-
 from macaron.slsa_analyzer.slsa_req import SLSAReqStatus
 
 
-class TestSLSARequirements(TestCase):
+def test_slsa_requirements_status() -> None:
     """
-    This class provided tests for the Requirement module
+    Test requirement status
     """
+    req_status = SLSAReqStatus()
+    assert (False, False, "") == req_status.get_tuple()
 
-    def test_status(self) -> None:
-        """
-        Test requirement status
-        """
-        req_status = SLSAReqStatus()
-        assert (False, False, "") == req_status.get_tuple()
-
-        feedback = "This repo passes this requirement"
-        req_status.set_status(True, feedback)
-        assert req_status.is_addressed
-        assert req_status.is_pass
-        assert req_status.feedback == feedback
-        assert (True, True, feedback) == req_status.get_tuple()
+    feedback = "This repo passes this requirement"
+    req_status.set_status(True, feedback)
+    assert req_status.is_addressed
+    assert req_status.is_pass
+    assert req_status.feedback == feedback
+    assert (True, True, feedback) == req_status.get_tuple()


### PR DESCRIPTION
Refactor BaseCheck.run_check to return all result info as part of return value, rather than passing in and mutating a CheckResult object containing other data irrelevant to run_check.
Refactor SLSA requirement status information in AnalyzeContext to avoid unnecessary replication of generic info about a SLSA requirement, which can be looked up by ReqName when needed instead.