### PR TITLE
fix: preserve the order of elements of the list extract from defaults.ini

### DIFF
--- a/src/macaron/config/defaults.py
+++ b/src/macaron/config/defaults.py
@@ -22,7 +22,7 @@ class ConfigParser(configparser.ConfigParser):
         delimiter: str | None = "\n",
         fallback: list[str] | None = None,
         strip: bool = True,
-        duplicated_ok: bool = False,
+        remove_duplicates: bool = True,
     ) -> list[str]:
         r"""Parse and return a list of strings from an ``option`` for ``section`` in ``defaults.ini``.
 
@@ -37,7 +37,7 @@ class ConfigParser(configparser.ConfigParser):
         If ``strip`` is True  (default: True), strings are whitespace-stripped and empty strings
         are removed from the final result.
 
-        If `duplicated_ok` is False, duplicated elements which come after the their first instances will
+        If `remove_duplicates` is True, duplicated elements which come after the their first instances will
         be removed from the list. This operation happens after ``strip`` is handled.
 
         The order of non-empty elements in the list is preserved.
@@ -55,8 +55,8 @@ class ConfigParser(configparser.ConfigParser):
             The fallback value in case of errors.
         strip : bool
             If True, strings are whitespace-stripped and any empty strings are removed.
-        duplicated_ok : bool
-            If True, duplicated elements are removed from the list.
+        remove_duplicates : bool
+            If True, duplicated elements will be removed from the list.
 
         Returns
         -------
@@ -88,7 +88,7 @@ class ConfigParser(configparser.ConfigParser):
                 if strip:
                     content = [x.strip() for x in content if x.strip()]
 
-                if duplicated_ok:
+                if not remove_duplicates:
                     return content
 
                 values = []

--- a/src/macaron/config/defaults.py
+++ b/src/macaron/config/defaults.py
@@ -48,7 +48,7 @@ class ConfigParser(configparser.ConfigParser):
         section : str
             The section in ``defaults.ini``.
         option : str
-            The option whose value will be split into the return list of strings.
+            The option whose values will be split into the a list of strings.
         delimiter : str | None
             The delimiter used to split the strings.
         fallback : list | None

--- a/src/macaron/config/defaults.py
+++ b/src/macaron/config/defaults.py
@@ -18,13 +18,12 @@ class ConfigParser(configparser.ConfigParser):
     def get_list(
         self,
         section: str,
-        item: str,
+        option: str,
         delimiter: str | None = "\n",
         fallback: list[str] | None = None,
-        duplicated_ok: bool = False,
         strip: bool = True,
     ) -> list[str]:
-        r"""Parse and return a list of strings from an item in ``defaults.ini``.
+        r"""Parse and return a list of strings from an ``option`` for ``section`` in ``defaults.ini``.
 
         This method uses str.split() to split the value into list of strings.
         References: https://docs.python.org/3/library/stdtypes.html#str.split.
@@ -37,22 +36,19 @@ class ConfigParser(configparser.ConfigParser):
         If ``strip`` is True  (default: True), strings are whitespace-stripped and empty strings
         are removed from the final result.
 
-        If ``duplicated_ok`` is True (default: False), duplicated values are not removed from the final list.
-
+        The order of non-empty elements in the list is preserved.
         The content of each string in the list is not validated and should be handled separately.
 
         Parameters
         ----------
         section : str
             The section in ``defaults.ini``.
-        item : str
-            The item to parse the list.
+        option : str
+            The option whose value will be split into the return list of strings.
         delimiter : str | None
             The delimiter used to split the strings.
         fallback : list | None
             The fallback value in case of errors.
-        duplicated_ok : bool
-            If True allow duplicate values.
         strip: bool
             If True, strings are whitespace-stripped and any empty strings are removed.
 
@@ -79,20 +75,15 @@ class ConfigParser(configparser.ConfigParser):
             allowed_hosts == ["github.com", "boo.com gitlab.com", "host com"]
         """
         try:
-            value = self.get(section, item)
+            value = self.get(section, option)
             if isinstance(value, str):
                 content = value.split(sep=delimiter)
 
                 if strip:
                     content = [x.strip() for x in content if x.strip()]
 
-                if duplicated_ok:
-                    return content
-
-                distinct_values = set()
-                distinct_values.update(content)
-                return list(distinct_values)
-        except configparser.NoOptionError as error:
+                return content
+        except (configparser.NoOptionError, configparser.NoSectionError) as error:
             logger.error(error)
 
         return fallback or []

--- a/src/macaron/config/defaults.py
+++ b/src/macaron/config/defaults.py
@@ -22,6 +22,7 @@ class ConfigParser(configparser.ConfigParser):
         delimiter: str | None = "\n",
         fallback: list[str] | None = None,
         strip: bool = True,
