### PR TITLE
chore: check tags using GitHub API before cloning.

### DIFF
--- a/src/macaron/slsa_analyzer/git_service/api_client.py
+++ b/src/macaron/slsa_analyzer/git_service/api_client.py
@@ -618,7 +618,6 @@ class GhAPIClient(BaseAPIClient):
             if not last_page and response.links:
                 # The response links header can be used to validate the passed page_limit as it contains the number
                 # of the final page.
-                print(f"LINK: {response.links}")
                 last: dict | None = response.links.get("last")
                 if not last:
                     break


### PR DESCRIPTION
For analysis targets that would require the cloning of a GitHub repository, and have a provided version but no provided digest, this PR adds an additional pre-step that performs the Commit Finder tag matching process on the first page of tag results returned via the GitHub API for that repository. 
One of the following outcomes result from this process:

- The version matched a tag within the results -> No change
- The version did not match a tag within the results, but there are more tags than the first page of results contains -> No change
- The version did not match a tag within the results, and the tags within the results are an exhaustive list -> Do not clone the repository

Closes #644 
Does not include #576 