### PR TITLE
feat: discover slsa v1 provenances for npm packages

### DIFF
--- a/src/macaron/slsa_analyzer/package_registry/npm_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/npm_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The module provides abstractions for the npm package registry."""
@@ -135,9 +135,10 @@ class NPMRegistry(PackageRegistry):
         * SLSA with "https://slsa.dev/provenance/v0.2" predicateType
         * SLSA with "https://slsa.dev/provenance/v1" predicateType
 
-        For now we download the SLSA provenance v0.2 in this method.
+        For now we download the SLSA provenance v0.2 or v1 in this method.
 
-        Here is an example SLSA v0.2 provenance: https://registry.npmjs.org/-/npm/v1/attestations/@sigstore/mock@0.1.0
+        An example SLSA v0.2 provenance: https://registry.npmjs.org/-/npm/v1/attestations/@sigstore/mock@0.1.0
+        An example SLSA v1 provenance: https://registry.npmjs.org/-/npm/v1/attestations/@sigstore/mock@0.6.3
 
         Parameters
         ----------
@@ -174,7 +175,7 @@ class NPMRegistry(PackageRegistry):
             if not att.get("predicateType"):
                 logger.debug("predicateType attribute is missing for %s", url)
                 continue
-            if att.get("predicateType") != "https://slsa.dev/provenance/v0.2":
+            if att.get("predicateType") not in ["https://slsa.dev/provenance/v0.2", "https://slsa.dev/provenance/v1"]:
                 logger.debug("predicateType %s is not accepted. Skipping...", att.get("predicateType"))
                 continue
             if not (bundle := att.get("bundle")):

--- a/src/macaron/slsa_analyzer/provenance/intoto/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """In-toto provenance schemas and validation."""
@@ -69,10 +69,6 @@ InTotoPayload = InTotoV01Payload | InTotoV1Payload
 def validate_intoto_payload(payload: dict[str, JsonType]) -> InTotoPayload:
     """Validate the schema of an in-toto provenance payload.
 
