### PR TITLE
test: add update option to integration script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,11 @@ integration-test:
 integration-test-docker:
 	scripts/dev_scripts/integration_tests_docker.sh $(REPO_PATH) scripts/release_scripts/run_macaron.sh
 
+# Update the expected results of the integration tests after generating the actual results.
+.PHONY: integration-test-update
+integration-test-update:
+	scripts/dev_scripts/integration_tests.sh $(REPO_PATH) "${HOME}" "--update"
+
 # Build a source distribution package and a binary wheel distribution artifact.
 # When building these artifacts, we need the environment variable SOURCE_DATE_EPOCH
 # set to the build date/epoch. For more details, see: https://flit.pypa.io/en/latest/reproducible.html

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -13,24 +13,31 @@ TEST_REPO_FINDER=$WORKSPACE/tests/e2e/repo_finder/repo_finder.py
 RUN_MACARON="python -m macaron -o $WORKSPACE/output"
 PYTHON="python "
 RESULT_CODE=0
+UPDATE=0
 
-function _copy() {
-  # To replace all python commands when updating results, rather than comparing them.
-  # Note that this function will always attempt to perform a file copy operation on arg #2 and #3, if there are
-  # sufficient arguments.
-  if [ $# -eq 3 ] ; then
-    # Copy arg 2 to arg 3.
-    cp "$2" "$3"
+# Optional argument for updating the expected results.
+if [ $# -eq 3 ] && [ "$3" == "--update" ] ; then
+  echo "Updating the expected results to match those currently produced by Macaron."
+  UPDATE=1
+fi
+
+function check_or_update_expected_output() {
+  if [ $UPDATE -eq 1 ] ; then
+    # Perform update of expected results by copying over produced output files.
+    # The copy only takes place if sufficient arguments are present.
+    # This function assumes arguments #2 and #3 are files: <actual_result>, <expected_result>.
+    if [ $# -eq 3 ] ; then
+      echo "Copying $2 to $3"
+      cp "$2" "$3"
+    else
+      # Calls with insufficient arguments are ignored to avoid some needless computation during updates.
+      echo "Ignoring $@"
+    fi
+  else
+    # Perform normal operation.
+    python "$@"
   fi
 }
-
-# Optional arguments for updating the expected results.
-if [ $# -ge 3 ] ; then
-  if [ $3 == "--update" ] ; then
-    echo "Updating expected results after running the tests needed to create them."
-    PYTHON="_copy " # All python calls are replaced with the local function call.
-  fi
-fi
 
 function log_fail() {
     printf "Error: FAILED integration test (line ${BASH_LINENO}) %s\n" $@
@@ -58,7 +65,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/micronaut-core/micronaut-cor
 JSON_RESULT=$WORKSPACE/output/reports/github_com/micronaut-projects/micronaut-core/micronaut-core.json
 $RUN_MACARON analyze -rp https://github.com/micronaut-projects/micronaut-core -b 3.8.x -d 68f9bb0a78fa930865d37fca39252b9ec66e4a43 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "gitlab.com/tinyMediaManager/tinyMediaManager: Analyzing the repo path and the branch name when automatic dependency resolution is skipped."
@@ -67,7 +74,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/tinyMediaManager/tinyMediaMa
 JSON_RESULT=$WORKSPACE/output/reports/gitlab_com/tinyMediaManager/tinyMediaManager/tinyMediaManager.json
 $RUN_MACARON analyze -rp https://gitlab.com/tinyMediaManager/tinyMediaManager -b main -d cca6b67a335074eca42136556f0a321f75dc4f48 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "jenkinsci/plot-plugin: Analyzing the repo path, the branch name and the commit digest when automatic dependency resolution is skipped."
@@ -76,7 +83,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/plot-plugin/plot-plugin.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/jenkinsci/plot-plugin/plot-plugin.json
 $RUN_MACARON analyze -rp https://github.com/jenkinsci/plot-plugin -b master -d 55b059187e252b35ac0d6cb52268833ee1bb7380 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped."
@@ -87,7 +94,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/urllib3/urllib3/urllib3.json
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/urllib3_PASS.cue
 $RUN_MACARON analyze -pe $EXPECTATION_FILE -rp https://github.com/urllib3/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped."
@@ -98,7 +105,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/urllib3/urllib3/urllib3.json
 EXPECTATION_DIR=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/
 $RUN_MACARON analyze -pe $EXPECTATION_DIR -rp https://github.com/urllib3/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "timyarkov/multibuild_test: Analyzing the repo path, the branch name and the commit digest"
@@ -110,9 +117,9 @@ DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_tim
 DEP_RESULT=$WORKSPACE/output/reports/github_com/timyarkov/multibuild_test/dependencies.json
 $RUN_MACARON analyze -rp https://github.com/timyarkov/multibuild_test -b main -d a8b0efe24298bc81f63217aaa84776c3d48976c5 || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo "timyarkov/docker_test: Analyzing the repo path, the branch name and the commit digest"
 echo "when automatic dependency resolution is skipped, for a project using docker as a build tool."
@@ -121,7 +128,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/docker_test/docker_test.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/timyarkov/docker_test/docker_test.json
 $RUN_MACARON analyze -rp https://github.com/timyarkov/docker_test -b main -d 404a51a2f38c4470af6b32e4e00b5318c2d7c0cc --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "uiv-lib/uiv: Analysing the repo path, the branch name and the commit digest for an npm project,"
@@ -131,7 +138,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/uiv/uiv.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/uiv-lib/uiv/uiv.json
 $RUN_MACARON analyze -rp https://github.com/uiv-lib/uiv -b dev -d 057b25b4db0913edab4cf728c306085e6fc20d49 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "onu-ui/onu-ui: Analysing the repo path, the branch name and the commit digest for a pnpm project,"
@@ -141,7 +148,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/onu-ui/onu-ui.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/onu-ui/onu-ui/onu-ui.json
 $RUN_MACARON analyze -rp https://github.com/onu-ui/onu-ui -b main -d e3f2825c3940002a920d65476116a64684b3d95e --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "facebook/yoga: Analysing the repo path, the branch name and the commit digest for a Yarn classic"
@@ -151,7 +158,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/yoga/yoga.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/facebook/yoga/yoga.json
 $RUN_MACARON analyze -rp https://github.com/facebook/yoga -b main -d f8e2bc0875c145c429d0e865c9b83a40f65b3070 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "wojtekmaj/react-pdf: Analysing the repo path, the branch name and the commit digest for a Yarn modern"
@@ -161,7 +168,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/react-pdf/react-pdf.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/wojtekmaj/react-pdf/react-pdf.json
 $RUN_MACARON analyze -rp https://github.com/wojtekmaj/react-pdf -b main -d be18436b7be827eb993b2e1e4bd9230dd835a9a3 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "sigstore/sget: Analysing the repo path, the branch name and the"
@@ -171,7 +178,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/sget/sget.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/sigstore/sget/sget.json
 $RUN_MACARON analyze -rp https://github.com/sigstore/sget -b main -d 99e7b91204d391ccc76507f7079b6d2a7957489e --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing with PURL and repository path without dependency resolution."
@@ -180,7 +187,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/purl/maven/maven.json
 JSON_RESULT=$WORKSPACE/output/reports/maven/apache/maven/maven.json
 $RUN_MACARON analyze -purl pkg:maven/apache/maven -rp https://github.com/apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing the repo path, the branch name and the commit digest with dependency resolution using cyclonedx maven plugin (default)."
@@ -191,9 +198,9 @@ DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_apa
 DEP_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/dependencies.json
 $RUN_MACARON analyze -rp https://github.com/apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing using a CycloneDx SBOM with target repo path"
@@ -204,7 +211,7 @@ DEP_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/dependencies.json
 
 $RUN_MACARON analyze -rp https://github.com/apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 -sbom "$SBOM_FILE" || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 
 echo -e "\n----------------------------------------------------------------------------------"
@@ -216,7 +223,7 @@ DEP_RESULT=$WORKSPACE/output/reports/private_domain_com/apache/maven/dependencie
 
 $RUN_MACARON analyze -purl pkg:private_domain.com/apache/maven -sbom "$SBOM_FILE" || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 # Analyze micronaut-projects/micronaut-test.
 echo -e "\n=================================================================================="
@@ -230,7 +237,7 @@ echo -e "-----------------------------------------------------------------------
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/skipdep_micronaut-projects_micronaut-test.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/micronaut_test_config.yaml --skip-deps || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 # TODO: uncomment the test below after resolving https://github.com/oracle/macaron/issues/60.
 # echo -e "\n----------------------------------------------------------------------------------"
@@ -257,7 +264,7 @@ $RUN_MACARON analyze -c $WORKSPACE/tests/e2e/configurations/micronaut_test_confi
 
 for i in "${COMPARE_FILES[@]}"
 do
-    python $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
+    check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
 done
 
 # Analyze apache/maven.
@@ -272,7 +279,7 @@ echo -e "-----------------------------------------------------------------------
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/skipdep_apache_maven.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/maven_config.yaml --skip-deps || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Check the e2e output JSON file with config and no dependency analyzing."
@@ -290,7 +297,7 @@ $RUN_MACARON analyze -c $WORKSPACE/tests/e2e/configurations/maven_config.yaml --
 
 for i in "${COMPARE_FILES[@]}"
 do
-    python $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
+    check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
 done
 
 echo -e "\n----------------------------------------------------------------------------------"
@@ -299,7 +306,7 @@ echo -e "-----------------------------------------------------------------------
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_apache_maven.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/maven_config.yaml || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Check: Check the e2e status code of running with invalid branch or digest defined in the yaml configuration."
@@ -328,7 +335,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/maven/maven.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/maven.json
 $RUN_MACARON analyze -rp https://github.com/apache/maven --skip-deps -b master -d 6767f2500f1d005924ccff27f04350c253858a84 -g $WORKSPACE/src/macaron/output_reporter/templates/macaron.html || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 # Analyze FasterXML/jackson-databind.
 echo -e "\n=================================================================================="
@@ -342,7 +349,7 @@ echo -e "-----------------------------------------------------------------------
 JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/jackson-databind/jackson-databind.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/e2e/configurations/jackson_databind_config.yaml --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 # echo -e "\n----------------------------------------------------------------------------------"
 # echo "FasterXML/jackson-databind: Check the resolved dependency output with config for cyclonedx maven plugin (default)."
@@ -351,7 +358,7 @@ $PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 # DEP_RESULT=$WORKSPACE/output/reports/github_com/FasterXML/jackson-databind/dependencies.json
 # $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/jackson_databind_config.yaml || log_fail
 
-# python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+# check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "google/guava: Analyzing with PURL and repository path without dependency resolution."
@@ -360,7 +367,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/purl/com_google_guava/guava/
 JSON_RESULT=$WORKSPACE/output/reports/maven/com_google_guava/guava/guava.json
 $RUN_MACARON analyze -purl pkg:maven/com.google.guava/guava@32.1.2-jre?type=jar -rp https://github.com/google/guava -b master -d d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4 --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 
 # Running Macaron using local paths.
@@ -377,8 +384,8 @@ DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_apa
 DEP_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/dependencies.json
 $RUN_MACARON -lr $WORKSPACE/output/git_repos/github_com analyze -rp apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 || log_fail
 
-$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing with local paths in configuration and without dependency resolution."
@@ -395,7 +402,7 @@ declare -a COMPARE_FILES=(
 $RUN_MACARON -lr $WORKSPACE/output/git_repos/github_com analyze -c $WORKSPACE/tests/e2e/configurations/maven_local_path.yaml --skip-deps || log_fail
 for i in "${COMPARE_FILES[@]}"
 do
-    python $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
+    check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
 done
 
 echo -e "\n----------------------------------------------------------------------------------"
@@ -414,7 +421,7 @@ declare -a COMPARE_FILES=(
 $RUN_MACARON -lr $WORKSPACE/output/git_repos/github_com/ analyze -rp apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 --skip-deps || log_fail
 for i in "${COMPARE_FILES[@]}"
 do
-    python $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
+    check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT_DIR/$i $JSON_EXPECT_DIR/$i || log_fail
 done
 
 echo -e "\n----------------------------------------------------------------------------------"
@@ -586,7 +593,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/slsa-framework/slsa-verifier/sl
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/slsa_verifier_PASS.cue
 $RUN_MACARON analyze -pe $EXPECTATION_FILE -rp https://github.com/slsa-framework/slsa-verifier -b main -d fc50b662fcfeeeb0e97243554b47d9b20b14efac --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped"
@@ -597,7 +604,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/urllib3/urllib3/urllib3.json
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/invalid_expectations/invalid.cue
 $RUN_MACARON analyze -pe $EXPECTATION_FILE -rp https://github.com/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
-$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 # Testing the Souffle policy engine.
 echo -e "\n----------------------------------------------------------------------------------"
@@ -611,7 +618,7 @@ POLICY_EXPECTED=$WORKSPACE/tests/policy_engine/expected_results/policy_report.js
 
 # Run policy engine on the database and compare results.
 $RUN_POLICY -f $POLICY_FILE -d "$WORKSPACE/output/macaron.db" || log_fail
-$PYTHON $COMPARE_POLICIES $POLICY_RESULT $POLICY_EXPECTED || log_fail
+check_or_update_expected_output $COMPARE_POLICIES $POLICY_RESULT $POLICY_EXPECTED || log_fail
 
 if [ $RESULT_CODE -ne 0 ];
 then
@@ -624,7 +631,7 @@ fi
 echo -e "\n----------------------------------------------------------------------------------"
 echo "Testing Repo Finder functionality."
 echo -e "----------------------------------------------------------------------------------\n"
-$PYTHON $TEST_REPO_FINDER || log_fail
+check_or_update_expected_output $TEST_REPO_FINDER || log_fail
 if [ $? -ne 0 ];
 then
     echo -e "Expect zero status code but got $?."

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -11,7 +11,6 @@ COMPARE_DEPS=$WORKSPACE/tests/dependency_analyzer/compare_dependencies.py
 COMPARE_JSON_OUT=$WORKSPACE/tests/e2e/compare_e2e_result.py
 TEST_REPO_FINDER=$WORKSPACE/tests/e2e/repo_finder/repo_finder.py
 RUN_MACARON="python -m macaron -o $WORKSPACE/output"
-PYTHON="python "
 RESULT_CODE=0
 UPDATE=0
 

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -17,26 +17,26 @@ UPDATE=0
 
 # Optional argument for updating the expected results.
 if [ $# -eq 3 ] && [ "$3" == "--update" ] ; then
-  echo "Updating the expected results to match those currently produced by Macaron."
-  UPDATE=1
+    echo "Updating the expected results to match those currently produced by Macaron."
+    UPDATE=1
 fi
 
 function check_or_update_expected_output() {
-  if [ $UPDATE -eq 1 ] ; then
-    # Perform update of expected results by copying over produced output files.
-    # The copy only takes place if sufficient arguments are present.
-    # This function assumes arguments #2 and #3 are files: <actual_result>, <expected_result>.
-    if [ $# -eq 3 ] ; then
-      echo "Copying $2 to $3"
-      cp "$2" "$3"
+    if [ $UPDATE -eq 1 ] ; then
+        # Perform update of expected results by copying over produced output files.
+        # The copy only takes place if sufficient arguments are present.
+        # This function assumes arguments #2 and #3 are files: <actual_result>, <expected_result>.
+        if [ $# -eq 3 ] ; then
+            echo "Copying $2 to $3"
+            cp "$2" "$3"
+        else
+            # Calls with insufficient arguments are ignored to avoid some needless computation during updates.
+            echo "Ignoring $@"
+        fi
     else
-      # Calls with insufficient arguments are ignored to avoid some needless computation during updates.
-      echo "Ignoring $@"
+        # Perform normal operation.
+        python "$@"
     fi
-  else
-    # Perform normal operation.
-    python "$@"
-  fi
 }
 
 function log_fail() {

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -11,7 +11,26 @@ COMPARE_DEPS=$WORKSPACE/tests/dependency_analyzer/compare_dependencies.py
 COMPARE_JSON_OUT=$WORKSPACE/tests/e2e/compare_e2e_result.py
 TEST_REPO_FINDER=$WORKSPACE/tests/e2e/repo_finder/repo_finder.py
 RUN_MACARON="python -m macaron -o $WORKSPACE/output"
+PYTHON="python "
 RESULT_CODE=0
+
+function _copy() {
+  # To replace all python commands when updating results, rather than comparing them.
+  # Note that this function will always attempt to perform a file copy operation on arg #2 and #3, if there are
+  # sufficient arguments.
+  if [ $# -eq 3 ] ; then
+    # Copy arg 2 to arg 3.
+    cp "$2" "$3"
+  fi
+}
+
+# Optional arguments for updating the expected results.
+if [ $# -ge 3 ] ; then
+  if [ $3 == "--update" ] ; then
+    echo "Updating expected results after running the tests needed to create them."
+    PYTHON="_copy " # All python calls are replaced with the local function call.
+  fi
+fi
 
 function log_fail() {
     printf "Error: FAILED integration test (line ${BASH_LINENO}) %s\n" $@
@@ -39,7 +58,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/micronaut-core/micronaut-cor
 JSON_RESULT=$WORKSPACE/output/reports/github_com/micronaut-projects/micronaut-core/micronaut-core.json
 $RUN_MACARON analyze -rp https://github.com/micronaut-projects/micronaut-core -b 3.8.x -d 68f9bb0a78fa930865d37fca39252b9ec66e4a43 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "gitlab.com/tinyMediaManager/tinyMediaManager: Analyzing the repo path and the branch name when automatic dependency resolution is skipped."
@@ -48,7 +67,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/tinyMediaManager/tinyMediaMa
 JSON_RESULT=$WORKSPACE/output/reports/gitlab_com/tinyMediaManager/tinyMediaManager/tinyMediaManager.json
 $RUN_MACARON analyze -rp https://gitlab.com/tinyMediaManager/tinyMediaManager -b main -d cca6b67a335074eca42136556f0a321f75dc4f48 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "jenkinsci/plot-plugin: Analyzing the repo path, the branch name and the commit digest when automatic dependency resolution is skipped."
@@ -57,7 +76,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/plot-plugin/plot-plugin.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/jenkinsci/plot-plugin/plot-plugin.json
 $RUN_MACARON analyze -rp https://github.com/jenkinsci/plot-plugin -b master -d 55b059187e252b35ac0d6cb52268833ee1bb7380 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped."
@@ -68,7 +87,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/urllib3/urllib3/urllib3.json
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/urllib3_PASS.cue
 $RUN_MACARON analyze -pe $EXPECTATION_FILE -rp https://github.com/urllib3/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped."
@@ -79,7 +98,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/urllib3/urllib3/urllib3.json
 EXPECTATION_DIR=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/
 $RUN_MACARON analyze -pe $EXPECTATION_DIR -rp https://github.com/urllib3/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "timyarkov/multibuild_test: Analyzing the repo path, the branch name and the commit digest"
@@ -91,9 +110,9 @@ DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_tim
 DEP_RESULT=$WORKSPACE/output/reports/github_com/timyarkov/multibuild_test/dependencies.json
 $RUN_MACARON analyze -rp https://github.com/timyarkov/multibuild_test -b main -d a8b0efe24298bc81f63217aaa84776c3d48976c5 || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo "timyarkov/docker_test: Analyzing the repo path, the branch name and the commit digest"
 echo "when automatic dependency resolution is skipped, for a project using docker as a build tool."
@@ -102,7 +121,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/docker_test/docker_test.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/timyarkov/docker_test/docker_test.json
 $RUN_MACARON analyze -rp https://github.com/timyarkov/docker_test -b main -d 404a51a2f38c4470af6b32e4e00b5318c2d7c0cc --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "uiv-lib/uiv: Analysing the repo path, the branch name and the commit digest for an npm project,"
@@ -112,7 +131,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/uiv/uiv.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/uiv-lib/uiv/uiv.json
 $RUN_MACARON analyze -rp https://github.com/uiv-lib/uiv -b dev -d 057b25b4db0913edab4cf728c306085e6fc20d49 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "onu-ui/onu-ui: Analysing the repo path, the branch name and the commit digest for a pnpm project,"
@@ -122,7 +141,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/onu-ui/onu-ui.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/onu-ui/onu-ui/onu-ui.json
 $RUN_MACARON analyze -rp https://github.com/onu-ui/onu-ui -b main -d e3f2825c3940002a920d65476116a64684b3d95e --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "facebook/yoga: Analysing the repo path, the branch name and the commit digest for a Yarn classic"
@@ -132,7 +151,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/yoga/yoga.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/facebook/yoga/yoga.json
 $RUN_MACARON analyze -rp https://github.com/facebook/yoga -b main -d f8e2bc0875c145c429d0e865c9b83a40f65b3070 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "wojtekmaj/react-pdf: Analysing the repo path, the branch name and the commit digest for a Yarn modern"
@@ -142,7 +161,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/react-pdf/react-pdf.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/wojtekmaj/react-pdf/react-pdf.json
 $RUN_MACARON analyze -rp https://github.com/wojtekmaj/react-pdf -b main -d be18436b7be827eb993b2e1e4bd9230dd835a9a3 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "sigstore/sget: Analysing the repo path, the branch name and the"
@@ -152,7 +171,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/sget/sget.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/sigstore/sget/sget.json
 $RUN_MACARON analyze -rp https://github.com/sigstore/sget -b main -d 99e7b91204d391ccc76507f7079b6d2a7957489e --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing with PURL and repository path without dependency resolution."
@@ -161,7 +180,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/purl/maven/maven.json
 JSON_RESULT=$WORKSPACE/output/reports/maven/apache/maven/maven.json
 $RUN_MACARON analyze -purl pkg:maven/apache/maven -rp https://github.com/apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing the repo path, the branch name and the commit digest with dependency resolution using cyclonedx maven plugin (default)."
@@ -172,9 +191,9 @@ DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_apa
 DEP_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/dependencies.json
 $RUN_MACARON analyze -rp https://github.com/apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing using a CycloneDx SBOM with target repo path"
@@ -185,7 +204,7 @@ DEP_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/dependencies.json
 
 $RUN_MACARON analyze -rp https://github.com/apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 -sbom "$SBOM_FILE" || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 
 echo -e "\n----------------------------------------------------------------------------------"
@@ -197,7 +216,7 @@ DEP_RESULT=$WORKSPACE/output/reports/private_domain_com/apache/maven/dependencie
 
 $RUN_MACARON analyze -purl pkg:private_domain.com/apache/maven -sbom "$SBOM_FILE" || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 # Analyze micronaut-projects/micronaut-test.
 echo -e "\n=================================================================================="
@@ -211,7 +230,7 @@ echo -e "-----------------------------------------------------------------------
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/skipdep_micronaut-projects_micronaut-test.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/micronaut_test_config.yaml --skip-deps || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 # TODO: uncomment the test below after resolving https://github.com/oracle/macaron/issues/60.
 # echo -e "\n----------------------------------------------------------------------------------"
@@ -253,7 +272,7 @@ echo -e "-----------------------------------------------------------------------
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/skipdep_apache_maven.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/maven_config.yaml --skip-deps || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Check the e2e output JSON file with config and no dependency analyzing."
@@ -280,7 +299,7 @@ echo -e "-----------------------------------------------------------------------
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_apache_maven.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/dependency_analyzer/configurations/maven_config.yaml || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Check: Check the e2e status code of running with invalid branch or digest defined in the yaml configuration."
@@ -309,7 +328,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/maven/maven.json
 JSON_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/maven.json
 $RUN_MACARON analyze -rp https://github.com/apache/maven --skip-deps -b master -d 6767f2500f1d005924ccff27f04350c253858a84 -g $WORKSPACE/src/macaron/output_reporter/templates/macaron.html || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 # Analyze FasterXML/jackson-databind.
 echo -e "\n=================================================================================="
@@ -323,7 +342,7 @@ echo -e "-----------------------------------------------------------------------
 JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/jackson-databind/jackson-databind.json
 $RUN_MACARON analyze -c $WORKSPACE/tests/e2e/configurations/jackson_databind_config.yaml --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 # echo -e "\n----------------------------------------------------------------------------------"
 # echo "FasterXML/jackson-databind: Check the resolved dependency output with config for cyclonedx maven plugin (default)."
@@ -341,7 +360,7 @@ JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/purl/com_google_guava/guava/
 JSON_RESULT=$WORKSPACE/output/reports/maven/com_google_guava/guava/guava.json
 $RUN_MACARON analyze -purl pkg:maven/com.google.guava/guava@32.1.2-jre?type=jar -rp https://github.com/google/guava -b master -d d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4 --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 
 # Running Macaron using local paths.
@@ -358,8 +377,8 @@ DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/cyclonedx_apa
 DEP_RESULT=$WORKSPACE/output/reports/github_com/apache/maven/dependencies.json
 $RUN_MACARON -lr $WORKSPACE/output/git_repos/github_com analyze -rp apache/maven -b master -d 6767f2500f1d005924ccff27f04350c253858a84 || log_fail
 
-python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing with local paths in configuration and without dependency resolution."
@@ -567,7 +586,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/slsa-framework/slsa-verifier/sl
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/slsa_verifier_PASS.cue
 $RUN_MACARON analyze -pe $EXPECTATION_FILE -rp https://github.com/slsa-framework/slsa-verifier -b main -d fc50b662fcfeeeb0e97243554b47d9b20b14efac --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped"
@@ -578,7 +597,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/urllib3/urllib3/urllib3.json
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/invalid_expectations/invalid.cue
 $RUN_MACARON analyze -pe $EXPECTATION_FILE -rp https://github.com/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
-python $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
+$PYTHON $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
 # Testing the Souffle policy engine.
 echo -e "\n----------------------------------------------------------------------------------"
@@ -592,7 +611,7 @@ POLICY_EXPECTED=$WORKSPACE/tests/policy_engine/expected_results/policy_report.js
 
 # Run policy engine on the database and compare results.
 $RUN_POLICY -f $POLICY_FILE -d "$WORKSPACE/output/macaron.db" || log_fail
-python $COMPARE_POLICIES $POLICY_RESULT $POLICY_EXPECTED || log_fail
+$PYTHON $COMPARE_POLICIES $POLICY_RESULT $POLICY_EXPECTED || log_fail
 
 if [ $RESULT_CODE -ne 0 ];
 then
@@ -605,7 +624,7 @@ fi
 echo -e "\n----------------------------------------------------------------------------------"
 echo "Testing Repo Finder functionality."
 echo -e "----------------------------------------------------------------------------------\n"
-python $TEST_REPO_FINDER || log_fail
+$PYTHON $TEST_REPO_FINDER || log_fail
 if [ $? -ne 0 ];
 then
     echo -e "Expect zero status code but got $?."


### PR DESCRIPTION
This PR aims to provide a way of automatically updating the expected results used by the integration tests, closing #542.

The initial implementation achieves this by replacing all `python` commands with a variable that can be overridden when the integration test script is passed a specific third argument, thereby performing a copy operation on the two file arguments that would otherwise be compared. At the current time, this avoids performing copy operations on other possible `python` commands by relying on the fact that only comparison commands use three arguments, with arguments 2 and 3 being files.

Usage:

1. Run the integration tests as usual.
2. Verify any differences between Macaron output and expected results are legitimate.
3. Run updater to replace outdated expected files.

Command: 
`make integration-tests-update`