### PR TITLE
chore: improve the run_macaron.sh script

### DIFF
--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -1,7 +1,7 @@
 .. Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
 .. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
-.. _analyze-action-cli:
+.. _analyze-command-cli:
 
 =======
 Analyze

--- a/docs/source/pages/cli_usage/command_dump_defaults.rst
+++ b/docs/source/pages/cli_usage/command_dump_defaults.rst
@@ -11,7 +11,7 @@ Dump Defaults
 Description
 -----------
 
-Dumps the ``defaults.ini`` configuration file used by Macaron to the output directory. You can make changes to this configuration file and pass it to Macaron using the ``--defaults-path`` option. See :ref:`Analyze <analyze-action-cli>` for more information.
+Dumps the ``defaults.ini`` configuration file used by Macaron to the output directory. You can make changes to this configuration file and pass it to Macaron using the ``--defaults-path`` option. See :ref:`Analyze <analyze-command-cli>` for more information.
 
 -----
 Usage

--- a/docs/source/pages/cli_usage/command_verify-policy.rst
+++ b/docs/source/pages/cli_usage/command_verify-policy.rst
@@ -1,7 +1,7 @@
 .. Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
 .. Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
-.. _verify-policy-action-cli:
+.. _verify-policy-command-cli:
 
 =============
 Verify Policy

--- a/docs/source/pages/cli_usage/index.rst
+++ b/docs/source/pages/cli_usage/index.rst
@@ -17,9 +17,9 @@ Usage
 
 	usage: ./run_macaron.sh [-h] [-V] [-v] [-o OUTPUT_DIR] [-dp DEFAULTS_PATH] [-lr LOCAL_REPOS_PATH] {analyze,dump-defaults,verify-policy} ...
 
-Macaron's CLI has multiple common flags (e.g ``-h``, ``-V``) and different action commands (e.g. ``analyze``), which have their own set of flags.
+Macaron's CLI has multiple common flags (e.g ``-h``, ``-V``) and different commands (e.g. ``analyze``), which have their own set of flags.
 
-.. note:: Running ``--help`` on the main entry ``macaron`` will only print out the help for common flags. To print the help messages for action-specific flags, please provide the name of the action you want to know about. For example: ``./run_macaron.sh analyze --help``. The documented flags for each action can be found at `Action Commands`_.
+.. note:: Running ``--help`` on the main entry ``macaron`` will only print out the help for common flags. To print the help messages for command-specific flags, please provide the name of the command you want to know about. For example: ``./run_macaron.sh analyze --help``. The documented flags for each command can be found at `Commands`_.
 
 --------------
 Common Options
@@ -58,11 +58,11 @@ Environment Variables
 * ``DOCKER_PULL``: Whether to pull the Docker image from the `GitHub Container registry <https://github.com/oracle/macaron/pkgs/container/macaron>`_; must be one of: ``always``, ``missing``, ``never`` (default: ``always``).
 
 ---------------
-Action Commands
+Commands
 ---------------
 
 .. toctree::
 	:glob:
 	:maxdepth: 1
 
-	action*
+	command*

--- a/docs/source/pages/output_files.rst
+++ b/docs/source/pages/output_files.rst
@@ -29,7 +29,7 @@ Top level structure
 Reports
 -------
 
-The report files of Macaron (from using the :ref:`analyze action <analyze-action-cli>`) are generated into the ``reports`` directory.
+The report files of Macaron (from using the :ref:`analyze command <analyze-command-cli>`) are generated into the ``reports`` directory.
 
 .. code-block::
 
@@ -51,7 +51,7 @@ path is formed from the PURL string of that component. The final path is created
 For more information on the three fields ``type``, ``namespace`` and ``name`` of a PURL string, please see
 `PURL Specification <https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst>`_.
 
-Typically, when a repository path is provided as the main software component of the :ref:`analyze action <analyze-action-cli>`,
+Typically, when a repository path is provided as the main software component of the :ref:`analyze command <analyze-command-cli>`,
 a PURL is generated from the repository path, which is then later used in generating the unique report path.
 
 For example, when running this command:
