### PR TITLE
fix: fix bash syntax error when running `run_macaron.sh` on MacOS

### DIFF
--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -10,7 +10,10 @@ Installation Guide
 -------------
 Prerequisites
 -------------
-- Installations of ``wget`` or ``curl`` and ``bash`` must be available and on the path.
+- Installations of ``wget`` or ``curl`` and ``bash`` must be available on ``PATH``.
+
+  - Macaron has been tested with ``bash 5.1.16(1)-release``.
+
 - Docker (or docker equivalent for your host OS) must be installed, with a docker command line equivalent to Docker 17.06 (Oracle Container Runtime 19.03) and the user should be a member of the operating system group ``docker`` (to run Docker in `rootless mode <https://docs.docker.com/engine/security/rootless/>`_).
 
 .. _download-macaron:

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -28,6 +28,21 @@ set -euo pipefail
 # Reference: https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
 shopt -s extglob
 
+# Log error (to stderr).
+log_err() {
+    echo "[ERROR]: $*" >&2
+}
+
+# Log warning (to stderr).
+log_warning() {
+    echo "[WARNING]: $*" >&2
+}
+
+if [[ "${BASH_VERSINFO[0]}" -lt "4" ]]; then
+    log_warning "Your bash version, '${BASH_VERSION}', is too old and is not actively supported by Macaron."
+    log_warning "Using bash version >=4 is recommended."
+fi
+
 if [[ -z ${MACARON_IMAGE_TAG:-} ]]; then
     MACARON_IMAGE_TAG="latest"
 fi
@@ -62,11 +77,6 @@ mounts=()
 
 # The proxy values obtained from the host environment.
 proxy_vars=()
-
-# Log error (to stderr).
-log_err() {
-    echo "[ERROR]: $*" >&2
-}
 
 # Convert a path to absolute path if it is a relative path.
 #

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -22,6 +22,12 @@
 # Reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
 set -euo pipefail
 
+# The `extglob` shopt option is required for the `@(...)` pattern matching syntax.
+# This option is not enabled by default for bash on some systems, most notably MacOS
+# where the default bash version is very old.
+# Reference: https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
+shopt -s extglob
+
 if [[ -z ${MACARON_IMAGE_TAG:-} ]]; then
     MACARON_IMAGE_TAG="latest"
 fi


### PR DESCRIPTION
The bash pattern matching syntax `@(...)` requires the shopt option `extglob` to be set. Although this option is set by default on newer versions of bash, it is not always the case. One known case is on MacOS, where the default bash version is `bash 3.2`. (even on the latest version of MacOS).

Reproduction: Run the following bash script in the `bash:3.2` docker container.

```
#!/usr/bin/env bash

if [[ "${DOCKER_PULL}" != @(always|missing|never) ]]; then
    echo "DOCKER_PULL must be one of: always, missing, never (default: always)"
    exit 1
fi
```