### PR TITLE
chore(deps-dev): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
 # Commitizen enforces semantic and conventional commit messages.
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: 3.5.2
+  rev: v3.13.0
   hooks:
   - id: commitizen
     name: Check conventional commit message
@@ -33,13 +33,13 @@ repos:
 
 # Add Black code formatters.
 - repo: https://github.com/ambv/black
-  rev: 23.7.0
+  rev: 23.11.0
   hooks:
   - id: black
     name: Format code
     args: [--config, pyproject.toml]
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.15.0
+  rev: 1.16.0
   hooks:
   - id: blacken-docs
     name: Format code in docstrings
@@ -48,7 +48,7 @@ repos:
 
 # Upgrade and rewrite Python idioms.
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.9.0
+  rev: v3.15.0
   hooks:
   - id: pyupgrade
     name: Upgrade code idioms
@@ -58,7 +58,7 @@ repos:
 # Similar to pylint, with a few more/different checks. For more available
 # extensions: https://github.com/DmytroLitvinov/awesome-flake8-extensions
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
     name: Check flake8 issues
@@ -69,7 +69,7 @@ repos:
 
 # Check GitHub Actions workflow files.
 - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-  rev: v1.6.25
+  rev: v1.6.26.11
   hooks:
   - id: actionlint
 
@@ -110,7 +110,7 @@ repos:
 # Enable a whole bunch of useful helper hooks, too.
 # See https://pre-commit.com/hooks.html for more hooks.
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-ast
   - id: check-case-conflict
@@ -151,7 +151,7 @@ repos:
 
 # Check and prettify the configuration files.
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.10.0
+  rev: v2.11.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -185,7 +185,7 @@ repos:
 
 # A linter for Golang
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.53.3
+  rev: v1.55.2
   hooks:
   - id: golangci-lint
 

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -107,7 +107,7 @@ class AnalyzeContext:
             ci_services = self.dynamic_data["ci_services"]
 
             # By default, initialize every key with an empty list.
-            result: dict[str, list[InTotoV01Statement | InTotoV1Statement]] = defaultdict(lambda: [])
+            result: dict[str, list[InTotoV01Statement | InTotoV1Statement]] = defaultdict(list)
             for ci_info in ci_services:
                 result[ci_info["service"].name].extend(payload.statement for payload in ci_info["provenances"])
             package_registry_entries = self.dynamic_data["package_registries"]


### PR DESCRIPTION
This PR updates the `pre-commit` hooks. As part of this update, the  `commitizen` version `3.5.2`, which is causing [this failure](https://github.com/oracle/macaron/actions/runs/7085677573/job/19282408488?pr=562#step:8:21) in the CI is updated to the latest version. This will fix the CI failures. 

This PR also adds the change made by `pyupgrade` after updating the `pre-commit` hook.