### PR TITLE
chore: use priority ordering in java repo finder

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -59,6 +59,7 @@ redirect_urls =
 [repofinder.java]
 # The list of maven-like repositories to attempt to retrieve artifact POMs from.
 artifact_repositories = https://repo.maven.apache.org/maven2
+# The repo_pom_paths list is a priority list. The first path that produces a valid URL will be returned as the result.
 repo_pom_paths =
     scm.url
     scm.connection

--- a/src/macaron/repo_finder/repo_finder_java.py
+++ b/src/macaron/repo_finder/repo_finder_java.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the JavaRepoFinder class to be used for finding Java repositories."""
@@ -116,7 +116,10 @@ class JavaRepoFinder(BaseRepoFinder):
             The list of created URLs.
         """
         repositories = defaults.get_list(
-            "repofinder.java", "artifact_repositories", fallback=["https://repo.maven.apache.org/maven2"]
+            "repofinder.java",
+            "artifact_repositories",
+            fallback=["https://repo.maven.apache.org/maven2"],
+            duplicated_ok=True,
         )
         urls = []
         for repo in repositories:
@@ -160,7 +163,7 @@ class JavaRepoFinder(BaseRepoFinder):
             The extracted contents as a list of strings.
         """
         # Retrieve tags
-        tags = defaults.get_list("repofinder.java", "repo_pom_paths")
+        tags = defaults.get_list("repofinder.java", "repo_pom_paths", duplicated_ok=True)
         if not any(tags):
             logger.debug("No POM tags found for URL discovery.")
             return []

--- a/src/macaron/repo_finder/repo_validator.py
+++ b/src/macaron/repo_finder/repo_validator.py
@@ -13,8 +13,6 @@ from macaron.util import send_get_http_raw
 def find_valid_repository_url(urls: Iterable[str]) -> str:
     """Find a valid URL from the provided URLs.
 
-    URLs are assumed to be a priority list, with the first match preventing further processing.
-
     Parameters
     ----------
     urls : Iterable[str]
@@ -23,12 +21,12 @@ def find_valid_repository_url(urls: Iterable[str]) -> str:
     Returns
     -------
     str
-        A valid URL, or an empty string if none can be found.
+        The first valid URL from the iterable, or an empty string if none can be found.
     """
     for url in urls:
         parsed_url = clean_url(url)
         if not parsed_url:
-            # URLs that failed to parse can be rejected here.
+            # URLs that fail to parse can be rejected here.
             continue
         redirect_url = resolve_redirects(parsed_url)
         checked_url = get_remote_vcs_url(redirect_url if redirect_url else parsed_url.geturl())

--- a/tests/repo_finder/test_repo_finder.py
+++ b/tests/repo_finder/test_repo_finder.py
@@ -2,13 +2,14 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module tests the repo finder."""
+import os
+from pathlib import Path
 
 import pytest
-from defusedxml.ElementTree import fromstring
 from packageurl import PackageURL
 
+from macaron.config.defaults import load_defaults
 from macaron.config.target_config import Configuration
-from macaron.repo_finder import repo_validator
 from macaron.repo_finder.repo_finder_java import JavaRepoFinder
 from macaron.slsa_analyzer.analyzer import Analyzer
 
