### PR TITLE
chore: explicitly git init with the `master` branch in tests requiring it

### DIFF
--- a/tests/repo_finder/test_commit_finder.py
+++ b/tests/repo_finder/test_commit_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module tests the commit finder."""
@@ -91,7 +91,12 @@ def test_commit_finder() -> None:
     """Test commit finder using mocked repository."""
     if os.path.exists(REPO_DIR):
         shutil.rmtree(REPO_DIR)
-    git_obj = initiate_repo(REPO_DIR)
+    git_obj = initiate_repo(
+        REPO_DIR,
+        git_init_options={
+            "initial_branch": "master",
+        },
+    )
 
     # Create a commit from a newly created file.
     with open(os.path.join(REPO_DIR, "file_1"), "w", encoding="utf-8") as file:

--- a/tests/slsa_analyzer/mock_git_utils.py
+++ b/tests/slsa_analyzer/mock_git_utils.py
@@ -22,8 +22,13 @@ def initiate_repo(repo_path: str | os.PathLike, git_init_options: dict | None = 
 
     Parameters
     ----------
-    repo_path : str or os.PathLike
+    repo_path : str | os.PathLike
         The path to the target repo.
+
+    git_init_options : dict
+        Additional keyword arguments passed to the `git.Repo.init` method.
+        Each key is the name of the argument and each value is the corresponding value
+        for the argument.
 
     Returns
     -------

--- a/tests/slsa_analyzer/mock_git_utils.py
+++ b/tests/slsa_analyzer/mock_git_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """
@@ -15,7 +15,7 @@ from macaron.database.table_definitions import Analysis, Component, Repository
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 
 
-def initiate_repo(repo_path: str | os.PathLike) -> Git:
+def initiate_repo(repo_path: str | os.PathLike, git_init_options: dict | None = None) -> Git:
     """Init the repo at `repo_path` and return a Git wrapper of that repository.
 
     This function will create the directory `repo_path` if it does not exist.
@@ -30,6 +30,8 @@ def initiate_repo(repo_path: str | os.PathLike) -> Git:
     Git
         The wrapper of the Git repository.
     """
+    git_init_options = git_init_options or {}
+
     if not os.path.isdir(repo_path):
         os.makedirs(repo_path)
 
@@ -38,7 +40,7 @@ def initiate_repo(repo_path: str | os.PathLike) -> Git:
         return git_wrapper
     except GitError:
         # No git repo at repo_path
-        git.Repo.init(repo_path)
+        git.Repo.init(repo_path, **git_init_options)
         return Git(repo_path)
 
 


### PR DESCRIPTION
Improves a unit test that fails on my machine.

The test fails due to the assumption that `git init` always initializes a repo with the branch `master`. Meanwhile, the git `defaultBranch` configured on my machine is not `master`. I think this git config is quite common since GitHub now defaults to `main` as the main branch.

I also reckon if the test is based on the precondition of "the repo should have a `master` branch", then it'd better be stated explicitly. This fix tries to achieve that.