### PR TITLE
feat: follow indirect repository URLs

### DIFF
--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -263,10 +263,11 @@ Within the configuration file under the ``repofinder.java`` header, three option
 - ``repo_pom_paths`` (Values: List of POM tags) - Determines where to search for repository information in the POM files. E.g. scm.url.
 - ``find_parents`` (Values: True or False) - When enabled, the Repository Finding feature will also search for repository URLs in parents POM files of the current dependency.
 
-Under the related header ``repofinder``, two more options exist: ``find_repos``, and ``use_open_source_insights``:
+Under the related header ``repofinder``, three more options exist: ``find_repos``, ``use_open_source_insights``, and ``redirect_urls``:
 
 - ``find_repos`` (Values: True or False) - Enables or disables the Repository Finding feature.
 - ``use_open_source_insights`` (Values: True or False) - Enables or disables use of Google's Open Source Insights API.
+- ``redirect_urls`` (Values: List of URLs) - Found URLs that exist in this list will be returned as the URL they redirect to.
 
 .. note:: Finding repositories requires at least one remote call, adding some additional overhead to an analysis run.
 
@@ -279,6 +280,9 @@ An example configuration file for utilising this feature:
     [repofinder]
     find_repos = True
     use_open_source_insights = True
+    redirect_urls =
+        gitbox.apache.org
+        git-wip-us.apache.org
 
     [repofinder.java]
     artifact_repositories = https://repo.maven.apache.org/maven2

