### PR TITLE
chore: resolve doctest issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ minversion = "7.0"
 addopts = "--verbose --doctest-modules -ra --cov macaron"  # Consider adding --pdb
 doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [
+    "src/macaron",  # this is included to run doctest on examples
     "tests",
 ]
 env = [

--- a/src/macaron/config/defaults.py
+++ b/src/macaron/config/defaults.py
@@ -65,7 +65,7 @@ class ConfigParser(configparser.ConfigParser):
         --------
         Given the following ``defaults.ini``
 
-        .. code-block::
+        .. code-block:: ini
 
             [git]
             allowed_hosts =
@@ -73,8 +73,10 @@ class ConfigParser(configparser.ConfigParser):
                 boo.com gitlab.com
                 host com
 
-        >>> config_parser.get_list("git", "allowed_hosts")
-        ['github.com', 'boo.com gitlab.com', 'host com']
+        .. code-block:: python3
+
+            allowed_hosts = config_parser.get_list("git", "allowed_hosts")
+            # allowed_hosts == ['github.com', 'boo.com gitlab.com', 'host com']
         """
         try:
             value = self.get(section, item)

--- a/src/macaron/output_reporter/jinja2_extensions.py
+++ b/src/macaron/output_reporter/jinja2_extensions.py
@@ -118,14 +118,13 @@ def j2_filter_get_flatten_dict(data: Any, has_key: bool = False) -> dict | Any:
     Examples
     --------
     >>> j2_filter_get_flatten_dict(
-        {
-            "A": [1,2,3],
-            "B": {
-                "C": ["blah", "bar", "foo"]
-            }
-        }
-    )
-    {'A': {'0': 1, '1': 2, '2': 3}, 'B': {'C': {'0': 'blah', '1': 'bar', '2': 'foo'}}}
+    ... {
+    ...     "A": [1, 2, 3],
+    ...     "B": {
+    ...         "C": ["blah", "bar", "foo"],
+    ...     },
+    ... })
+    {'A': {0: 1, 1: 2, 2: 3}, 'B': {'C': {0: 'blah', 1: 'bar', 2: 'foo'}}}
     """
     if isinstance(data, (str, int, bool, float)):
         if has_key:

--- a/src/macaron/output_reporter/results.py
+++ b/src/macaron/output_reporter/results.py
@@ -98,8 +98,15 @@ class Record(Generic[RecordNode]):
 
         Examples
         --------
-        >>> record.get_summary()
-        {'id': 'apache/maven', 'description': 'Analysis completed', 'report': 'apache.html', 'status': SCMStatus.AVAILABLE}
+        .. code-block:: python3
+
+            summary = record.get_summary()
+            # summary == {
+            #     'id': 'apache/maven',
+            #     'description': 'Analysis completed',
+            #     'report': 'apache.html',
+            #     'status': SCMStatus.AVAILABLE,
+            # }
         """
         return {
             "id": self.record_id,

--- a/src/macaron/output_reporter/results.py
+++ b/src/macaron/output_reporter/results.py
@@ -98,15 +98,23 @@ class Record(Generic[RecordNode]):
 
         Examples
         --------
-        .. code-block:: python3
-
-            summary = record.get_summary()
-            # summary == {
-            #     'id': 'apache/maven',
-            #     'description': 'Analysis completed',
-            #     'report': 'apache.html',
-            #     'status': SCMStatus.AVAILABLE,
-            # }
+        >>> from pprint import pprint
+        >>> from macaron.config.target_config import Configuration
+        >>> from macaron.output_reporter.scm import SCMStatus
+        >>> from macaron.output_reporter.results import Record
+        >>> record = Record(
+        ...     record_id="apache/maven",
+        ...     description="Analysis completed",
+        ...     pre_config=Configuration({}),
+        ...     status=SCMStatus.MISSING_SCM,
+        ...     context=None,
+        ...     dependencies=[],
+        ... )
+        >>> pprint(record.get_summary())
+        {'description': 'Analysis completed',
+         'id': 'apache/maven',
+         'repo_url_status': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
+         'report': ''}
         """
         return {
             "id": self.record_id,

--- a/src/macaron/policy_engine/souffle_code_generator.py
+++ b/src/macaron/policy_engine/souffle_code_generator.py
@@ -95,8 +95,11 @@ def table_to_declaration(table: Table) -> str:
 
     Examples
     --------
-    >>> tbl = Table("example", Column("id", Integer), Column("hello", String)
-    >>> assert table_to_declaration(tbl) == '.decl "example" (id: number, hello: symbol)'
+    >>> from sqlalchemy import Column, MetaData, Table
+    >>> from sqlalchemy.sql.sqltypes import Boolean, Integer, String, Text
+    >>> metadata = MetaData()
+    >>> tbl = Table("_example", metadata, Column("id", Integer, nullable=False), Column("hello", String))
+    >>> assert table_to_declaration(tbl) == '.decl example (id: number, hello: symbol)'
 
     Parameters
     ----------

--- a/src/macaron/slsa_analyzer/git_service/api_client.py
+++ b/src/macaron/slsa_analyzer/git_service/api_client.py
@@ -193,10 +193,12 @@ class GhAPIClient(BaseAPIClient):
         The following call to this method will perform a query to
         ``https://api.github.com/repos/owner/repo/actions/workflows/build.yml``
 
-        >>> gh_client.get_repo_workflow_data(
-            full_name="owner/repo",
-            workflow_name="build.yml"
-        )
+        .. code-block: python3
+
+            gh_client.get_repo_workflow_data(
+                full_name="owner/repo",
+                workflow_name="build.yml",
+            )
         """
         logger.debug("Query for %s workflow in repo %s", workflow_name, full_name)
         url = f"{GhAPIClient._REPO_END_POINT}/{full_name}/actions/workflows/{workflow_name}"
@@ -239,12 +241,14 @@ class GhAPIClient(BaseAPIClient):
         ``https://api.github/com/repos/owner/repo/actions/runs?1&branch=master&created=>=
         2022-03-11T16:44:40Z&per_page=100``
 
-        >>> gh_client.get_workflow_runs(
-            full_name="owner/repo",
-            branch_name="master",
-            created_after="2022-03-11T16:44:40Z",
-            page=1
-        )
+        .. code-block: python3
+
+            gh_client.get_workflow_runs(
+                full_name="owner/repo",
+                branch_name="master",
+                created_after="2022-03-11T16:44:40Z",
+                page=1,
+            )
         """
         logger.debug("Query for runs data in repo %s", full_name)
         query_params: dict = {
@@ -290,10 +294,12 @@ class GhAPIClient(BaseAPIClient):
         ``https://api.github/com/repos/{full_name}/
         actions/runs/<run_id>/jobs``
 
-        >>> gh_client.get_workflow_run_jobs(
-            full_name="owner/repo",
-            run_id=<run_id>
-        )
+        .. code-block: python3
+
+            gh_client.get_workflow_run_jobs(
+                full_name="owner/repo",
+                run_id=<run_id>,
+            )
         """
         logger.debug("Query GitHub to get run jobs for %s with run ID %s", full_name, run_id)
 
@@ -325,10 +331,12 @@ class GhAPIClient(BaseAPIClient):
         The following call to this method will perform a query to
         ``https://api.github/com/repos/owner/repo/actions/runs?created=2022-11-05T20:38:40..2022-11-05T20:38:58``
 
-        >>> e.g., gh_client.get_workflow_run_for_date_time_range(
-            full_name="owner/repo",
-            created=2022-11-05T20:38:40..2022-11-05T20:38:58
-        )
+        .. code-block: python3
+
+            gh_client.get_workflow_run_for_date_time_range(
+                full_name="owner/repo",
+                created=2022-11-05T20:38:40..2022-11-05T20:38:58,
+            )
         """
         logger.debug("Query GitHub to get run details for %s at %s", full_name, datetime_range)
         query_params = {"created": datetime_range}
@@ -362,10 +370,12 @@ class GhAPIClient(BaseAPIClient):
         The following call to this method will perform a query to:
         ``https://api.github.com/repos/owner/repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e``
 
-        >>> gh_client.get_commit_data_from_hash(
-            full_name="owner/repo",
-            commit_hash="6dcb09b5b57875f334f61aebed695e2e4193db5e"
-        )
+        .. code-block:: python3
+
+            gh_client.get_commit_data_from_hash(
+                full_name="owner/repo",
+                commit_hash="6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            )
         """
         logger.debug("Query for commit %s 's data in repo %s", commit_hash, full_name)
         url = f"{GhAPIClient._REPO_END_POINT}/{full_name}/commits/{commit_hash}"
@@ -396,10 +406,12 @@ class GhAPIClient(BaseAPIClient):
         The following call to this method will perform a query to:
         ``https://api.github.com/search/code?q=addClass+in:file+language:js+repo:jquery/jquery``
 
-        >>> gh_client.search(
-            target="repositories",
-            query="q=addClass+in:file+language:js+repo:jquery/jquery"
-        )
+        .. code-block:: python3
+
+            gh_client.search(
+                target="repositories",
+                query="q=addClass+in:file+language:js+repo:jquery/jquery",
+            )
         """
         logger.debug("Search %s with query: %s", target, query)
         url = f"{GhAPIClient._SEARCH_END_POINT}/{target}?{query}"
@@ -457,7 +469,9 @@ class GhAPIClient(BaseAPIClient):
         --------
         To get the repo data from repository ``apache/maven``:
 
-        >>> gh_client.get_repo_data("apache/maven")
+        .. code-block:: python3
+
+            gh_client.get_repo_data("apache/maven")
         """
         logger.debug("Get data of repository %s", full_name)
         url = f"{GhAPIClient._REPO_END_POINT}/{full_name}"
@@ -488,7 +502,8 @@ class GhAPIClient(BaseAPIClient):
 
         Examples
         --------
-        >>> get_files_link("owner/repo", "5aaaaa43caabbdbc26c254df8f3aaa7bb3f4ec01", ".travis_ci.yml")
+        >>> api_client = GhAPIClient(profile={"headers": "", "query": []})
+        >>> api_client.get_file_link("owner/repo", "5aaaaa43caabbdbc26c254df8f3aaa7bb3f4ec01", ".travis_ci.yml")
         'https://github.com/owner/repo/blob/5aaaaa43caabbdbc26c254df8f3aaa7bb3f4ec01/.travis_ci.yml'
         """
         return f"https://github.com/{full_name}/blob/{commit_sha}/{file_path}"
@@ -508,6 +523,7 @@ class GhAPIClient(BaseAPIClient):
 
         Examples
         --------
+        >>> api_client = GhAPIClient(profile={"headers": "", "query": []})
         >>> api_client.get_relative_path_of_workflow("build.yaml")
         '.github/workflows/build.yaml'
         """

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -348,7 +348,10 @@ def get_repo_complete_name_from_url(url: str) -> str:
 
     Examples
     --------
-    >>> get_repo_complete_name_from_url("github.com/apache/maven")
+    >>> from macaron.config.defaults import load_defaults
+    >>> load_defaults("")
+    True
+    >>> get_repo_complete_name_from_url("https://github.com/apache/maven")
     'github.com/apache/maven'
     """
     remote_url = get_remote_vcs_url(url)

--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -291,10 +291,10 @@ class Registry:
 
         Examples
         --------
-        >>> Register._validate_check_id_format("mcn_the_check_name_123")
+        >>> Registry._validate_check_id_format("mcn_the_check_name_123")
         True
 
-        >>> Register._validate_check_id_format("Some_Thing', '', '%(*$)")
+        >>> Registry._validate_check_id_format("Some_Thing', '', '%(*$)")
         False
         """
         if (not isinstance(check_id, str)) or (not Registry._id_format.match(check_id)):

--- a/src/macaron/util.py
+++ b/src/macaron/util.py
@@ -232,7 +232,9 @@ def copy_file_bulk(file_list: list, src_path: str, target_path: str) -> bool:
     --------
     ``file.txt`` will be copied from ``src/foo/bar/file.txt`` to ``target/foo/bar/file.txt``
 
-    >>> copy_file_bulk(['foo/bar/file.txt'], 'src', 'target')
+    .. code-block:: python3
+
+        copy_file_bulk(["foo/bar/file.txt"], "src", "target")
     """
     for file in file_list:
         file_src_path = os.path.join(src_path, file)


### PR DESCRIPTION
While reading through some code, I realized the examples in some docstrings are wrong. These should have been caught by `doctest`.

Currently in `pyproject.toml`, `pytest` is configured as follows:

```toml
[tool.pytest.ini_options]
addopts = "--verbose --doctest-modules -ra --cov macaron"  # Consider adding --pdb
testpaths = [
    "tests",
]
```

Although the `--doctest-modules` flag is enabled, meaning `doctest` should run, `testpaths` is limited to only the `tests` directory. This does not allow `doctest` to pick up the docstring examples in `src/macaron`.

In this PR, I enable `doctest` to discover docstring examples in `src/macaron` as follows:

```diff
testpaths = [
+   "src/macaron",  # this is included to run doctest on examples
    "tests",
]
```

I also fix cases where the example fails `doctest`. There are commonly two reasons why these examples fail:
* Case 1: The example is wrong. One or more of these things happen: the test is syntactically wrong, or the input is wrong, or the output is wrong. In these cases, I fix the example.
* Case 2: The example is only intended to demonstrate how the API looks like, and not how it is actually used and what the corresponding result should be. In addition, the setup required for some of these examples is quite complex (e.g. requires loading a config or making an HTTP request). In these cases, I convert the example from using a Python REPL block, which is what `doctest` picks up, to using a Python code block.