### PR TITLE
docs: treat Sphinx warnings as erros

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Minimal makefile for Sphinx documentation
@@ -6,7 +6,9 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+
+# Treat the warnings as errors.
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
 ]
 docs = [
     "sphinx >=5.3.0,<8.0.0",
-    "sphinx-autodoc-typehints >=1.19.4,<2.0.0",
+    "sphinx-autodoc-typehints >=1.25.2,<2.0.0",
     "sphinx-rtd-theme >=1.0.0,<2.0.0",
     "numpydoc >=1.5.0,<2.0.0",
     "sphinx_tabs >=3.4.1,<4.0.0",


### PR DESCRIPTION
Since this [issue](https://github.com/oracle/macaron/issues/84) in `sphinx-autodoc-typehints` extension is resolved, we don't have any warnings. This PR changes the Sphinx configuration to treat warnings as errors, which helps us to detect documentation issues in CI tests.

This PR also raises the lower bound version of `sphinx-autodoc-typehints` to `1.25.2`, which is currently the latest version, making sure the problematic versions are not used again.