### PR TITLE
chore: improve build command output

### DIFF
--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -84,6 +84,21 @@ class BuildAsCodeCheck(BaseCheck):
             result_on_skip=CheckResultType.PASSED,
         )
 
+    def _serialize_command(self, cmd: list[str]) -> str:
+        """Convert a list of command-line arguments to a json-encoded string so that it is easily parsable by later consumers.
+
+        Parameters
+        ----------
+        cmd: list[str]
+            List of command-line arguments.
+
+        Returns
+        -------
+        str
+            The list of command-line arguments as a json-encoded string.
+        """
+        return json.dumps(cmd)
+
     def _has_deploy_command(self, commands: list[list[str]], build_tool: BaseBuildTool) -> str:
         """Check if the bash command is a build and deploy command."""
         # Account for Python projects having separate tools for packaging and publishing.
@@ -118,14 +133,14 @@ class BuildAsCodeCheck(BaseCheck):
                 # If there are no deploy args for this build tool, accept as deploy command.
                 # TODO: Support multi-argument build keywords, issue #493.
                 if not build_tool.deploy_arg:
-                    com_str = json.dumps(com)
+                    com_str = self._serialize_command(com)
                     logger.info("No deploy arguments required. Accept %s as deploy command.", com_str)
                     return com_str
 
                 for word in com[(prog_name_index + 1) :]:
                     # TODO: allow plugin versions in arguments, e.g., maven-plugin:1.6.8:deploy.
                     if word in build_tool.deploy_arg:
-                        com_str = json.dumps(com)
+                        com_str = self._serialize_command(com)
                         logger.info("Found deploy command %s.", com_str)
                         return com_str
         return ""

--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -1,8 +1,9 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the BuildAsCodeCheck class."""
 
+import json
 import logging
 import os
 from typing import Any
@@ -117,14 +118,16 @@ class BuildAsCodeCheck(BaseCheck):
                 # If there are no deploy args for this build tool, accept as deploy command.
                 # TODO: Support multi-argument build keywords, issue #493.
                 if not build_tool.deploy_arg:
-                    logger.info("No deploy arguments required. Accept %s as deploy command.", str(com))
-                    return str(com)
+                    com_str = json.dumps(com)
+                    logger.info("No deploy arguments required. Accept %s as deploy command.", com_str)
+                    return com_str
 
                 for word in com[(prog_name_index + 1) :]:
                     # TODO: allow plugin versions in arguments, e.g., maven-plugin:1.6.8:deploy.
                     if word in build_tool.deploy_arg:
-                        logger.info("Found deploy command %s.", str(com))
-                        return str(com)
+                        com_str = json.dumps(com)
+                        logger.info("Found deploy command %s.", com_str)
+                        return com_str
         return ""
 
     def _check_build_tool(

--- a/src/macaron/slsa_analyzer/checks/build_service_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_service_check.py
@@ -75,6 +75,21 @@ class BuildServiceCheck(BaseCheck):
             result_on_skip=CheckResultType.PASSED,
         )
 
+    def _serialize_command(self, cmd: list[str]) -> str:
+        """Convert a list of command-line arguments to a json-encoded string so that it is easily parsable by later consumers.
+
+        Parameters
+        ----------
+        cmd: list[str]
+            List of command-line arguments.
+
+        Returns
+        -------
+        str
+            The list of command-line arguments as a json-encoded string.
+        """
+        return json.dumps(cmd)
+
     def _has_build_command(self, commands: list[list[str]], build_tool: BaseBuildTool) -> str:
         """Check if the bash command is a build command."""
         for com in commands:
@@ -110,13 +125,13 @@ class BuildServiceCheck(BaseCheck):
                 # If there are no build args for this build tool, accept as build command.
                 # TODO: Support multi-argument build keywords, issue #493.
                 if not build_tool.build_arg:
-                    com_str = json.dumps(com)
+                    com_str = self._serialize_command(com)
                     logger.info("No build arguments required. Accept %s as build command.", com_str)
                     return com_str
                 for word in com[(prog_name_index + 1) :]:
                     # TODO: allow plugin versions in arguments, e.g., maven-plugin:1.6.8:package.
                     if word in build_tool.build_arg:
-                        com_str = json.dumps(com)
+                        com_str = self._serialize_command(com)
                         logger.info("Found build command %s.", com_str)
                         return com_str
         return ""

--- a/src/macaron/slsa_analyzer/checks/build_service_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_service_check.py
@@ -1,8 +1,9 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the BuildServiceCheck class."""
 
+import json
 import logging
 import os
 from typing import Any
@@ -109,13 +110,15 @@ class BuildServiceCheck(BaseCheck):
                 # If there are no build args for this build tool, accept as build command.
                 # TODO: Support multi-argument build keywords, issue #493.
                 if not build_tool.build_arg:
-                    logger.info("No build arguments required. Accept %s as build command.", str(com))
-                    return str(com)
+                    com_str = json.dumps(com)
+                    logger.info("No build arguments required. Accept %s as build command.", com_str)
+                    return com_str
                 for word in com[(prog_name_index + 1) :]:
                     # TODO: allow plugin versions in arguments, e.g., maven-plugin:1.6.8:package.
                     if word in build_tool.build_arg:
-                        logger.info("Found build command %s.", str(com))
-                        return str(com)
+                        com_str = json.dumps(com)
+                        logger.info("Found build command %s.", com_str)
+                        return com_str
         return ""
 
     def _check_build_tool(
@@ -189,6 +192,7 @@ class BuildServiceCheck(BaseCheck):
                         BuildServiceFacts(
                             build_tool_name=build_tool.name,
                             build_trigger=trigger_link,
+                            build_command=build_cmd,
                             ci_service_name=ci_service.name,
                         )
                     )


### PR DESCRIPTION
Record build command in build service check, and change encoding of build/deploy commands in build as code and build service checks to json to make it easier to parse later.