### PR TITLE
chore: display the repository URL status of dependencies in html report instead of the analysis status

### DIFF
--- a/src/macaron/output_reporter/jinja2_extensions.py
+++ b/src/macaron/output_reporter/jinja2_extensions.py
@@ -147,12 +147,12 @@ def j2_filter_get_flatten_dict(data: Any, has_key: bool = False) -> dict | Any:
     return {"0": str(data)}
 
 
-def j2_filter_get_dep_status_color(dep_status: str) -> str:
-    """Return the html class name for the color of the dep status.
+def j2_filter_get_dep_status_color(repo_url_status: str) -> str:
+    """Return the html class name for the color of the dep repo url status.
 
     Parameters
     ----------
-    dep_status : str
+    repo_url_status : str
         The dep status as string.
 
     Returns
@@ -161,7 +161,7 @@ def j2_filter_get_dep_status_color(dep_status: str) -> str:
         The css class name with the corresponding color or an empty string if the status is not recognized.
     """
     try:
-        scm_status = SCMStatus(dep_status)
+        scm_status = SCMStatus(repo_url_status)
         match scm_status:
             case SCMStatus.AVAILABLE:
                 return "green_bg"

--- a/src/macaron/output_reporter/results.py
+++ b/src/macaron/output_reporter/results.py
@@ -99,13 +99,13 @@ class Record(Generic[RecordNode]):
         Examples
         --------
         >>> record.get_summary()
-        {'id': 'apache/maven', 'description': 'Analysis completed', 'report': 'apache.html', 'status': 'AVAILABLE'}
+        {'id': 'apache/maven', 'description': 'Analysis completed', 'report': 'apache.html', 'status': SCMStatus.AVAILABLE}
         """
         return {
             "id": self.record_id,
             "description": self.description,
             "report": f"{self.context.component.report_file_name}.html" if self.context else "",
-            "status": self.status,
+            "repo_url_status": self.pre_config.get_value("available") or SCMStatus.MISSING_SCM,
         }
 
     def get_dict(self) -> dict:

--- a/src/macaron/output_reporter/templates/macaron.html
+++ b/src/macaron/output_reporter/templates/macaron.html
@@ -153,7 +153,7 @@
         {% else %}
         <td>Not available.</td>
         {% endif %}
-        {% elif header == "status" %}
+        {% elif header == "repo_url_status" %}
         <td class={{ item[header] | get_dep_status_color }}>{{ item[header].value }}</td>
         {% else %}
         <td>{{ item[header] }}</td>
@@ -250,7 +250,7 @@
     {% if dependencies.analyzed_deps != 0 %}
     <div class="table_caption" id="deps_result_title">Dependency results</div>
     <div class="table_sub_caption">
-    {{ dependencies.analyzed_deps }} dependencies have been found.
+    {{ dependencies.analyzed_deps }} dependencies that map to {{ dependencies.unique_dep_repos }} unique repositories have been successfully analyzed.
     </div>
     {{ render_dep_summary(dependencies.checks_summary) | indent(4) }}
     <div class="space_divider"></div>


### PR DESCRIPTION
# Description
This Pull request fixes the issues in the HTML report of the main target where the dependencies are all displayed as `AVAILABLE` even though the repository URL is not available for them - see example below:
```shell
macaron analyze -rp https://github.com/apache/maven -sbom test_sbom.json
```
with the content of `test_sbom.json` as follows: [test_sbom.json](https://github.com/oracle/macaron/files/13234713/test_sbom.json)

![image](https://github.com/oracle/macaron/assets/33509400/8d5e0618-8b73-4589-b15a-695ce80ecf3e)

In this example, Macaron cannot find the repository URL for the dependency component `javax.inject:javax.inject`. However, Macaron still tries to run all checks on that component and produce an "empty" HTML report for it. This is part of the design implemented in this [PR](https://github.com/oracle/macaron/pull/165):
- Macaron still run the checks and produce a HTML report for all software component (including both the main target and dependencies if available) even when no repository URL is found for them (consistent with the data model where the [repository is an optional field of a software component](https://github.com/oracle/macaron/blob/1b7740b682030e42f41d319d38af8aa20764643a/src/macaron/database/table_definitions.py#L139)).

Therefore, it's required to correctly display the repository URL status in the `status` column (as shown in the example above). One of the reason why this is happening is because we are using [`SCMStatus`](https://github.com/oracle/macaron/blob/ecc21626209222cb4c40ef678916dd631ddee04e/src/macaron/output_reporter/scm.py#L9) enum for two purposes:
- Show the status of repository URL for a software component (used in DependencyAnalyzer)
- Show the status of running the analysis for a software component (used in Analyzer)

# Implementation
This PR currently introduce a work-around for this issue. @behnazh-w Please let me know if it's preferred to use this work-around at the moment or implement a proper fix for it directly.