### PR TITLE
feat: support tox to publish artifacts to PyPI

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 [runner]
@@ -265,6 +265,7 @@ publisher =
     twine
     flit
     conda
+    tox
 # These are the Python interpreters that may be used to load modules.
 interpreter =
     python


### PR DESCRIPTION
This PR adds `tox` as a tool to publish artifacts for Python packages.