### PR TITLE
chore: print debug message if a ci service config file is not found

### DIFF
--- a/src/macaron/slsa_analyzer/ci_service/base_ci_service.py
+++ b/src/macaron/slsa_analyzer/ci_service/base_ci_service.py
@@ -164,7 +164,7 @@ class BaseCIService:
                 logger.info("No build command found in %s", file_path)
                 return "", ""
             except FileNotFoundError as error:
-                logger.error(error)
+                logger.debug(error)
                 continue
         return "", ""
 


### PR DESCRIPTION
This PR change the error message printed out [here](https://github.com/oracle/macaron/blob/13206e56463f51ccd98415ec9c249688c70ccdff/src/macaron/slsa_analyzer/ci_service/base_ci_service.py#L167) to a debug message.
This is because in this [method](https://github.com/oracle/macaron/blob/13206e56463f51ccd98415ec9c249688c70ccdff/src/macaron/slsa_analyzer/ci_service/base_ci_service.py#L129), we are trying multiple config file names for a ci service until we find one, so it's not an error if we cannot find a config file. 
For example, if we run Macaron:
```
macaron analyze -purl pkg:maven/org.opentest4j/opentest4j@1.2.0?type=jar --skip-deps
```  
This is the log message if we keep it as an error message
```
...
2023-10-27 10:53:21,731 [INFO] BEGIN CHECK: mcn_build_service_1
2023-10-27 10:53:21,731 [INFO] ----------------------------------
2023-10-27 10:53:21,732 [ERROR] [Errno 2] No such file or directory: '.../output/git_repos/github_com/ota4j-team/opentest4j/.travis.yaml'
2023-10-27 10:53:21,732 [INFO] Found build command ./gradlew at line 11 in .travis.yml: "- ./gradlew --version # Display Gradle, Groovy, JVM and other versions"
2023-10-27 10:53:21,732 [INFO] Check mcn_build_service_1 run PASSED on target pkg:maven/org.opentest4j/opentest4j@1.2.0?type=jar, result: ['The target repository uses build tool gradle in travis_ci to build.']
```