@@ -74,14 +75,36 @@ def test_resolve_analysis_target(
     assert Analyzer.to_analysis_target(config, available_domains) == expect
 
 
-def test_pom_extraction_ordering() -> None:
+@pytest.mark.parametrize(
+    ("user_config_input", "expected"),
+    [
+        (
+            """
+                [repofinder.java]
+                repo_pom_paths =
+                    scm.connection
+                    scm.url
+                """,
+            ["scm:git:git@github.com:oracle-samples/macaron.git", "https://github.com/oracle/macaron"],
+        ),
+        (
+            """
+                [repofinder.java]
+                repo_pom_paths =
+                    scm.url
+                    scm.connection
+                """,
+            ["https://github.com/oracle/macaron", "scm:git:git@github.com:oracle-samples/macaron.git"],
+        ),
+    ],
+)
+def test_pom_extraction_ordering(tmp_path: Path, user_config_input: str, expected: list[str]) -> None:
     """Test the ordering of elements extracted from the POM is correct and maintained."""
     pom_text = """
     <project>
         <url>https://example.org</url>
         <scm>
             <connection>scm:git:git@github.com:oracle-samples/macaron.git</connection>
-            <developerConnection>scm:git:git@github.com:oracle/macaron.git</developerConnection>
             <url>https://github.com/oracle/macaron</url>
         </scm>
         <properties>
@@ -89,19 +112,12 @@ def test_pom_extraction_ordering() -> None:
         </properties>
     </project>
     """
-    pom = fromstring(pom_text)
+    user_config_path = os.path.join(tmp_path, "config.ini")
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+    load_defaults(user_config_path)
+
     repo_finder = JavaRepoFinder()
 
     # Retrieve SCM from POM.
-    connection_urls = repo_finder._find_scm(pom, ["scm.connection", "scm.url"])  # pylint: disable=W0212
-    assert connection_urls
-    connection_url = repo_validator.find_valid_repository_url(connection_urls)
-    assert connection_url
-
-    urls = repo_finder._find_scm(pom, ["scm.url", "scm.connection"])  # pylint: disable=W0212
-    assert urls
-    url = repo_validator.find_valid_repository_url(urls)
-    assert url
-
-    # Ensure found URLs differ.
-    assert connection_url != url
+    assert expected == repo_finder._read_pom(pom_text)  # pylint: disable=W0212

--- a/tests/repo_finder/test_repo_finder.py
+++ b/tests/repo_finder/test_repo_finder.py
@@ -84,7 +84,7 @@ def test_resolve_analysis_target(
                 repo_pom_paths =
                     scm.connection
                     scm.url
-                """,
+            """,
             ["scm:git:git@github.com:oracle-samples/macaron.git", "https://github.com/oracle/macaron"],
         ),
         (
@@ -93,7 +93,7 @@ def test_resolve_analysis_target(
                 repo_pom_paths =
                     scm.url
                     scm.connection
-                """,
+            """,
             ["https://github.com/oracle/macaron", "scm:git:git@github.com:oracle-samples/macaron.git"],
         ),
     ],

--- a/tests/repo_finder/test_repo_finder.py
+++ b/tests/repo_finder/test_repo_finder.py
@@ -1,12 +1,15 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module tests the repo finder."""
 
 import pytest
+from defusedxml.ElementTree import fromstring
 from packageurl import PackageURL
 
 from macaron.config.target_config import Configuration
+from macaron.repo_finder import repo_validator
+from macaron.repo_finder.repo_finder_java import JavaRepoFinder
 from macaron.slsa_analyzer.analyzer import Analyzer
 
 
@@ -69,3 +72,36 @@ def test_resolve_analysis_target(
 ) -> None:
     """Test the resolve analysis target method with valid inputs."""
     assert Analyzer.to_analysis_target(config, available_domains) == expect
+
+
+def test_pom_extraction_ordering() -> None:
+    """Test the ordering of elements extracted from the POM is correct and maintained."""
+    pom_text = """
+    <project>
+        <url>https://example.org</url>
+        <scm>
+            <connection>scm:git:git@github.com:oracle-samples/macaron.git</connection>
+            <developerConnection>scm:git:git@github.com:oracle/macaron.git</developerConnection>
+            <url>https://github.com/oracle/macaron</url>
+        </scm>
+        <properties>
+            <url>1.9.15</url>
+        </properties>
+    </project>
+    """
+    pom = fromstring(pom_text)
+    repo_finder = JavaRepoFinder()
+
+    # Retrieve SCM from POM.
+    connection_urls = repo_finder._find_scm(pom, ["scm.connection", "scm.url"])  # pylint: disable=W0212
+    assert connection_urls
+    connection_url = repo_validator.find_valid_repository_url(connection_urls)
+    assert connection_url
+
+    urls = repo_finder._find_scm(pom, ["scm.url", "scm.connection"])  # pylint: disable=W0212
+    assert urls
+    url = repo_validator.find_valid_repository_url(urls)
+    assert url
+
+    # Ensure found URLs differ.
+    assert connection_url != url


### PR DESCRIPTION
This PR makes the configuration property `repo_pom_paths` a priority list. When the Repo Finder is resolving URLs to repositories, the first valid URL (based on the ordering of the `repo_pom_paths`) will be returned. By default, the highest priority SCM entry in a POM should be `url`, as this most reliably represents the URL of the source repository.

Closes #640 