### PR TITLE
chore: use dunder function __str__ when requiring a string serialization of a PackageURL object

### DIFF
--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -70,11 +70,11 @@ def find_repo(purl: PackageURL) -> str:
     ]:
         repo_finder = DepsDevRepoFinder()
     else:
-        logger.debug("No Repo Finder found for package type: %s of %s", purl.type, purl.to_string())
+        logger.debug("No Repo Finder found for package type: %s of %s", purl.type, purl)
         return ""
 
     # Call Repo Finder and return first valid URL
-    logger.debug("Analyzing %s with Repo Finder: %s", purl.to_string(), str(type(repo_finder)))
+    logger.debug("Analyzing %s with Repo Finder: %s", purl, type(repo_finder))
     return repo_finder.find_repo(purl)
 
 
@@ -129,14 +129,12 @@ def to_repo_path(purl: PackageURL, available_domains: list[str]) -> str | None:
     """
     domain = to_domain_from_known_purl_types(purl.type) or (purl.type if purl.type in available_domains else None)
     if not domain:
-        logger.info(
-            "The PURL type of %s is not valid as a repository type. Trying to find the repository...", purl.to_string()
-        )
+        logger.info("The PURL type of %s is not valid as a repository type. Trying to find the repository...", purl)
         # Try to find the repository
         return find_repo(purl)
 
     if not purl.namespace:
-        logger.error("Expecting a non-empty namespace from %s.", purl.to_string())
+        logger.error("Expecting a non-empty namespace from %s.", purl)
         return None
 
     # TODO: Handle the version tag and commit digest if they are given in the PURL.

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -554,11 +554,11 @@ class Analyzer:
                 name=repository.name,
                 version=repository.commit_sha,
             )
-            return Component(purl=repo_snapshot_purl.to_string(), analysis=analysis, repository=repository)
+            return Component(purl=str(repo_snapshot_purl), analysis=analysis, repository=repository)
 
         # If the PURL is available, we always create the software component with it whether the repository is
         # available or not.
-        return Component(purl=analysis_target.parsed_purl.to_string(), analysis=analysis, repository=repository)
+        return Component(purl=str(analysis_target.parsed_purl), analysis=analysis, repository=repository)
 
     @staticmethod
     def parse_purl(config: Configuration) -> PackageURL | None:


### PR DESCRIPTION
The `PackageURL` class implements the [`__str__()`](https://docs.python.org/3/reference/datamodel.html#object.__str__) function [here](https://github.com/package-url/packageurl-python/blob/ef3747a2e6c136f3fbe1742c81d6da295cee4546/src/packageurl/__init__.py#L416-L417):
```python
    def __str__(self, *args: Any, **kwargs: Any) -> str:
        return self.to_string()
```
That `__str__()` function is invoked automatically when using `%s` in a format string (as is the case when logging, [docs](https://docs.python.org/3/library/string.html#format-specification-mini-language)) or when calling the [str()](https://docs.python.org/3/library/stdtypes.html#str) built-in.

This change removes the `to_string()` use such that the plain `PackageURL` objects are passed to logging and `str()` and thereby their `__str__()` function is called instead. That guarantees that the `PackageURL` class is responsible for returning the “‘informal’ or nicely printable string representation” of the object. And, lucky enough, that’s the value produced by `to_string()` anyway.