### PR TITLE
chore: update deps.dev repo finder to use latest API.

### DIFF
--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -90,6 +90,7 @@ class DepsDevRepoFinder(BaseRepoFinder):
         """
         # See https://docs.deps.dev/api/v3alpha/
         base_url = f"https://api.deps.dev/v3alpha/purl/{encode(purl.to_string()).replace('/', '%2F')}"
+        print(f"URL: {base_url} -- {purl}")
 
         if not base_url:
             return []
@@ -112,7 +113,7 @@ class DepsDevRepoFinder(BaseRepoFinder):
         try:
             versions_keys = ["package", "versions"] if "package" in metadata else ["version"]
             versions = json_extract(metadata, versions_keys, list)
-            latest_version = json_extract(versions[:-1], ["versionKey", "version"], str)
+            latest_version = json_extract(versions[-1], ["versionKey", "version"], str)
         except JsonError as error:
             logger.debug("Could not extract 'version' from deps.dev response: %s", error)
             return []

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -89,8 +89,7 @@ class DepsDevRepoFinder(BaseRepoFinder):
             The list of created URLs.
         """
         # See https://docs.deps.dev/api/v3alpha/
-        base_url = f"https://api.deps.dev/v3alpha/purl/{encode(purl.to_string()).replace('/', '%2F')}"
-        print(f"URL: {base_url} -- {purl}")
+        base_url = f"https://api.deps.dev/v3alpha/purl/{encode(str(purl)).replace('/', '%2F')}"
 
         if not base_url:
             return []

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -109,8 +109,8 @@ class DepsDevRepoFinder(BaseRepoFinder):
             logger.debug("Failed to parse response from deps.dev: %s", error)
             return []
 
+        versions_keys = ["package", "versions"] if "package" in metadata else ["version"]
         try:
-            versions_keys = ["package", "versions"] if "package" in metadata else ["version"]
             versions = json_extract(metadata, versions_keys, list)
             latest_version = json_extract(versions[-1], ["versionKey", "version"], str)
         except JsonError as error:
@@ -165,11 +165,13 @@ class DepsDevRepoFinder(BaseRepoFinder):
             links_keys = ["version", "links"] if "version" in parsed else ["links"]
             links = json_extract(parsed, links_keys, list)
         except JsonError as error:
-            logger.debug("Could not extract 'links' from deps.dev response: %s", error)
+            logger.debug("Could not extract 'version' or 'links' from deps.dev response: %s", error)
             return []
 
         result = []
         for item in links:
-            result.append(item.get("url"))
+            url = item.get("url")
+            if url and isinstance(url, str):
+                result.append(url)
 
         return result


### PR DESCRIPTION
This PR simplifies code in the `DepsDevRepoFinder` class thanks to the changes made to the API as part of a new `deps.dev` release. Previously, each language (Python, Rust, C#, and JavaScript) had to follow specific rules to allow for the API to handle each of them. Now, the PURL itself can be sent instead.

Closes #666 