### PR TITLE
chore: disable redirect resolution in tests

### DIFF
--- a/tests/dependency_analyzer/cyclonedx/__snapshots__/test_cyclonedx.ambr
+++ b/tests/dependency_analyzer/cyclonedx/__snapshots__/test_cyclonedx.ambr
@@ -377,8 +377,8 @@
       'url': 'https://github.com/apache/commons-codec',
     }),
     'commons-fileupload:commons-fileupload': dict({
-      'available': <SCMStatus.AVAILABLE: 'AVAILABLE'>,
-      'note': '',
+      'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
+      'note': 'Manual configuration required. Could not find SCM URL.',
       'purl': PackageURL(
         name='commons-fileupload',
         namespace='commons-fileupload',
@@ -389,11 +389,11 @@
         type='maven',
         version='1.4',
       ),
-      'url': 'https://github.com/apache/commons-fileupload',
+      'url': '',
     }),
     'commons-io:commons-io': dict({
-      'available': <SCMStatus.AVAILABLE: 'AVAILABLE'>,
-      'note': '',
+      'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
+      'note': 'Manual configuration required. Could not find SCM URL.',
       'purl': PackageURL(
         name='commons-io',
         namespace='commons-io',
@@ -404,7 +404,7 @@
         type='maven',
         version='2.11.0',
       ),
-      'url': 'https://github.com/apache/commons-io',
+      'url': '',
     }),
     'commons-logging:commons-logging': dict({
       'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
@@ -1547,8 +1547,8 @@
       'url': 'https://github.com/JodaOrg/joda-time',
     }),
     'org.apache.commons:commons-compress': dict({
-      'available': <SCMStatus.AVAILABLE: 'AVAILABLE'>,
-      'note': '',
+      'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,
+      'note': 'Manual configuration required. Could not find SCM URL.',
       'purl': PackageURL(
         name='commons-compress',
         namespace='org.apache.commons',
@@ -1559,7 +1559,7 @@
         type='maven',
         version='1.21',
       ),
-      'url': 'https://github.com/apache/commons-compress',
+      'url': '',
     }),
     'org.apache.httpcomponents:httpclient': dict({
       'available': <SCMStatus.MISSING_SCM: 'MISSING REPO URL'>,

--- a/tests/dependency_analyzer/cyclonedx/defaults.ini
+++ b/tests/dependency_analyzer/cyclonedx/defaults.ini
@@ -1,6 +1,10 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 [repofinder.java]
 # Disables remote calls made to find missing repositories
 find_repos = False
+
+[repofinder]
+# Disables attempts at resolving redirecting URLs via remote calls
+redirect_urls =

--- a/tests/dependency_analyzer/cyclonedx/test_cyclonedx.py
+++ b/tests/dependency_analyzer/cyclonedx/test_cyclonedx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module tests the CycloneDX helper functions."""
@@ -69,6 +69,7 @@ def test_convert_components_to_artifacts(snapshot: dict[str, DependencyInfo]) ->
     # Disable repo finding to prevent remote calls during testing
     load_defaults(os.path.join(os.path.dirname(os.path.abspath(__file__)), "defaults.ini"))
     assert defaults.getboolean("repofinder.java", "find_repos") is False
+    assert defaults.get_list("repofinder", "redirect_urls") == []
 
     # Path to the sub-project bom.json files.
     child_bom_paths = [Path(RESOURCES_DIR, child) for child in ["child_bom_1.json", "child_bom_2.json"]]


### PR DESCRIPTION
Updates the configuration file for the cyclonedx unit test that was previously performing remote calls due to containing URLs that required following redirection to resolve. The related test resource file is reverted to how it looked before the redirection resolution feature was added.

Closes #686 