@@ -118,7 +118,7 @@ For example, `<https://github.com/micronaut-projects/micronaut-core>`_ will be c
         └── micronaut-projects
             └── micronaut-core
 
-By default, if a local path is provided to the :ref:`analyze action <analyze-action-cli>`, this path will be treated as a relative path
+By default, if a local path is provided to the :ref:`analyze command <analyze-command-cli>`, this path will be treated as a relative path
 to the directory:
 
 .. code-block::

--- a/docs/source/pages/tutorials/index.rst
+++ b/docs/source/pages/tutorials/index.rst
@@ -88,7 +88,7 @@ First, we need to run the ``analyze`` command of Macaron to run a number of :ref
 .. note:: By default, Macaron clones the repositories and creates output files under the ``output`` directory. To understand the structure of this directory please see :ref:`Output Files Guide <output_files_guide>`.
 
 By default, this command analyzes the the latest commit of the default branch of the repository. You can also analyze the repository
-at a specific commit by providing the branch and commit digest. See the :ref:`CLI options<analyze-action-cli>` of the ``analyze`` command for more information.
+at a specific commit by providing the branch and commit digest. See the :ref:`CLI options<analyze-command-cli>` of the ``analyze`` command for more information.
 After running the ``analyze`` command, we can view the data that Macaron has gathered about the ``example-maven-app`` repository in an HTML report.
 
 .. code-block:: shell

--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -9,7 +9,7 @@ Using Macaron
 
 .. note:: The instructions below assume that you have setup you environment correctly to run Macaron (if not, please refer to :ref:`Installation Guide <installation-guide>`).
 
-.. _analyze-action:
+.. _analyze-command:
 
 .. contents:: :local:
 
@@ -230,7 +230,7 @@ Analyzing dependencies in the SBOM without the main software component
 
 In the case where the repository URL of the main software component is not available (e.g. the repository is in a private domain where Macaron cannot access),
 Macaron can still run the analysis on the dependencies listed in the SBOM.
-To do that, you must first create a PURL to present the main software component. This is so that this software component could be referenced later in the :ref:`verify-policy <verify-policy-action-cli>` command.
+To do that, you must first create a PURL to present the main software component. This is so that this software component could be referenced later in the :ref:`verify-policy <verify-policy-command-cli>` command.
 For example: ``pkg:private_domain.com/org/name``.
 
 Then the analysis can be run with:
@@ -253,7 +253,7 @@ In some cases the dependencies that Macaron discovers lack a direct connection t
 
 This feature is enabled by default. To disable, or configure its behaviour in other ways, a custom ``defaults.ini`` should be passed to Macaron during execution.
 
-See :ref:`dump-defaults <action_dump_defaults>`, the CLI command to dump the default configurations in ``defaults.ini``. After making changes, see :ref:`analyze <analyze-action-cli>` CLI command for the option to pass the modified ``defaults.ini`` file.
+See :ref:`dump-defaults <action_dump_defaults>`, the CLI command to dump the default configurations in ``defaults.ini``. After making changes, see :ref:`analyze <analyze-command-cli>` CLI command for the option to pass the modified ``defaults.ini`` file.
 
 Within the configuration file under the ``repofinder.java`` header, three options exist: ``artifact_repositories``, ``repo_pom_paths``, ``find_parents``. These options behave as follows:
 
@@ -320,7 +320,7 @@ Running the policy engine
 
 Macaron's policy engine accepts policies specified in `Datalog <https://en.wikipedia.org/wiki/Datalog>`_. An example policy
 can verify if a project and all its dependencies pass certain checks. We use `Soufflé <https://souffle-lang.github.io/index.html>`_
-as the Datalog engine in Macaron. Once you run the checks on a target project as described :ref:`here <analyze-action>`,
+as the Datalog engine in Macaron. Once you run the checks on a target project as described :ref:`here <analyze-command>`,
 the check results will be stored in ``macaron.db`` in the output directory. We pass the check results to the policy engine by providing the path to ``macaron.db`` together with a Datalog policy file to be validated by the policy engine.
 In the Datalog policy file, we must specify the identifier for the target software component that we are interested in to validate the policy against. These are two ways to specify the target software component in the Datalog policy file:
 
