### PR TITLE
chore: use --force for running git checkout to prevent issues like #530

### DIFF
--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -292,6 +292,11 @@ An example configuration file for utilising this feature:
 Analyzing a locally cloned repository
 -------------------------------------
 
+.. warning::
+  During the analysis, Macaron can check out different commits, which can reset the index and working tree of the repository.
+  Therefore, any uncommitted changes in the repository need to be backed up to prevent loss (these include unstaged changes, staged changes and untracked files).
+  However, Macaron will not modify the history of the repository.
+
 If you have a local repository that you want to analyze, Macaron also supports running the analysis against a local repository.
 
 Assume that the dir tree at the local repository has the following components:

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -695,10 +695,6 @@ class Analyzer:
             logger.error("The target repository does not have any commit.")
             return None
 
-        if not git_url.reset_git_repo(git_obj):
-            logger.error("Cannot reset the target repository.")
-            return None
-
         # Checking out the specific branch or commit. This operation varies depends on the git service that the
         # repository uses.
         if not is_remote:

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -22,45 +22,6 @@ from macaron.errors import CloneError
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def reset_git_repo(git_obj: Git, stash: bool = True, index: bool = True, working_tree: bool = True) -> bool:
-    """Reset the index and working tree of the target repository.
-
-    Note that this method does not reset any untracked or ignored files.
-
-    Parameters
-    ----------
-    git_obj : Git
-        The pydriller.Git object of the repository.
-    stash : bool
-        If True, any uncommitted changes will be stashed.
-    index : bool
-        If True, the index of the repository will be reset.
-    working_tree : bool
-        If True, the working tree will be forcefully adjusted to match HEAD, possibly overwriting uncommitted changes.
-        If working_tree is True, index must be true as well.
-
-    Returns
-    -------
-    bool
-        True if no errors encountered, else False.
-    """
-    try:
-        if stash:
-            logger.info("Stashing any uncommitted changes.")
-            stash_out = git_obj.repo.git.stash(message="Stashing uncommitted changes by Macaron.")
-            logger.debug("\t Git CMD output: %s", stash_out)
-
-        logger.info("Forcefully reset the repository.")
-        git_obj.repo.head.reset(index=index, working_tree=working_tree)
-        return True
-    except GitCommandError as error:
-        logger.error("Error while trying to reset untracked changes in the repository: %s", error)
-        return False
-    except ValueError as error:
-        logger.error(error)
-        return False
-
-
 def check_out_repo_target(git_obj: Git, branch_name: str = "", digest: str = "", offline_mode: bool = False) -> bool:
     """Checkout the branch and commit specified by the user.
 

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -120,7 +120,8 @@ def check_out_repo_target(git_obj: Git, branch_name: str = "", digest: str = "",
 
     try:
         # Switch to the target branch by running ``git checkout <branch_name>`` in the target repository.
-        git_obj.repo.git.checkout(res_branch)
+        # We need to use force checkout to prevent issues similar to https://github.com/oracle/macaron/issues/530.
+        git_obj.repo.git.checkout("--force", res_branch)
     except GitCommandError as error:
         logger.error("Cannot checkout branch %s. Error: %s", res_branch, error)
         return False
@@ -150,8 +151,9 @@ def check_out_repo_target(git_obj: Git, branch_name: str = "", digest: str = "",
 
     if digest:
         # Checkout the specific commit that the user want by running ``git checkout <commit>`` in the target repository.
+        # We need to use force checkout to prevent issues similar to https://github.com/oracle/macaron/issues/530.
         try:
-            git_obj.repo.git.checkout(digest)
+            git_obj.repo.git.checkout("--force", digest)
         except GitCommandError as error:
             logger.error(
                 "Commit %s cannot be checked out. Error: %s",


### PR DESCRIPTION
Closes #530 .

This Pull Request addresses the issues described in #530 by doing the following tasks:
- When checkout a branch or a commit, use the `--force` flag of the `git checkout` command to reset the index and working tree, potentially remove any uncommitted changes. For more information on this flag, see [here](https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt---force).
- Remove the `git_url.reset_git_repo` function which create a stash and reset the index and working tree of the target repository before checking out any branch or commit. 
- Add a warning to the Sphinx documentation for the use case of `Analyzing a locally cloned repository` about Macaron's ability to reset the index and working tree of the target repository.