### PR TITLE
chore: remove incorrect usage of registry instance in the Registry.pepare method

### DIFF
--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -683,7 +683,7 @@ class Registry:
         ex_pats = defaults.get_list(section="analysis.checks", item="exclude", fallback=[])
         in_pats = defaults.get_list(section="analysis.checks", item="include", fallback=["*"])
         try:
-            checks_to_run = registry.get_final_checks(ex_pats, in_pats)
+            checks_to_run = self.get_final_checks(ex_pats, in_pats)
         except CheckRegistryError as error:
             logger.error(error)
             return False


### PR DESCRIPTION
This Pull fixes the usage of the `registry` singleton instance with in the `prepare` method of `Registry` class. The correct usage should be `self`.
At the moment, it doesn't cause any unexpected behaviors. However, it is by no doubt an error.