@@ -355,7 +355,7 @@ The differences between the two policy files can be observed below:
 
     apply_policy_to("oci_micronaut_dependencies", component_id) :- is_component(component_id, "<target_software_component_purl>").
 
-The PURL string for the target software component is printed to the console by the :ref:`analyze command <analyze-action>`. For example:
+The PURL string for the target software component is printed to the console by the :ref:`analyze command <analyze-command>`. For example:
 
 .. code::
 

--- a/scripts/dev_scripts/test_run_macaron_sh.py
+++ b/scripts/dev_scripts/test_run_macaron_sh.py
@@ -3,6 +3,7 @@
 
 """Tests for the ``run_macaron.sh`` script."""
 
+import os
 import subprocess
 import sys
 from collections import namedtuple
@@ -32,9 +33,13 @@ def test_macaron_command() -> int:
     ]
 
     exit_code = 0
+    env = dict(os.environ)
+    env["MCN_DEBUG_ARGS"] = "1"
 
     for test_case in test_cases:
         name, script_args, expected_macaron_args = test_case
+        print(f"test_macaron_command[{name}]:", end=" ")
+
         result = subprocess.run(
             [
                 "scripts/release_scripts/run_macaron.sh",
@@ -42,12 +47,17 @@ def test_macaron_command() -> int:
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env={"MCN_DEBUG_ARGS": "1"},
-            check=True,
+            env=env,
+            check=False,
         )
-        resulting_macaron_args = list(result.stderr.decode("utf-8").split())
+        if result.returncode != 0:
+            exit_code = 1
+            print(f"FAILED with exit code {exit_code}")
+            print("stderr:")
+            print(result.stderr.decode("utf-8"))
+            continue
 
-        print(f"test_macaron_command[{name}]:", end=" ")
+        resulting_macaron_args = list(result.stderr.decode("utf-8").split())
 
         if resulting_macaron_args != expected_macaron_args:
             print("FAILED")

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -333,11 +333,10 @@ if [[ -f "$HOME/.m2/settings.xml" ]]; then
 fi
 
 # Set up proxy.
-# - We respect the host machine's proxy environment variables.
-# - For Maven wrapper `mvnw`, proxy configuration can be set through
-# the `MAVEN_OPTS` environment variable.
-# - For Gradle wrapper `gradlew`, proxy configuration can be set through
-# the `GRADLE_OPTS` or `JAVA_OPTS` environment variables.
+# We respect the host machine's proxy environment variables.
+# For Maven and Gradle projects that Macaron needs to analyzes, the proxy configuration
+# for Maven wrapper `mvnw` and Gradle wrapper `gradlew` are set using `MAVEN_OPTS` and
+# `GRADLE_OPTS` environment variables.
 proxy_var_names=(
     "http_proxy"
     "https_proxy"
@@ -349,7 +348,6 @@ proxy_var_names=(
     "NO_PROXY"
     "MAVEN_OPTS"
     "GRADLE_OPTS"
-    "JAVA_OPTS"
 )
 
 for v in "${proxy_var_names[@]}"; do

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -209,8 +209,7 @@ if [[ -n "${arg_local_repos_path}" ]]; then
         exit 1
     fi
     argv_main+=("--local-repos-path" "${MACARON_WORKSPACE}/output/git_repos/local_repos/")
-fi
-if [[ -n "${local_repos_path}" ]]; then
+
     local_repos_path="$(ensure_absolute_path "${local_repos_path}")"
     mounts+=("-v" "${local_repos_path}:${MACARON_WORKSPACE}/output/git_repos/local_repos/:rw,Z")
 fi
@@ -225,8 +224,7 @@ if [[ -n "${arg_defaults_path}" ]]; then
     fi
     file_name="$(basename "${defaults_path}")"
     argv_main+=("--defaults-path" "${MACARON_WORKSPACE}/defaults/${file_name}")
-fi
-if [[ -n "${defaults_path}" ]]; then
+
     defaults_path="$(ensure_absolute_path "${defaults_path}")"
     mounts+=("-v" "${defaults_path}:${MACARON_WORKSPACE}/defaults/${file_name}:ro")
 fi
@@ -241,8 +239,7 @@ if [[ -n "${arg_policy}" ]]; then
     fi
     file_name="$(basename "${policy}")"
     argv_main+=("--policy" "${MACARON_WORKSPACE}/policy/${file_name}")
-fi
-if [[ -n "${policy}" ]]; then
+
     policy="$(ensure_absolute_path "${policy}")"
     mounts+=("-v" "${policy}:${MACARON_WORKSPACE}/policy/${file_name}:ro")
 fi
@@ -258,8 +255,7 @@ if [[ -n "${arg_template_path}" ]]; then
     fi
     file_name="$(basename "${template_path}")"
     argv_action+=("--template-path" "${MACARON_WORKSPACE}/template/${file_name}")
-fi
-if [[ -n "${template_path}" ]]; then
+
     template_path="$(ensure_absolute_path "${template_path}")"
     mounts+=("-v" "${template_path}:${MACARON_WORKSPACE}/template/${file_name}:ro")
 fi
@@ -274,8 +270,7 @@ if [[ -n "${arg_config_path}" ]]; then
     fi
     file_name="$(basename "${config_path}")"
     argv_action+=("--config-path" "${MACARON_WORKSPACE}/config/${file_name}")
-fi
-if [[ -n "${config_path}" ]]; then
+
     config_path="$(ensure_absolute_path "${config_path}")"
     mounts+=("-v" "${config_path}:${MACARON_WORKSPACE}/config/${file_name}:ro")
 fi
@@ -290,8 +285,7 @@ if [[ -n "${arg_sbom_path}" ]]; then
     fi
     file_name="$(basename "${sbom_path}")"
     argv_action+=("--sbom-path" "${MACARON_WORKSPACE}/sbom/${file_name}")
-fi
-if [[ -n "${sbom_path}" ]]; then
+
     sbom_path="$(ensure_absolute_path "${sbom_path}")"
     mounts+=("-v" "${sbom_path}:${MACARON_WORKSPACE}/sbom/${file_name}:ro")
 fi
@@ -306,8 +300,7 @@ if [[ -n "${arg_prov_exp}" ]]; then
     fi
     pe_name="$(basename "${prov_exp}")"
     argv_action+=("--provenance-expectation" "${MACARON_WORKSPACE}/prov_expectations/${pe_name}")
-fi
-if [[ -n "${prov_exp}" ]]; then
+
     prov_exp="$(ensure_absolute_path "${prov_exp}")"
     mounts+=("-v" "${prov_exp}:${MACARON_WORKSPACE}/prov_expectations/${pe_name}:ro")
 fi
@@ -324,8 +317,7 @@ if [[ -n "${arg_database}" ]]; then
     fi
     file_name="$(basename "${database}")"
     argv_action+=("--database" "${MACARON_WORKSPACE}/database/${file_name}")
-fi
-if [[ -n "${database}" ]]; then
+
     database="$(ensure_absolute_path "${database}")"
     mounts+=("-v" "${database}:${MACARON_WORKSPACE}/database/${file_name}:rw,Z")
 fi
@@ -340,8 +332,7 @@ if [[ -n "${arg_datalog_policy_file}" ]]; then
     fi
     file_name="$(basename "${datalog_policy_file}")"
     argv_action+=("--file" "${MACARON_WORKSPACE}/policy/${file_name}")
-fi
-if [[ -n "${datalog_policy_file}" ]]; then
+
     datalog_policy_file="$(ensure_absolute_path "${datalog_policy_file}")"
     mounts+=("-v" "${datalog_policy_file}:${MACARON_WORKSPACE}/policy/${file_name}:ro")
 fi

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -333,10 +333,11 @@ if [[ -f "$HOME/.m2/settings.xml" ]]; then
 fi
 
 # Set up proxy.
-# We respect the host machine's proxy environment variables.
-# For Maven and Gradle projects that Macaron needs to analyzes, the proxy configuration
-# for Maven wrapper `mvnw` and Gradle wrapper `gradlew` are set using `MAVEN_OPTS` and
-# `GRADLE_OPTS` environment variables.
+# - We respect the host machine's proxy environment variables.
+# - For Maven wrapper `mvnw`, proxy configuration can be set through
+# the `MAVEN_OPTS` environment variable.
+# - For Gradle wrapper `gradlew`, proxy configuration can be set through
+# the `GRADLE_OPTS` or `JAVA_OPTS` environment variables.
 proxy_var_names=(
     "http_proxy"
     "https_proxy"
@@ -348,6 +349,7 @@ proxy_var_names=(
     "NO_PROXY"
     "MAVEN_OPTS"
     "GRADLE_OPTS"
+    "JAVA_OPTS"
 )
 
 for v in "${proxy_var_names[@]}"; do

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -191,15 +191,14 @@ else
     output=$(pwd)/output
     echo "Setting default output directory to ${output}."
 fi
-if [[ -n "${output}" ]]; then
-    output="$(ensure_absolute_path "${output}")"
-    # Mounting the necessary .m2 and .gradle directories.
-    m2_dir="${output}/.m2"
-    gradle_dir="${output}/.gradle"
-    mounts+=("-v" "${output}:${MACARON_WORKSPACE}/output:rw,Z")
-    mounts+=("-v" "${m2_dir}:${MACARON_WORKSPACE}/.m2:rw,Z")
-    mounts+=("-v" "${gradle_dir}:${MACARON_WORKSPACE}/.gradle:rw,Z")
-fi
+
+output="$(ensure_absolute_path "${output}")"
+# Mounting the necessary .m2 and .gradle directories.
+m2_dir="${output}/.m2"
+gradle_dir="${output}/.gradle"
+mounts+=("-v" "${output}:${MACARON_WORKSPACE}/output:rw,Z")
+mounts+=("-v" "${m2_dir}:${MACARON_WORKSPACE}/.m2:rw,Z")
+mounts+=("-v" "${gradle_dir}:${MACARON_WORKSPACE}/.gradle:rw,Z")
 
 # Determine the local repos path to be mounted into ${MACARON_WORKSPACE}/output/git_repos/local_repos/
 if [[ -n "${arg_local_repos_path}" ]]; then

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -366,7 +366,7 @@ proxy_var_names=(
 )
 
 for v in "${proxy_var_names[@]}"; do
-    [[ -n ${!v} ]] && proxy_vars+=("-e" "${v}=${!v}")
+    proxy_vars+=("-e" "${v}")
 done
 
 prod_vars=(
@@ -424,9 +424,9 @@ docker run \
     --rm -i "${tty[@]}" \
     -e "USER_UID=${USER_UID}" \
     -e "USER_GID=${USER_GID}" \
-    -e "GITHUB_TOKEN=${GITHUB_TOKEN}" \
-    -e "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}" \
-    -e "MCN_SELF_HOSTED_GITLAB_TOKEN=${MCN_SELF_HOSTED_GITLAB_TOKEN}" \
+    -e GITHUB_TOKEN \
+    -e MCN_GITLAB_TOKEN \
+    -e MCN_SELF_HOSTED_GITLAB_TOKEN \
     "${proxy_vars[@]}" \
     "${prod_vars[@]}" \
     "${mounts[@]}" \

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -5,8 +5,24 @@
 
 # This script runs the Macaron Docker image.
 
+# Strict bash options.
+#
+# -e:          exit immediately if a command fails (with non-zero return code),
+#              or if a function returns non-zero.
+#
+# -u:          treat unset variables and parameters as error when performing
+#              parameter expansion.
+#              In case a variable ${VAR} is unset but we still need to expand,
+#              use the syntax ${VAR:-} to expand it to an empty string.
+#
+# -o pipefail: set the return value of a pipeline to the value of the last
+#              (rightmost) command to exit with a non-zero status, or zero
+#              if all commands in the pipeline exit successfully.
+#
+# Reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
+set -euo pipefail
 
-if [[ -z ${MACARON_IMAGE_TAG} ]]; then
+if [[ -z ${MACARON_IMAGE_TAG:-} ]]; then
     MACARON_IMAGE_TAG="latest"
 fi
 
@@ -180,7 +196,7 @@ fi
 
 # MACARON entrypoint - Main argvs
 # Determine the output path to be mounted into ${MACARON_WORKSPACE}/output/
-if [[ -n "${arg_output}" ]]; then
+if [[ -n "${arg_output:-}" ]]; then
     output="${arg_output}"
     err=$(check_dir_exists "${output}" "-o/--output")
     if [[ -n "${err}" ]]; then
@@ -202,7 +218,7 @@ mounts+=("-v" "${m2_dir}:${MACARON_WORKSPACE}/.m2:rw,Z")
 mounts+=("-v" "${gradle_dir}:${MACARON_WORKSPACE}/.gradle:rw,Z")
 
 # Determine the local repos path to be mounted into ${MACARON_WORKSPACE}/output/git_repos/local_repos/
-if [[ -n "${arg_local_repos_path}" ]]; then
+if [[ -n "${arg_local_repos_path:-}" ]]; then
     local_repos_path="${arg_local_repos_path}"
     err=$(check_dir_exists "${local_repos_path}" "-lr/--local-repos-path")
     if [[ -n "${err}" ]]; then
@@ -216,7 +232,7 @@ if [[ -n "${arg_local_repos_path}" ]]; then
 fi
 
 # Determine the defaults path to be mounted into ${MACARON_WORKSPACE}/defaults/${file_name}
-if [[ -n "${arg_defaults_path}" ]]; then
+if [[ -n "${arg_defaults_path:-}" ]]; then
     defaults_path="${arg_defaults_path}"
     err=$(check_file_exists "${defaults_path}" "-dp/--defaults-path")
     if [[ -n "${err}" ]]; then
@@ -231,7 +247,7 @@ if [[ -n "${arg_defaults_path}" ]]; then
 fi
 
 # Determine the policy path to be mounted into ${MACARON_WORKSPACE}/policy/${file_name}
-if [[ -n "${arg_policy}" ]]; then
+if [[ -n "${arg_policy:-}" ]]; then
     policy="${arg_policy}"
     err=$(check_file_exists "${policy}" "-po/--policy")
     if [[ -n "${err}" ]]; then
@@ -247,7 +263,7 @@ fi
 
 # MACARON entrypoint - Analyze command argvs
 # Determine the template path to be mounted into ${MACARON_WORKSPACE}/template/${file_name}
-if [[ -n "${arg_template_path}" ]]; then
+if [[ -n "${arg_template_path:-}" ]]; then
     template_path="${arg_template_path}"
     err=$(check_file_exists "${template_path}" "-g/--template-path")
     if [[ -n "${err}" ]]; then
@@ -262,7 +278,7 @@ if [[ -n "${arg_template_path}" ]]; then
 fi
 
 # Determine the config path to be mounted into ${MACARON_WORKSPACE}/config/${file_name}
-if [[ -n "${arg_config_path}" ]]; then
+if [[ -n "${arg_config_path:-}" ]]; then
     config_path="${arg_config_path}"
     err=$(check_file_exists "${config_path}" "-c/--config-path")
     if [[ -n "${err}" ]]; then
@@ -277,7 +293,7 @@ if [[ -n "${arg_config_path}" ]]; then
 fi
 
 # Determine the sbom path to be mounted into ${MACARON_WORKSPACE}/sbom/${file_name}
-if [[ -n "${arg_sbom_path}" ]]; then
+if [[ -n "${arg_sbom_path:-}" ]]; then
     sbom_path="${arg_sbom_path}"
     err=$(check_file_exists "${sbom_path}" "-sbom/--sbom-path")
     if [[ -n "${err}" ]]; then
@@ -292,7 +308,7 @@ if [[ -n "${arg_sbom_path}" ]]; then
 fi
 
 # Determine the provenance expectation path to be mounted into ${MACARON_WORKSPACE}/prov_expectations/${file_name}
-if [[ -n "${arg_prov_exp}" ]]; then
+if [[ -n "${arg_prov_exp:-}" ]]; then
     prov_exp="${arg_prov_exp}"
     err=$(check_path_exists "${prov_exp}" "-pe/--provenance-expectation")
     if [[ -n "${err}" ]]; then
@@ -309,7 +325,7 @@ fi
 # MACARON entrypoint - verify-policy command argvs
 # This is for macaron verify-policy command.
 # Determine the database path to be mounted into ${MACARON_WORKSPACE}/database/macaron.db
-if [[ -n "${arg_database}" ]]; then
+if [[ -n "${arg_database:-}" ]]; then
     database="${arg_database}"
     err=$(check_file_exists "${database}" "-d/--database")
     if [[ -n "${err}" ]]; then
@@ -324,7 +340,7 @@ if [[ -n "${arg_database}" ]]; then
 fi
 
 # Determine the Datalog policy to be verified by verify-policy command.
-if [[ -n "${arg_datalog_policy_file}" ]]; then
+if [[ -n "${arg_datalog_policy_file:-}" ]]; then
     datalog_policy_file="${arg_datalog_policy_file}"
     err=$(check_file_exists "${datalog_policy_file}" "-f/--file")
     if [[ -n "${err}" ]]; then
@@ -391,7 +407,7 @@ then
     entrypoint=("macaron")
 fi
 
-if [[ -n "${DOCKER_PULL}" ]]; then
+if [[ -n "${DOCKER_PULL:-}" ]]; then
     if [[ "${DOCKER_PULL}" != @(always|missing|never) ]]; then
         echo "DOCKER_PULL must be one of: always, missing, never (default: always)"
         exit 1
@@ -414,7 +430,7 @@ macaron_args=(
 # env var `MCN_DEBUG_ARGS=1`.
 # In this case, the script will just print the arguments to stderr without
 # running the Macaron container.
-if [[ -n ${MCN_DEBUG_ARGS} ]]; then
+if [[ -n ${MCN_DEBUG_ARGS:-} ]]; then
     >&2 echo "${macaron_args[@]}"
     exit 0
 fi


### PR DESCRIPTION
This pull request makes a number of improvements to our current `run_macaron.sh` script.

This is to prepare for another pull request, #512, which adds support for Podman as an alternative container engine to run the Macaron image.

## Set bash "strict" flags

**Commit**: 95cb003d27dd41287eb78ea20d7f2ac401264551

The following bash built-in flags are added to the script. These flags effectively help make the script less error-prone.

- `set -e`: exit immediately if a command fails (with non-zero return code), or if a function returns non-zero.
- `set -u`: treat unset variables and parameters as errors when performing parameter expansion.
Note: In case a variable `${VAR}` is unset but we still need to expand, we can use the syntax `${VAR:-}` to expand it to an empty string ([bash documentation](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)).
- `set -o pipefail`: set the return value of a pipeline to the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully.

Reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.

## Simplify passing environment variables into the container

**Commit**: b4d49f0f04551370a865d16d630ddcb11d72bcac

During `docker run`, we can pass environment variables into the container as follows:

```bash
$ docker run [...] -e "http_proxy=${http_proxy}" [...]
```

In cases where we want the container to "inherit" the environment variables on the host, we do not need to explicitly specify the value, i.e., doing this should be enough:

```bash
$ docker run [...] -e http_proxy [...]
```

Passing the environment variables into the container in this implicit manner is also very useful when we want to use the `set -x` flag of bash for debugging purposes but do not want secret values to be logged out as plain text.

## Inherit the `JAVA_OPTS` environment variable into the container

**Commit**: d1f6341978f124e7c13d0a434150b089f5fe4b46

Proxy settings for the Gradle wrapper can also be set through the `JAVA_OPTS` environment variable (besides `GRADLE_OPTS`). We should also pass it into the container.

## Other changes

* b7374c240f0bdd639e838665cdfeec7663d2ed28 and dca163b360cd5c6c5b97ace77e5f87fd7269f783 mostly remove redundant logic from the script.
* 1147ede7890b8a37ecd4e7bd99e29247b0c7dee9 changes how `analyze` and `verify-policy` are referred to, from "actions" to "commands".
* fff08a9ad61900219e4467647a43bdd9276de4d6 refactors functions in the script that check for the existence of files or directories. With `set -u`, these functions can `return 1` and immediately stop the script with exit code 1.
* c2bda959b0c046b5fa594300f67584cc8080b5ce renames the functions in the script to make the intentions clearer.