--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -267,7 +267,7 @@ Under the related header ``repofinder``, three more options exist: ``find_repos`
 
 - ``find_repos`` (Values: True or False) - Enables or disables the Repository Finding feature.
 - ``use_open_source_insights`` (Values: True or False) - Enables or disables use of Google's Open Source Insights API.
-- ``redirect_urls`` (Values: List of URLs) - Found URLs that exist in this list will be returned as the URL they redirect to.
+- ``redirect_urls`` (Values: List of URLs) - These are URLs that are known to redirect to actual repository URLs.
 
 .. note:: Finding repositories requires at least one remote call, adding some additional overhead to an analysis run.
 

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -51,6 +51,10 @@ recursive = False
 [repofinder]
 find_repos = True
 use_open_source_insights = True
+# The list of URLs that will be returned as the location they redirect to.
+redirect_urls =
+    gitbox.apache.org
+    git-wip-us.apache.org
 
 [repofinder.java]
 # The list of maven-like repositories to attempt to retrieve artifact POMs from.

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -51,7 +51,7 @@ recursive = False
 [repofinder]
 find_repos = True
 use_open_source_insights = True
-# The list of URLs that will be returned as the location they redirect to.
+# These are URLs that are known to redirect to actual repository URLs.
 redirect_urls =
     gitbox.apache.org
     git-wip-us.apache.org

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -629,8 +629,7 @@ def parse_remote_url(
                 redirect_url = response.headers.get("location")
                 if not redirect_url:
                     return None
-                # Pass the redirect_url through this function and prevent loops by setting the redirect parameter to an
-                # empty string.
+                # Pass the redirect_url through this function and prevent loops by setting the redirect flag to False.
                 return parse_remote_url(redirect_url, allowed_git_service_hostnames, False)
 
         if parsed_url.netloc not in allowed_git_service_hostnames:

--- a/tests/dependency_analyzer/cyclonedx/__snapshots__/test_cyclonedx.ambr
+++ b/tests/dependency_analyzer/cyclonedx/__snapshots__/test_cyclonedx.ambr
@@ -377,8 +377,8 @@
       'url': 'https://github.com/apache/commons-codec',
     }),
     'commons-fileupload:commons-fileupload': dict({
-      'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
-      'note': 'Manual configuration required. Could not find SCM URL.',
+      'available': <SCMStatus.AVAILABLE: 'AVAILABLE'>,
+      'note': '',
       'purl': PackageURL(
         name='commons-fileupload',
         namespace='commons-fileupload',
@@ -389,11 +389,11 @@
         type='maven',
         version='1.4',
       ),
-      'url': '',
+      'url': 'https://github.com/apache/commons-fileupload',
     }),
     'commons-io:commons-io': dict({
-      'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
-      'note': 'Manual configuration required. Could not find SCM URL.',
+      'available': <SCMStatus.AVAILABLE: 'AVAILABLE'>,
+      'note': '',
       'purl': PackageURL(
         name='commons-io',
         namespace='commons-io',
@@ -404,7 +404,7 @@
         type='maven',
         version='2.11.0',
       ),
-      'url': '',
+      'url': 'https://github.com/apache/commons-io',
     }),
     'commons-logging:commons-logging': dict({
       'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
@@ -1547,8 +1547,8 @@
       'url': 'https://github.com/JodaOrg/joda-time',
     }),
     'org.apache.commons:commons-compress': dict({
-      'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
-      'note': 'Manual configuration required. Could not find SCM URL.',
+      'available': <SCMStatus.AVAILABLE: 'AVAILABLE'>,
+      'note': '',
       'purl': PackageURL(
         name='commons-compress',
         namespace='org.apache.commons',
@@ -1559,7 +1559,7 @@
         type='maven',
         version='1.21',
       ),
-      'url': '',
+      'url': 'https://github.com/apache/commons-compress',
     }),
     'org.apache.httpcomponents:httpclient': dict({
       'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,

--- a/tests/dependency_analyzer/expected_results/cyclonedx_apache_maven.json
+++ b/tests/dependency_analyzer/expected_results/cyclonedx_apache_maven.json
@@ -29,7 +29,7 @@
     {
         "id": "commons-cli:commons-cli",
         "purl": "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
-        "path": "https://github.com/apache/maven-apache-parent",
+        "path": "https://github.com/apache/commons-cli",
         "branch": "",
         "digest": "",
         "note": "",
@@ -200,7 +200,7 @@
     {
         "id": "commons-io:commons-io",
         "purl": "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
-        "path": "https://github.com/apache/maven-apache-parent",
+        "path": "https://github.com/apache/commons-io",
         "branch": "",
         "digest": "",
         "note": "",

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -292,16 +292,13 @@ def test_parse_git_branch_output_with_random_input(content: str) -> None:
 @pytest.mark.parametrize(
     ("url", "expected"),
     [
-        ("", ""),
+        ("", None),
         ("scm:git:git@github.com:FasterXML/jackson-databind.git", "git@github.com:FasterXML/jackson-databind.git"),
         ("https://github.com/commons-io/commons-io", "https://github.com/commons-io/commons-io"),
-        ("askjdlkajsdlkajsdlkjasldjlk:scm", ""),
+        ("askjdlkajsdlkajsdlkjasldjlk:scm", None),
     ],
 )
-def test_clean_url(url: str, expected: str) -> None:
+def test_clean_url(url: str, expected: str | None) -> None:
     """Test the functionality of the clean_url function."""
     result = git_url.clean_url(url)
-    if result is None:
-        assert expected == ""
-    else:
-        assert expected == result.geturl()
+    assert result.geturl() == expected if result is not None else expected is None

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -292,13 +292,24 @@ def test_parse_git_branch_output_with_random_input(content: str) -> None:
 @pytest.mark.parametrize(
     ("url", "expected"),
     [
-        ("", None),
         ("scm:git:git@github.com:FasterXML/jackson-databind.git", "git@github.com:FasterXML/jackson-databind.git"),
         ("https://github.com/commons-io/commons-io", "https://github.com/commons-io/commons-io"),
-        ("askjdlkajsdlkajsdlkjasldjlk:scm", None),
     ],
 )
-def test_clean_url(url: str, expected: str | None) -> None:
-    """Test the functionality of the clean_url function."""
+def test_clean_url_valid_input(url: str, expected: str) -> None:
+    """Test that the clean_url function correctly returns the expected URL for valid input."""
     result = git_url.clean_url(url)
-    assert result.geturl() == expected if result is not None else expected is None
+    assert result is not None
+    assert result.geturl() == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "askjdlkajsdlkajsdlkjasldjlk:scm",
+    ],
+)
+def test_clean_url_invalid_input(url: str) -> None:
+    """Test that the clean_url function correctly returns None for invalid input."""
+    assert git_url.clean_url(url) is None

--- a/tests/slsa_analyzer/test_git_url.py
+++ b/tests/slsa_analyzer/test_git_url.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module tests the generic actions on Git repositories."""
@@ -287,3 +287,21 @@ def test_parse_git_branch_output(content: str, expected_output: list[str]) -> No
 def test_parse_git_branch_output_with_random_input(content: str) -> None:
     """Test the parse git branch output function using random text input."""
     git_url.parse_git_branch_output(content)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("", ""),
+        ("scm:git:git@github.com:FasterXML/jackson-databind.git", "git@github.com:FasterXML/jackson-databind.git"),
+        ("https://github.com/commons-io/commons-io", "https://github.com/commons-io/commons-io"),
+        ("askjdlkajsdlkajsdlkjasldjlk:scm", ""),
+    ],
+)
+def test_clean_url(url: str, expected: str) -> None:
+    """Test the functionality of the clean_url function."""
+    result = git_url.clean_url(url)
+    if result is None:
+        assert expected == ""
+    else:
+        assert expected == result.geturl()


### PR DESCRIPTION
This PR allows the Repo Finder to return GitHub, etc. URLs that are initially presented as a redirect URL. URLs that can be considered valid redirects are included within a list in the defaults configuration file. URLs found from redirects are validated as per any other URL. A flag is used to prevent infinite redirect loop shenanigans.

Closes #626 