### PR TITLE
fix: fix a compatibility issue in run_macaron.sh for macOS

### DIFF
--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -156,7 +156,8 @@ function assert_path_exists() {
 function create_dir_if_not_exists() {
     dir=$1
     if [ ! -d "$dir" ]; then
-        mkdir --parents "$dir"
+        # Use the `-p` option for `mkdir` intead of `--parents` to be compatible with macOS.
+        mkdir -p "$dir"
     fi
 }
 


### PR DESCRIPTION
macOS does not support the `--parents` option in `mkdir`. This PR fixes the `run_macaron.sh` script by using the `-p` option instead to be compatible with macOS.