### PR TITLE
test(integration): skip comparing Macaron version in VSA test

### DIFF
--- a/tests/vsa/compare_vsa.py
+++ b/tests/vsa/compare_vsa.py
@@ -250,6 +250,9 @@ def main() -> int:
         expected=expected_payload,
         compare_fn_map={
             ".predicate.timeVerified": skip_compare,
+            # We should not compare Macaron version against the snapshot test VSA because the test will
+            # fail once we bump the Macaron version in the next release, failing the automatic release altogether!
+            ".predicate.verifier.version.macaron": skip_compare,
         },
     )
 


### PR DESCRIPTION
This PR fixes an issue in the VSA comparison integration test. We should not compare Macaron version against the snapshot test VSA because the test will fail once we bump the Macaron version in the next release, failing the automatic release altogether!