### PR TITLE
chore: update repo finder e2e test

### DIFF
--- a/src/macaron/repo_finder/repo_validator.py
+++ b/src/macaron/repo_finder/repo_validator.py
@@ -29,7 +29,7 @@ def find_valid_repository_url(urls: Iterable[str]) -> str:
         if not parsed_url:
             # URLs that failed to parse can be rejected here.
             continue
-        redirect_url = _resolve_redirects(parsed_url)
+        redirect_url = resolve_redirects(parsed_url)
         # If a redirect URL is found add it, otherwise add the parsed url.
         pruned_list.append(redirect_url if redirect_url else parsed_url.geturl())
 
@@ -45,8 +45,19 @@ def find_valid_repository_url(urls: Iterable[str]) -> str:
     return vcs_list.pop()
 
 
-def _resolve_redirects(parsed_url: urllib.parse.ParseResult) -> str | None:
-    """Resolve redirecting URLs by returning the location they point to."""
+def resolve_redirects(parsed_url: urllib.parse.ParseResult) -> str | None:
+    """Resolve redirecting URLs by returning the location they point to.
+
+    Parameters
+    ----------
+    parsed_url: ParseResult
+        A parsed URL.
+
+    Returns
+    -------
+    str | None
+        The resolved redirect location, or None if none was found.
+    """
     redirect_list = defaults.get_list("repofinder", "redirect_urls", fallback=[])
     if parsed_url.netloc in redirect_list:
         response = send_get_http_raw(parsed_url.geturl(), allow_redirects=False)

--- a/tests/e2e/repo_finder/repo_finder.py
+++ b/tests/e2e/repo_finder/repo_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This script tests the functionality of the repo finder's remote API calls."""
@@ -29,6 +29,7 @@ def test_repo_finder() -> int:
     if not defaults.has_section("repofinder"):
         defaults.add_section("repofinder")
     defaults.set("repofinder", "use_open_source_insights", "True")
+    defaults.set("repofinder", "redirect_urls", "gitbox.apache.org git-wip-us.apache.org")
 
     if not defaults.has_section("git_service.github"):
         defaults.add_section("git_service.github")
@@ -60,6 +61,10 @@ def test_repo_finder() -> int:
 
     # Test deps.dev API for Cargo package.
     if not find_repo(PackageURL.from_string("pkg:cargo/rand_core")):
+        return os.EX_UNAVAILABLE
+
+    # Test redirecting URL from Apache commons-io package.
+    if not find_repo(PackageURL.from_string("pkg:maven/commons-io/commons-io@2.15.1")):
         return os.EX_UNAVAILABLE
 
     return os.EX_OK


### PR DESCRIPTION
This PR updates the Repo Finder e2e test to support the changes made by the new indirect Apache URL support feature.

Closes #642