-    TODO: Consider using the in-toto-attestation package (https://github.com/in-toto/attestation/tree/main/python),
-    which contains Python bindings for in-toto attestation.
-    See issue: https://github.com/oracle/macaron/issues/426.
-
     Parameters
     ----------
     payload : dict[str, JsonType]
@@ -110,6 +106,16 @@ def validate_intoto_payload(payload: dict[str, JsonType]) -> InTotoPayload:
         except ValidateInTotoPayloadError as error:
             raise error
 
-    # TODO: add support for version 1.
+    if type_ == "https://in-toto.io/Statement/v1":
+        # The type must always be this value for version v1.
+        # See specification: https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md.
+
+        try:
+            if v1.validate_intoto_statement(payload):
+                return InTotoV1Payload(statement=payload)
+
+            raise ValidateInTotoPayloadError("Unexpected error while validating the in-toto statement.")
+        except ValidateInTotoPayloadError as error:
+            raise error
 
     raise ValidateInTotoPayloadError("Invalid value for the attribute '_type' of the provenance payload.")

--- a/src/macaron/slsa_analyzer/provenance/intoto/v01/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v01/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module handles in-toto version 0.1 attestations."""
@@ -39,10 +39,6 @@ def validate_intoto_statement(payload: dict[str, JsonType]) -> TypeGuard[InTotoV
 
     Specification: https://github.com/in-toto/attestation/tree/main/spec/v0.1.0#statement.
 
-    TODO: Consider using the in-toto-attestation package (https://github.com/in-toto/attestation/tree/main/python),
-    which contains Python bindings for in-toto attestation.
-    See issue: https://github.com/oracle/macaron/issues/426.
-
     Parameters
     ----------
     payload : dict[str, JsonType]
@@ -64,9 +60,9 @@ def validate_intoto_statement(payload: dict[str, JsonType]) -> TypeGuard[InTotoV
         raise ValidateInTotoPayloadError(
             "The attribute '_type' of the in-toto statement is missing.",
         )
-    if not isinstance(type_, str):
+    if not isinstance(type_, str) or not type_ == "https://in-toto.io/Statement/v0.1":
         raise ValidateInTotoPayloadError(
-            "The value of attribute '_type' in the in-toto statement is invalid: expecting a string.",
+            "The value of attribute '_type' in the in-toto statement must be: 'https://in-toto.io/Statement/v0.1'",
         )
 
     subjects_payload = payload.get("subject")
@@ -106,10 +102,6 @@ def validate_intoto_subject(subject: JsonType) -> TypeGuard[InTotoV01Subject]:
     """Validate a single subject in the in-toto statement.
 
     See specification: https://github.com/in-toto/attestation/tree/main/spec/v0.1.0#statement.
-
-    TODO: Consider using the in-toto-attestation package (https://github.com/in-toto/attestation/tree/main/python),
-    which contains Python bindings for in-toto attestation.
-    See issue: https://github.com/oracle/macaron/issues/426.
 
     Parameters
     ----------

--- a/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
@@ -167,7 +167,7 @@ def validate_intoto_subject(subject: JsonType) -> TypeGuard[InTotoV1ResourceDesc
     _validate_property(subject, "name", lambda x: isinstance(x, str))
     _validate_property(subject, "downloadLocation", lambda x: isinstance(x, str))
     _validate_property(subject, "mediaType", lambda x: isinstance(x, str))
-    _validate_property(subject, "annotations", is_valid_annotation_map)
+    _validate_property(subject, "annotations", lambda x: isinstance(x, dict))
 
     return True
 
@@ -194,24 +194,6 @@ def is_valid_digest_set(digest: JsonType) -> bool:
             return False
         if not isinstance(digest[key], str):
             return False
-    return True
-
-
-def is_valid_annotation_map(annotation_map: JsonType) -> bool:
-    """Validate the annotation map which is a dictionary with string keys and JsonType values.
-
-    Parameters
-    ----------
-    annotation_map : JsonType
-        The annotation map dictionary.
-
-    Returns
-    -------
-    bool:
-        ``True`` if the annotation map is valid according to the spec.
-    """
-    if not isinstance(annotation_map, dict):
-        return False
     return True
 
 

--- a/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
@@ -221,7 +221,7 @@ def _validate_property(
     object_: JsonType,
     key: str,
     required: bool,
-    validator_function: Callable[[JsonType], bool],
+    validator: Callable[[JsonType], bool],
     report_errors: bool = True,
 ) -> _ValidityState:
     """Validate the existence and type of target within the passed Json object."""
@@ -238,7 +238,7 @@ def _validate_property(
             return _ValidityState.MISSING
         return _ValidityState.VALID
 
-    valid = validator_function(value)
+    valid = validator(value)
     if not valid:
         if report_errors:
             raise ValidateInTotoPayloadError(f"The attribute {key} of the in-toto subject is invalid.")

--- a/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
@@ -1,9 +1,37 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module handles in-toto version 1 attestations."""
 
-from typing import TypedDict
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypedDict, TypeGuard
+
+from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
+from macaron.util import JsonType
+
+VALID_ALGORITHMS = [
+    "sha256",
+    "sha224",
+    "sha384",
+    "sha512",
+    "sha512_224",
+    "sha512_256",
+    "sha3_224",
+    "sha3_256",
+    "sha3_384",
+    "sha3_512",
+    "shake128",
+    "shake256",
+    "blake2b",
+    "blake2s",
+    "ripemd160",
+    "sm3",
+    "gost",
+    "sha1",
+    "md5",
+]
 
 
 class InTotoV1Statement(TypedDict):
@@ -12,3 +40,198 @@ class InTotoV1Statement(TypedDict):
     This is the type of the payload in a version 1 in-toto attestation.
     Specification: https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md.
     """
+
+    _type: str
+    subject: list[InTotoV1ResourceDescriptor]
+    predicateType: str  # noqa: N815
+    predicate: dict[str, JsonType] | None
+
+
+class InTotoV1ResourceDescriptor(TypedDict):
+    """An in-toto resource descriptor.
+
+    Specification: https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md
+    """
+
+    name: str | None
+    uri: str | None
+    digest: dict[str, str] | None
+    content: str | None
+    download_location: str | None
+    media_type: str | None
+    annotations: dict[str, JsonType] | None
+
+
+def validate_intoto_statement(payload: dict[str, JsonType]) -> TypeGuard[InTotoV1Statement]:
+    """Validate the statement of an in-toto attestation.
+
+    Specification: https://github.com/in-toto/attestation/tree/main/spec/v1/statement.md.
+
+    Parameters
+    ----------
+    payload : dict[str, JsonType]
+        The JSON statement after being base64-decoded.
+
+    Returns
+    -------
+    TypeGuard[InTotoStatement]
+        ``True`` if the attestation statement is valid, in which case its type is narrowed to an
+        ``InTotoStatement``; ``False`` otherwise.
+
+    Raises
+    ------
+    ValidateInTotoPayloadError
+        When the payload does not follow the expected schema.
+    """
+    type_ = payload.get("_type")
+    if type_ is None:
+        raise ValidateInTotoPayloadError(
+            "The attribute '_type' of the in-toto statement is missing.",
+        )
+    if not isinstance(type_, str) or not type_ == "https://in-toto.io/Statement/v1":
+        raise ValidateInTotoPayloadError(
+            "The value of attribute '_type' in the in-toto statement must be: 'https://in-toto.io/Statement/v1'",
+        )
+
+    subjects_payload = payload.get("subject")
+    if subjects_payload is None:
+        raise ValidateInTotoPayloadError(
+            "The attribute 'subject' of the in-toto statement is missing.",
+        )
+    if not isinstance(subjects_payload, list):
+        raise ValidateInTotoPayloadError(
+            "The value of attribute 'subject' in the in-toto statement is invalid: expecting a list.",
+        )
+
+    for subject_json in subjects_payload:
+        validate_intoto_subject(subject_json)
+
+    predicate_type = payload.get("predicateType")
+    if predicate_type is None:
+        raise ValidateInTotoPayloadError(
+            "The attribute 'predicateType' of the in-toto statement is missing.",
+        )
+
+    if not isinstance(predicate_type, str):
+        raise ValidateInTotoPayloadError(
+            "The value of attribute 'predicateType' in the in-toto statement is invalid: expecting a string."
+        )
+
+    predicate = payload.get("predicate")
+    if predicate is not None and not isinstance(predicate, dict):
+        raise ValidateInTotoPayloadError(
+            "The value attribute 'predicate' in the in-toto statement is invalid: expecting an object.",
+        )
+
+    return True
+
+
+def validate_intoto_subject(subject: JsonType) -> TypeGuard[InTotoV1ResourceDescriptor]:
+    """Validate a single subject in the in-toto statement.
+
+    See specification: https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md
+
+    Parameters
+    ----------
+    subject : JsonType
+        The JSON element representing a single subject.
+
+    Returns
+    -------
+    TypeGuard[InTotoSubject]
+        ``True`` if the subject element is valid, in which case its type is narrowed to an
+        ``InTotoSubject``; ``False`` otherwise.
+
+    Raises
+    ------
+    ValidateInTotoPayloadError
+        When the payload does not follow the expecting schema.
+    """
+    if not isinstance(subject, dict):
+        raise ValidateInTotoPayloadError(
+            "A subject in the in-toto statement is invalid: expecting an object.",
+        )
+
+    name_valid = _validate_property(subject, "name", False, lambda x: isinstance(x, str))
+    if not name_valid:
+        raise ValidateInTotoPayloadError("The subject name is not valid.")
+
+    # At least one of 'uri', 'digest', and 'content' must be valid and present.
+    uri_valid = _validate_property(subject, "uri", True, lambda x: isinstance(x, str))
+    content_valid = _validate_property(subject, "content", True, lambda x: isinstance(x, str))
+    digest_valid = _validate_property(subject, "digest", True, is_valid_digest_set)
+    if not (uri_valid or content_valid or digest_valid):
+        raise ValidateInTotoPayloadError(
+            "One of 'uri', 'digest', or 'content' must be present and valid within 'subject'."
+        )
+
+    download_location_valid = _validate_property(subject, "downloadLocation", False, lambda x: isinstance(x, str))
+    if not download_location_valid:
+        raise ValidateInTotoPayloadError("The subject downloadLocation is not valid.")
+
+    media_type_valid = _validate_property(subject, "mediaType", False, lambda x: isinstance(x, str))
+    if not media_type_valid:
+        raise ValidateInTotoPayloadError("The subject mediaType is not valid.")
+
+    annotations_valid = _validate_property(subject, "annotations", False, is_valid_annotation_map)
+    if not annotations_valid:
+        raise ValidateInTotoPayloadError("The subject annotations are not valid.")
+
+    return True
+
+
+def is_valid_digest_set(digest: JsonType) -> bool:
+    """Validate the digest set.
+
+    Specification for the digest set: https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md.
+
+    Parameters
+    ----------
+    digest : JsonType
+        The digest set.
+
+    Returns
+    -------
+    bool:
+        ``True`` if the digest is valid according to the spec.
+    """
+    if not isinstance(digest, dict):
+        return False
+    for key in digest:
+        if key not in VALID_ALGORITHMS:
+            return False
+        if not isinstance(digest[key], str):
+            return False
+    return True
+
+
+def is_valid_annotation_map(annotation_map: JsonType) -> bool:
+    """Validate the annotation map which is a dictionary with string keys and JsonType values.
+
+    Parameters
+    ----------
+    annotation_map : JsonType
+        The annotation map dictionary.
+
+    Returns
+    -------
+    bool:
+        ``True`` if the annotation map is valid according to the spec.
+    """
+    if not isinstance(annotation_map, dict):
+        return False
+    return True
+
+
+def _validate_property(
+    object_: JsonType, target_name: str, required: bool, validator_function: Callable[[JsonType], bool]
+) -> bool:
+    """Validate the existence and type of target within the passed Json object."""
+    if not isinstance(object_, dict):
+        return False
+
+    target = object_.get(target_name)
+    if not target:
+        return not required
+
+    return validator_function(target)

--- a/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
@@ -144,7 +144,7 @@ def validate_intoto_subject(subject: JsonType) -> TypeGuard[InTotoV1ResourceDesc
     -------
     TypeGuard[InTotoV1ResourceDescriptor]
         ``True`` if the subject element is valid, in which case its type is narrowed to an
-        ``InTotoSubject``; ``False`` otherwise.
+        ``InTotoV1ResourceDescriptor``; ``False`` otherwise.
 
     Raises
     ------

--- a/tests/slsa_analyzer/package_registry/test_npm_registry.py
+++ b/tests/slsa_analyzer/package_registry/test_npm_registry.py
@@ -17,14 +17,14 @@ from macaron.slsa_analyzer.package_registry.npm_registry import NPMAttestationAs
 
 @pytest.fixture(name="npm_registry")
 def create_npm_registry() -> NPMRegistry:
-    """Create an NPM registry instance."""
+    """Create an npm registry instance."""
     return NPMRegistry(
         hostname="registry.npmjs.org", attestation_endpoint="-/npm/v1/attestations", request_timeout=20, enabled=True
     )
 
 
 def test_disable_npm_registry(npm_registry: NPMRegistry, tmp_path: Path, npm_tool: NPM) -> None:
-    """Test disabling NPM registry."""
+    """Test disabling npm registry."""
     config = """
     [package_registry.npm]
     enabled = False
@@ -57,7 +57,7 @@ def test_disable_npm_registry(npm_registry: NPMRegistry, tmp_path: Path, npm_too
     ],
 )
 def test_npm_registry_invalid_config(npm_registry: NPMRegistry, tmp_path: Path, config: str) -> None:
-    """Test loading invalid NPM registry configuration."""
+    """Test loading invalid npm registry configuration."""
     config_path = os.path.join(tmp_path, "test_config.ini")
     with open(config_path, mode="w", encoding="utf-8") as config_file:
         config_file.write(config)
@@ -117,7 +117,7 @@ def test_is_detected(
 def test_npm_attestation_asset_url(
     npm_registry: NPMRegistry, namespace: str | None, artifact_id: str, version: str, expected: str
 ) -> None:
-    """Test that the NPM attestation url is correctly constructed."""
+    """Test that the npm attestation url is correctly constructed."""
     asset = NPMAttestationAsset(
         namespace=namespace, artifact_id=artifact_id, version=version, npm_registry=npm_registry, size_in_bytes=0
     )

--- a/tests/slsa_analyzer/package_registry/test_npm_registry.py
+++ b/tests/slsa_analyzer/package_registry/test_npm_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for the npm registry."""
@@ -17,14 +17,14 @@ from macaron.slsa_analyzer.package_registry.npm_registry import NPMAttestationAs
 
 @pytest.fixture(name="npm_registry")
 def create_npm_registry() -> NPMRegistry:
-    """Create an npm registry instance."""
+    """Create an NPM registry instance."""
     return NPMRegistry(
         hostname="registry.npmjs.org", attestation_endpoint="-/npm/v1/attestations", request_timeout=20, enabled=True
     )
 
 
 def test_disable_npm_registry(npm_registry: NPMRegistry, tmp_path: Path, npm_tool: NPM) -> None:
-    """Test disabling npm registry."""
+    """Test disabling NPM registry."""
     config = """
     [package_registry.npm]
     enabled = False
@@ -57,7 +57,7 @@ def test_disable_npm_registry(npm_registry: NPMRegistry, tmp_path: Path, npm_too
     ],
 )
 def test_npm_registry_invalid_config(npm_registry: NPMRegistry, tmp_path: Path, config: str) -> None:
-    """Test loading invalid npm registry configuration."""
+    """Test loading invalid NPM registry configuration."""
     config_path = os.path.join(tmp_path, "test_config.ini")
     with open(config_path, mode="w", encoding="utf-8") as config_file:
         config_file.write(config)
@@ -117,7 +117,7 @@ def test_is_detected(
 def test_npm_attestation_asset_url(
     npm_registry: NPMRegistry, namespace: str | None, artifact_id: str, version: str, expected: str
 ) -> None:
-    """Test that the npm attestation url is correctly constructed."""
+    """Test that the NPM attestation url is correctly constructed."""
     asset = NPMAttestationAsset(
         namespace=namespace, artifact_id=artifact_id, version=version, npm_registry=npm_registry, size_in_bytes=0
     )

--- a/tests/slsa_analyzer/provenance/intoto/v1/__init__.py
+++ b/tests/slsa_analyzer/provenance/intoto/v1/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.

--- a/tests/slsa_analyzer/provenance/intoto/v1/test_validate.py
+++ b/tests/slsa_analyzer/provenance/intoto/v1/test_validate.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Tests for validation of in-toto attestation version 0.1."""
+
+import pytest
+
+from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
+from macaron.slsa_analyzer.provenance.intoto.v1 import validate_intoto_statement
+from macaron.util import JsonType
+
+
+@pytest.mark.parametrize(
+    ("payload"),
+    [
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "uri": "sammple_sample_uri",
+                    },
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="With uri",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "digest": {"sha256": "abcxyz123456"},
+                    },
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="With digest",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {"name": "foo.txt", "content": "content_content"},
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="With content",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "uri": "sample_sample_uri",
+                        "digest": {"sha256": "abcxyz123456"},
+                        "content": "content_content",
+                    },
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="With uri, digest, and content",
+        ),
+    ],
+)
+def test_validate_valid_intoto_statement(
+    payload: dict[str, JsonType],
+) -> None:
+    """Test validating valid in-toto statements."""
+    assert validate_intoto_statement(payload) is True
+
+
+@pytest.mark.parametrize(
+    ("payload"),
+    [
+        pytest.param(
+            {
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "digest": {"sha256": "abcxyz123456"},
+                    },
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="Missing '_type'",
+        ),
+        pytest.param(
+            {
+                "_type": {},
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "digest": {"sha256": "abcxyz123456"},
+                    },
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="Invalid '_type'",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="Missing 'subject'",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": "subject",
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+            },
+            id="Invalid 'subject'",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "digest": {"sha256": "abcxyz123456"},
+                    },
+                ],
+            },
+            id="Missing 'predicateType'",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "digest": {"sha256": "abcxyz123456"},
+                    },
+                ],
+                "predicateType": {},
+            },
+            id="Invalid 'predicateType'",
+        ),
+        pytest.param(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [
+                    {
+                        "name": "foo.txt",
+                        "digest": {"sha256": "abcxyz123456"},
+                    },
+                ],
+                "predicateType": "https://slsa.dev/provenance/v0.2",
+                "predicate": [],
+            },
+            id="Invalid 'predicate'",
+        ),
+    ],
+)
+def test_validate_invalid_intoto_statement(
+    payload: dict[str, JsonType],
+) -> None:
+    """Test validating invalid in-toto statements."""
+    with pytest.raises(ValidateInTotoPayloadError):
+        validate_intoto_statement(payload)


### PR DESCRIPTION
This PR adds:

- Support for downloading SLSA v1 provenance files for NPM packages
- Support for v1 in-toto attestation files, including content validation

It also removes comments relating to intended use of the in-toto attestation library after the investigation reported in #426 

Closes #549 