### PR TITLE
chore: use GitHub release API to filter possible tag matches

### DIFF
--- a/src/macaron/repo_finder/commit_finder.py
+++ b/src/macaron/repo_finder/commit_finder.py
@@ -12,9 +12,10 @@ from gitdb.exc import BadName
 from packageurl import PackageURL
 from pydriller import Commit, Git
 
+from macaron.config.global_config import global_config
 from macaron.repo_finder import repo_finder_deps_dev
 from macaron.repo_finder.repo_finder import to_domain_from_known_purl_types
-from macaron.slsa_analyzer.git_service import GIT_SERVICES
+from macaron.slsa_analyzer.git_service import GIT_SERVICES, api_client
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class AbstractPurlType(Enum):
     UNSUPPORTED = (2,)
 
 
-def find_commit(git_obj: Git, purl: PackageURL) -> str | None:
+def find_commit(git_obj: Git, purl: PackageURL, git_url: str = "") -> tuple[str, str] | None:
     """Try to find the commit matching the passed PURL.
 
     The PURL may be a repository type, e.g. GitHub, in which case the commit might be in its version part.
@@ -127,11 +128,13 @@ def find_commit(git_obj: Git, purl: PackageURL) -> str | None:
         The repository.
     purl: PackageURL
         The PURL of the analysis target.
+    git_url: str
+        The path to the remote git repository, or an empty string.
 
     Returns
     -------
-    str | None
-        The digest, or None if the commit cannot be correctly retrieved.
+    tuple[str, str] | None
+        The branch name, and tag (if applicable) as a tuple, or None if the commit cannot be retrieved.
     """
     version = purl.version
     if not version:
@@ -140,9 +143,12 @@ def find_commit(git_obj: Git, purl: PackageURL) -> str | None:
 
     repo_type = determine_abstract_purl_type(purl)
     if repo_type == AbstractPurlType.REPOSITORY:
-        return extract_commit_from_version(git_obj, version)
+        digest = extract_commit_from_version(git_obj, version)
+        if not digest:
+            return None
+        return digest, ""
     if repo_type == AbstractPurlType.ARTIFACT:
-        return find_commit_from_version_and_name(git_obj, purl.name, version)
+        return find_commit_from_version_and_name(git_obj, purl.name, version, git_url)
     logger.debug("Type of PURL is not supported for commit finding: %s", purl.type)
     return None
 
@@ -216,7 +222,7 @@ def extract_commit_from_version(git_obj: Git, version: str) -> str | None:
     return commit.hash if commit else None
 
 
-def find_commit_from_version_and_name(git_obj: Git, name: str, version: str) -> str | None:
+def find_commit_from_version_and_name(git_obj: Git, name: str, version: str, git_url: str) -> tuple[str, str] | None:
     """Try to find the matching commit in a repository of a given version (and name) via tags.
 
     The passed version is used to match with the tags in the target repository. The passed name is used in cases where
@@ -230,11 +236,13 @@ def find_commit_from_version_and_name(git_obj: Git, name: str, version: str) -> 
         The name of the analysis target.
     version: str
         The version of the analysis target.
+    git_url: str
+        The path to the remote gif repository, or an empty string.
 
     Returns
     -------
-    str | None
-        The digest, or None if the commit cannot be correctly retrieved.
+    tuple[str, str] | None
+        The digest, and tag (if it is a release tag) as a tuple, or None if the commit cannot be retrieved.
     """
     logger.debug("Searching for commit of artifact version using tags: %s@%s", name, version)
 
@@ -253,8 +261,33 @@ def find_commit_from_version_and_name(git_obj: Git, name: str, version: str) -> 
         logger.debug("No tags with commits found for %s", name)
         return None
 
-    # Match tags.
-    matched_tags = match_tags(list(valid_tags.keys()), name, version)
+    # Try to filter tags based on what exists in the GitHub releases API.
+    release_tags = {}
+    if git_url:
+        client = api_client.get_default_gh_client(global_config.gh_token)
+        split = git_url.split("/")
+        releases = client.get_all_releases(f"{split[-2]}/{split[-1]}")
+        for release in releases:
+            release_tags[release["name"]] = release["tag_name"]
+
+    matched_tags = []
+    if release_tags:
+        # Try to match using release tags.
+        filtered_tags = {}
+        filtered_keys = filter(lambda _key: _key in release_tags, valid_tags.keys())
+        for key in filtered_keys:
+            filtered_tags[key] = valid_tags[key]
+        if filtered_tags:
+            matched_tags = match_tags(list(filtered_tags.keys()), name, version)
+        if not matched_tags:
+            # Try to match using release names. Here we assume that the tag name is similar to the target version
+            # while the connected tag is not. Names are mapped back to actual tags after matching has taken place.
+            matched_names = match_tags(list(release_tags.keys()), name, version)
+            matched_tags = [release_tags[matched_name] for matched_name in matched_names]
+
+    if not matched_tags:
+        # Try to match using all tags if nothing matched so far.
+        matched_tags = match_tags(list(valid_tags.keys()), name, version)
 
     if not matched_tags:
         logger.debug("No tags matched for %s", name)
@@ -284,7 +317,14 @@ def find_commit_from_version_and_name(git_obj: Git, name: str, version: str) -> 
         name,
         version,
     )
-    return hexsha if hexsha else None
+
+    if not hexsha:
+        return None
+
+    release_tag_name = ""
+    if release_tags and (tag_name in release_tags.values() or tag_name in release_tags):
+        release_tag_name = tag_name
+    return hexsha, release_tag_name
 
 
 def _build_version_pattern(name: str, version: str) -> tuple[Pattern | None, list[str]]:

--- a/src/macaron/slsa_analyzer/git_service/api_client.py
+++ b/src/macaron/slsa_analyzer/git_service/api_client.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The module provides API clients for VCS services, such as GitHub."""
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Sequence
 from enum import Enum
@@ -65,6 +66,21 @@ class BaseAPIClient:
             The latest release object in JSON format.
         """
         return {}
+
+    def get_all_releases(self, full_name: str) -> list:  # pylint: disable=unused-argument
+        """Return all releases for the repo.
+
+        Parameters
+        ----------
+        full_name: str
+            The full name of the repo.
+
+        Returns
+        -------
+        list
+            The releases in JSON format.
+        """
+        return []
 
     def fetch_assets(self, release: dict, ext: str = "") -> Sequence[AssetLocator]:  # pylint: disable=unused-argument
         """Return the release assets that match or empty if it doesn't exist.
@@ -548,6 +564,51 @@ class GhAPIClient(BaseAPIClient):
         response_data = send_get_http(url, self.headers)
 
         return response_data or {}
+
+    def get_all_releases(self, full_name: str) -> list:
+        """Return all releases for the repo.
+
+        Parameters
+        ----------
+        full_name : str
+            The full name of the repo.
+
+        Returns
+        -------
+        list
+            The list of releases in JSON format.
+
+        Note that this can only return the first 1000 results at most.
+        This is not detailed in the documentation, but can be discovered when trying to retrieve more than 1000.
+        Documentation: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
+        """
+        logger.debug("Get all releases for %s.", full_name)
+        url = f"{GhAPIClient._REPO_END_POINT}/{full_name}/releases"
+        page = 0
+        releases = []
+        while True:
+            response = send_get_http_raw(f"{url}?per_page=100&page={page}", self.headers)
+            if not response:
+                break
+
+            if response.text == "[]":
+                # An "empty" response can occur when the release limit has been reached.
+                break
+
+            try:
+                release_data = json.loads(response.text)
+            except ValueError as error:
+                logger.debug("Failed to parse response data: %s", error)
+                return []
+
+            for entry in release_data:
+                releases.append(entry)
+
+            if not response.links:
+                break
+            page = page + 1
+
+        return releases
 
     def fetch_assets(self, release: dict, ext: str = "") -> Sequence[AssetLocator]:
         """Return the release assets that match or empty if it doesn't exist.

--- a/tests/repo_finder/test_commit_finder.py
+++ b/tests/repo_finder/test_commit_finder.py
@@ -145,35 +145,42 @@ def test_commit_finder() -> None:
     assert not commit_finder.find_commit(git_obj, PackageURL.from_string("pkg:maven/apache/maven@1"))
 
     # Valid repository PURL.
-    digest = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:github/apache/maven@{commit_0.hexsha}"))
-    assert digest == commit_0.hexsha
+    result = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:github/apache/maven@{commit_0.hexsha}"))
+    assert result
+    assert result[0] == commit_0.hexsha
 
     # Valid artifact PURL.
-    digest = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version}"))
-    assert digest == commit_0.hexsha
+    result = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version}"))
+    assert result
+    assert result[0] == commit_0.hexsha
 
     # Valid artifact PURL with an alphanumeric suffix.
-    digest = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version}-RC1"))
-    assert digest == commit_0.hexsha
+    result = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version}-RC1"))
+    assert result
+    assert result[0] == commit_0.hexsha
 
     # Valid artifact PURL that should match a tag with a name prefix.
-    digest = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/prefix_name@{tag_version}"))
-    assert digest == empty_commit.hexsha
+    result = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/prefix_name@{tag_version}"))
+    assert result
+    assert result[0] == empty_commit.hexsha
 
     # Valid artifact PURL that matches a version with a suffix, to a tag with the same suffix.
-    digest = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version_2}-DEV"))
-    assert digest == empty_commit.hexsha
+    result = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version_2}-DEV"))
+    assert result
+    assert result[0] == empty_commit.hexsha
 
     # Valid artifact PURL that matches a version with a suffix, to a tag with the same suffix part in a multi-suffix.
-    digest = commit_finder.find_commit(
+    result = commit_finder.find_commit(
         git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version_2}_RELEASE")
     )
-    assert digest == empty_commit.hexsha
+    assert result
+    assert result[0] == empty_commit.hexsha
 
     # Valid artifact PURL that matches a version with an alphanumeric suffix, to a tag with the same suffix part in a
     # multi-suffix.
-    digest = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version_2}_RC1"))
-    assert digest == empty_commit.hexsha
+    result = commit_finder.find_commit(git_obj, PackageURL.from_string(f"pkg:maven/apache/maven@{tag_version_2}_RC1"))
+    assert result
+    assert result[0] == empty_commit.hexsha
 
 
 @given(text())


### PR DESCRIPTION
Closes #537 

The GitHub API is called when finding commits for artefacts to retrieve release information in cases where an analysis target has a corresponding GitHub URL. These results are limited to the first 1000 instances by the API. The information retrieved includes two key properties: release name, and release tag. 

The release tags retrieved via the API call can be used to filter down the list of all tags, thereby eliminating potentially spurious entries before the regular expression matching takes place. If that fails, the release names can instead be used as the list of tags for the same purpose, with the linked tag (in the API information) being returned in the case of a successful match. If that also fails, the behaviour is as it was before this change was added, i.e. all repository tags are used for the matching.