+        duplicated_ok: bool = False,
     ) -> list[str]:
         r"""Parse and return a list of strings from an ``option`` for ``section`` in ``defaults.ini``.
 
@@ -36,6 +37,9 @@ class ConfigParser(configparser.ConfigParser):
         If ``strip`` is True  (default: True), strings are whitespace-stripped and empty strings
         are removed from the final result.
 
+        If `duplicated_ok` is False, duplicated elements which come after the their first instances will
+        be removed from the list. This operation happens after ``strip`` is handled.
+
         The order of non-empty elements in the list is preserved.
         The content of each string in the list is not validated and should be handled separately.
 
@@ -49,8 +53,10 @@ class ConfigParser(configparser.ConfigParser):
             The delimiter used to split the strings.
         fallback : list | None
             The fallback value in case of errors.
-        strip: bool
+        strip : bool
             If True, strings are whitespace-stripped and any empty strings are removed.
+        duplicated_ok : bool
+            If True, duplicated elements are removed from the list.
 
         Returns
         -------
@@ -82,7 +88,15 @@ class ConfigParser(configparser.ConfigParser):
                 if strip:
                     content = [x.strip() for x in content if x.strip()]
 
-                return content
+                if duplicated_ok:
+                    return content
+
+                values = []
+                for ele in content:
+                    if ele in values:
+                        continue
+                    values.append(ele)
+                return values
         except (configparser.NoOptionError, configparser.NoSectionError) as error:
             logger.error(error)
 

--- a/src/macaron/repo_finder/repo_finder_java.py
+++ b/src/macaron/repo_finder/repo_finder_java.py
@@ -119,7 +119,6 @@ class JavaRepoFinder(BaseRepoFinder):
             "repofinder.java",
             "artifact_repositories",
             fallback=["https://repo.maven.apache.org/maven2"],
-            duplicated_ok=True,
         )
         urls = []
         for repo in repositories:
@@ -163,7 +162,7 @@ class JavaRepoFinder(BaseRepoFinder):
             The extracted contents as a list of strings.
         """
         # Retrieve tags
-        tags = defaults.get_list("repofinder.java", "repo_pom_paths", duplicated_ok=True)
+        tags = defaults.get_list("repofinder.java", "repo_pom_paths")
         if not any(tags):
             logger.debug("No POM tags found for URL discovery.")
             return []

--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -680,8 +680,8 @@ class Registry:
             logger.error("Found circular dependencies in registered checks: %s", str(error))
             return False
 
-        ex_pats = defaults.get_list(section="analysis.checks", item="exclude", fallback=[])
-        in_pats = defaults.get_list(section="analysis.checks", item="include", fallback=["*"])
+        ex_pats = defaults.get_list(section="analysis.checks", option="exclude", fallback=[])
+        in_pats = defaults.get_list(section="analysis.checks", option="include", fallback=["*"])
         try:
             checks_to_run = self.get_final_checks(ex_pats, in_pats)
         except CheckRegistryError as error:

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -146,7 +146,11 @@ def test_get_str_list_default(
     expect: list[str],
     tmp_path: Path,
 ) -> None:
-    """Test default behavior of getting a list of strings from an option in defaults.ini."""
+    """Test default behavior of getting a list of strings from an option in defaults.ini.
+
+    The default behavior includes striping leading/trailing whitespaces from elements, removing empty elements and
+    removing duplicated elements from the return list.
+    """
     user_config_path = os.path.join(tmp_path, "config.ini")
     with open(user_config_path, "w", encoding="utf-8") as user_config_file:
         user_config_file.write(user_config_input)
@@ -204,7 +208,7 @@ def test_get_str_list_default_with_errors(
     expect: list[str],
     tmp_path: Path,
 ) -> None:
-    """Test default behavior of getting a list of strings with errors from defaults.ini."""
+    """Test errors from getting a list of string from defaults.ini."""
     content = """
     [section]
     option =

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -271,5 +271,5 @@ def test_get_str_list_default_duplicated_ok(
         user_config_file.write(user_config_input)
     load_defaults(user_config_path)
 
-    results = defaults.get_list(section="test.list", option="list", duplicated_ok=True)
+    results = defaults.get_list(section="test.list", option="list", remove_duplicates=False)
     assert results == expect


### PR DESCRIPTION
This PR is created to addressed to issue mentioned here https://github.com/oracle/macaron/pull/641#issuecomment-1960742681.

This issue is addressed by removing the parameter `duplicate_ok` in the `get_list` method https://github.com/oracle/macaron/blob/023e0952a2c885b8e31a813b32c1274d210d5629/src/macaron/config/defaults.py#L18-L26. This essentially will make the `get_list` method not modifying the order of elements in the return list of strings. 

As a result, the unit tests in [tests/config/test_defaults.py](https://github.com/oracle/macaron/blob/fb302eba14bf5eab637d788c28dfa1cd492ef890/tests/config/test_defaults.py) are also re-implemented to reflect this new behavior, hence a major modification within that file. 

In additions, I have also rename the parameter `item` to `option` according to the documentation of ConfigParser - https://docs.python.org/3/library/configparser.html#module-configparser  