### PR TITLE
chore: improve commit finder accuracy

### DIFF
--- a/tests/e2e/repo_finder/commit_finder.py
+++ b/tests/e2e/repo_finder/commit_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module performs a regression test of the commit finder's tag matching functionality."""
@@ -18,7 +18,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 # Set logging debug level.
 logger.setLevel(logging.DEBUG)
 
-java_tags_file_path = Path(__file__).parent.joinpath("resources", "java_tags.json")
+java_tags_file_path = Path(__file__).parent.joinpath("resources", "tags.json")
 
 
 def test_commit_finder() -> int:


### PR DESCRIPTION
This PR improves the Commit Finder so it can match in two additional tag usage cases:

- Where part of a suffix has a different case to the version it represents. E.g. rc4 vs RC4
- Where part of a suffix contains a number string with a different amount of preceding zeros to the version it represents.

Tests for these cases have been added to the regression data set.

Closes #684 