### PR TITLE
feat: add checks to determine if repo and commit came from provenance

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,10 +82,10 @@ the requirements that are currently supported by Macaron.
    * - 3
      - **Provenance expectation** - Check if the provenance meets an expectation.
      - The user can provide an expectation for the provenance as a CUE policy, which will be compared against the SLSA provenance.
-   * - 4
+   * - 3
      - **Provenance derived repo** - Check if the analysis target's repository matches the repository in the provenance.
      - If there is no provenance, this check will fail.
-   * - 4
+   * - 3
      - **Provenance derived commit** - Check if the analysis target's commit matches the commit in the provenance.
      - If there is no commit, this check will fail.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,6 +82,12 @@ the requirements that are currently supported by Macaron.
    * - 3
      - **Provenance expectation** - Check if the provenance meets an expectation.
      - The user can provide an expectation for the provenance as a CUE policy, which will be compared against the SLSA provenance.
+   * - 4
+     - **Provenance derived repo** - Check if the analysis target's repository matches the repository in the provenance.
+     - If there is no provenance, this check will fail.
+   * - 4
+     - **Provenance derived commit** - Check if the analysis target's commit matches the commit in the provenance.
+     - If there is no commit, this check will fail.
 
 ----------------------
 How does Macaron work?

--- a/docs/source/pages/developers_guide/apidoc/macaron.repo_finder.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.repo_finder.rst
@@ -17,6 +17,22 @@ macaron.repo\_finder.commit\_finder module
    :undoc-members:
    :show-inheritance:
 
+macaron.repo\_finder.provenance\_extractor module
+-------------------------------------------------
+
+.. automodule:: macaron.repo_finder.provenance_extractor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+macaron.repo\_finder.provenance\_finder module
+----------------------------------------------
+
+.. automodule:: macaron.repo_finder.provenance_finder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.repo\_finder.repo\_finder module
 ----------------------------------------
 

--- a/docs/source/pages/developers_guide/apidoc/macaron.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.rst
@@ -42,6 +42,14 @@ macaron.errors module
    :undoc-members:
    :show-inheritance:
 
+macaron.json\_tools module
+--------------------------
+
+.. automodule:: macaron.json_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.util module
 -------------------
 

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.checks.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.checks.rst
@@ -65,6 +65,14 @@ macaron.slsa\_analyzer.checks.provenance\_available\_check module
    :undoc-members:
    :show-inheritance:
 
+macaron.slsa\_analyzer.checks.provenance\_commit\_check module
+--------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.checks.provenance_commit_check
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.slsa\_analyzer.checks.provenance\_l3\_check module
 ----------------------------------------------------------
 
@@ -77,6 +85,14 @@ macaron.slsa\_analyzer.checks.provenance\_l3\_content\_check module
 -------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_l3_content_check
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+macaron.slsa\_analyzer.checks.provenance\_repo\_check module
+------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.checks.provenance_repo_check
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.git_service.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.git_service.rst
@@ -48,3 +48,11 @@ macaron.slsa\_analyzer.git\_service.gitlab module
    :members:
    :undoc-members:
    :show-inheritance:
+
+macaron.slsa\_analyzer.git\_service.local\_repo\_git\_service module
+--------------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.git_service.local_repo_git_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -46,6 +46,10 @@ class ChecksOutputs(TypedDict):
     """The package registries for the target software component."""
     provenance: InTotoPayload | None
     """The provenance payload for the target software component."""
+    provenance_repo: str | None
+    """The repository URL extracted from provenance, if applicable."""
+    provenance_commit: str | None
+    """The commit digest extracted from provenance, if applicable."""
 
 
 class AnalyzeContext:
@@ -97,6 +101,8 @@ class AnalyzeContext:
             is_inferred_prov=True,
             expectation=None,
             provenance=None,
+            provenance_repo=None,
+            provenance_commit=None,
         )
 
     @property

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -46,9 +46,9 @@ class ChecksOutputs(TypedDict):
     """The package registries for the target software component."""
     provenance: InTotoPayload | None
     """The provenance payload for the target software component."""
-    provenance_repo: str | None
+    provenance_repo_url: str | None
     """The repository URL extracted from provenance, if applicable."""
-    provenance_commit: str | None
+    provenance_commit_digest: str | None
     """The commit digest extracted from provenance, if applicable."""
 
 
@@ -101,8 +101,8 @@ class AnalyzeContext:
             is_inferred_prov=True,
             expectation=None,
             provenance=None,
-            provenance_repo=None,
-            provenance_commit=None,
+            provenance_repo_url=None,
+            provenance_commit_digest=None,
         )
 
     @property

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -634,8 +634,8 @@ class Analyzer:
         config: Configuration,
         available_domains: list[str],
         parsed_purl: PackageURL | None,
-        provenance_repo: str | None,
-        provenance_commit: str | None,
+        provenance_repo: str | None = None,
+        provenance_commit: str | None = None,
     ) -> AnalysisTarget:
         """Resolve the details of a software component from user input.
 

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -317,10 +317,20 @@ class Analyzer:
             # Try to find the provenance file for the parsed PURL.
             provenance_payload = ProvenanceFinder().find_provenance(parsed_purl)
 
+        # Try to extract the repository URL and commit digest from the Provenance, if it exists.
+        provenance_repo = provenance_commit = None
+        if provenance_payload:
+            try:
+                provenance_repo, provenance_commit = extract_repo_and_commit_from_provenance(provenance_payload)
+            except ProvenanceError as error:
+                logger.debug("Failed to extract repo or commit from provenance: %s", error)
+
         # Create the analysis target.
         available_domains = [git_service.hostname for git_service in GIT_SERVICES if git_service.hostname]
         try:
-            analysis_target = Analyzer.to_analysis_target(config, available_domains, parsed_purl, provenance_payload)
+            analysis_target = Analyzer.to_analysis_target(
+                config, available_domains, parsed_purl, provenance_repo, provenance_commit
+            )
         except InvalidAnalysisTargetError as error:
             return Record(
                 record_id=repo_id,
@@ -330,7 +340,6 @@ class Analyzer:
             )
 
         # Create the component.
-        component = None
         try:
             component = self.add_component(
                 analysis,
@@ -368,6 +377,8 @@ class Analyzer:
         analyze_ctx.dynamic_data["provenance"] = provenance_payload
         if provenance_payload:
             analyze_ctx.dynamic_data["is_inferred_prov"] = False
+        analyze_ctx.dynamic_data["provenance_repo"] = provenance_repo
+        analyze_ctx.dynamic_data["provenance_commit"] = provenance_commit
         analyze_ctx.check_results = self.perform_checks(analyze_ctx)
 
         return Record(
@@ -506,6 +517,8 @@ class Analyzer:
             The target of this analysis.
         existing_records : dict[str, Record] | None
             The mapping of existing records that the analysis has run successfully.
+        provenance_payload: InTotoVPayload | None
+            The provenance intoto payload for the analyzed software component.
 
         Returns
         -------
@@ -621,7 +634,8 @@ class Analyzer:
         config: Configuration,
         available_domains: list[str],
         parsed_purl: PackageURL | None,
-        provenance_payload: InTotoPayload | None = None,
+        provenance_repo: str | None,
+        provenance_commit: str | None,
     ) -> AnalysisTarget:
         """Resolve the details of a software component from user input.
 
@@ -634,8 +648,10 @@ class Analyzer:
             of the corresponding software component.
         parsed_purl: PackageURL | None
             The PURL to use for the analysis target, or None if one has not been provided.
-        provenance_payload : InToToPayload | None
-            The provenance in-toto payload for the software component.
+        provenance_repo: str | None
+            The repository URL extracted from provenance, or None if not found or no provenance.
+        provenance_commit: str | None
+            The commit extracted from provenance, or None if not found or no provenance.
 
         Returns
         -------
@@ -662,24 +678,17 @@ class Analyzer:
                 # Note that we can't always extract the repository path from any provided PURL.
                 converted_repo_path = None
                 repo: str | None = None
-                digest: str | None = None
                 # parsed_purl cannot be None here, but mypy cannot detect that without some extra help.
                 if parsed_purl is not None:
-                    if provenance_payload:
-                        # Try to find repository and commit via provenance.
-                        try:
-                            repo, digest = extract_repo_and_commit_from_provenance(provenance_payload)
-                        except ProvenanceError as error:
-                            logger.debug("Failed to extract repo or commit from provenance: %s", error)
-
+                    if provenance_repo or provenance_commit:
                         return Analyzer.AnalysisTarget(
                             parsed_purl=parsed_purl,
-                            repo_path=repo or "",
+                            repo_path=provenance_repo or "",
                             branch="",
-                            digest=digest or "",
+                            digest=provenance_commit or "",
                         )
 
-                    # As there is no provenance, use the Repo Finder to find the repo.
+                    # As there is no repo or commit from provenance, use the Repo Finder to find the repo.
                     converted_repo_path = repo_finder.to_repo_path(parsed_purl, available_domains)
                     if converted_repo_path is None:
                         # Try to find repo from PURL
@@ -693,8 +702,8 @@ class Analyzer:
                 )
 
             case (_, _) | (None, _):
-                # 1. If only the repository path is provided, we will use the user-provided repository path to create the
-                # ``Repository`` instance. Note that if this case happen, the software component will be initialized
+                # 1. If only the repository path is provided, we will use the user-provided repository path to create
+                # the``Repository`` instance. Note that if this case happen, the software component will be initialized
                 # with the PURL generated from the ``Repository`` instance (i.e. as a PURL pointing to a git repository
                 # at a specific commit). For example: ``pkg:github.com/org/name@<commit_digest>``.
                 # 2. If both the PURL and the repository are provided, we will use the user-provided repository path to
@@ -710,22 +719,15 @@ class Analyzer:
                         digest=input_digest,
                     )
 
-                prov_digest = None
-                if provenance_payload:
-                    try:
-                        _, prov_digest = extract_repo_and_commit_from_provenance(provenance_payload)
-                    except ProvenanceError as error:
-                        logger.debug("Failed to extract commit from provenance: %s", error)
-
                 return Analyzer.AnalysisTarget(
                     parsed_purl=parsed_purl,
                     repo_path=repo_path_input,
                     branch=input_branch,
-                    digest=prov_digest or "",
+                    digest=provenance_commit or "",
                 )
 
             case _:
-                # Even though this case is unecessary, it is still put here because mypy cannot type-narrow tuples
+                # Even though this case is unnecessary, it is still put here because mypy cannot type-narrow tuples
                 # correctly (see https://github.com/python/mypy/pull/16905, which was fixed, but not released).
                 raise InvalidAnalysisTargetError(
                     "Cannot determine the analysis target: PURL and repository path are missing."

--- a/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module adds a check that determines whether the repository URL came from provenance."""
+import logging
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from macaron.database.table_definitions import CheckFacts
+from macaron.slsa_analyzer.analyze_context import AnalyzeContext
+from macaron.slsa_analyzer.checks.base_check import BaseCheck
+from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType, Confidence, JustificationType
+from macaron.slsa_analyzer.registry import registry
+from macaron.slsa_analyzer.slsa_req import ReqName
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ProvenanceDerivedCommitFacts(CheckFacts):
+    """The ORM mapping for justifications in the commit from provenance check."""
+
+    __tablename__ = "_provenance_derived_commit_check"
+
+    #: The primary key.
+    id: Mapped[int] = mapped_column(ForeignKey("_check_facts.id"), primary_key=True)  # noqa: A003
+
+    #: The state of the commit.
+    commit_info: Mapped[str] = mapped_column(String, nullable=True, info={"justification": JustificationType.TEXT})
+
+    __mapper_args__ = {
+        "polymorphic_identity": __tablename__,
+    }
+
+
+class ProvenanceDerivedCommitCheck(BaseCheck):
+    """This check tries to extract the repo from the provenance and compare it to what is in the context."""
+
+    def __init__(self) -> None:
+        """Initialize instance."""
+        check_id = "mcn_provenance_derived_commit_1"
+        description = "Check whether the commit came from provenance."
+        depends_on: list[tuple[str, CheckResultType]] = []
+        eval_reqs = [ReqName.SECURITY]
+        super().__init__(
+            check_id=check_id,
+            description=description,
+            depends_on=depends_on,
+            eval_reqs=eval_reqs,
+            result_on_skip=CheckResultType.FAILED,
+        )
+
+    def run_check(self, ctx: AnalyzeContext) -> CheckResultData:
+        """Implement the check in this method.
+
+        Parameters
+        ----------
+        ctx : AnalyzeContext
+            The object containing processed data for the target repo.
+
+        Returns
+        -------
+        CheckResultData
+            The result of the check.
+        """
+        if ctx.dynamic_data["provenance_commit"]:
+            return CheckResultData(
+                result_tables=[
+                    ProvenanceDerivedCommitFacts(
+                        commit_info="The commit digest was found from provenance.", confidence=Confidence.HIGH
+                    )
+                ],
+                result_type=CheckResultType.PASSED,
+            )
+
+        return CheckResultData(result_tables=[], result_type=CheckResultType.FAILED)
+
+
+registry.register(ProvenanceDerivedCommitCheck())

--- a/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
@@ -64,14 +64,23 @@ class ProvenanceDerivedCommitCheck(BaseCheck):
             The result of the check.
         """
         if ctx.dynamic_data["provenance_commit"]:
-            return CheckResultData(
-                result_tables=[
-                    ProvenanceDerivedCommitFacts(
-                        commit_info="The commit digest was found from provenance.", confidence=Confidence.HIGH
-                    )
-                ],
-                result_type=CheckResultType.PASSED,
-            )
+            if not ctx.component.repository:
+                return CheckResultData(
+                    result_tables=[],
+                    result_type=CheckResultType.FAILED,
+                )
+
+            current_commit = ctx.component.repository.commit_sha
+
+            if current_commit == ctx.dynamic_data["provenance_commit"]:
+                return CheckResultData(
+                    result_tables=[
+                        ProvenanceDerivedCommitFacts(
+                            commit_info="The commit digest was found from provenance.", confidence=Confidence.HIGH
+                        )
+                    ],
+                    result_type=CheckResultType.PASSED,
+                )
 
         return CheckResultData(result_tables=[], result_type=CheckResultType.FAILED)
 

--- a/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
@@ -41,7 +41,7 @@ class ProvenanceDerivedCommitCheck(BaseCheck):
         check_id = "mcn_provenance_derived_commit_1"
         description = "Check whether the commit came from provenance."
         depends_on: list[tuple[str, CheckResultType]] = []
-        eval_reqs = [ReqName.SECURITY]
+        eval_reqs = [ReqName.EXPECTATION]
         super().__init__(
             check_id=check_id,
             description=description,

--- a/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
@@ -63,7 +63,7 @@ class ProvenanceDerivedCommitCheck(BaseCheck):
         CheckResultData
             The result of the check.
         """
-        if ctx.dynamic_data["provenance_commit"]:
+        if ctx.dynamic_data["provenance_commit_digest"]:
             if not ctx.component.repository:
                 return CheckResultData(
                     result_tables=[],
@@ -72,7 +72,7 @@ class ProvenanceDerivedCommitCheck(BaseCheck):
 
             current_commit = ctx.component.repository.commit_sha
 
-            if current_commit == ctx.dynamic_data["provenance_commit"]:
+            if current_commit == ctx.dynamic_data["provenance_commit_digest"]:
                 return CheckResultData(
                     result_tables=[
                         ProvenanceDerivedCommitFacts(

--- a/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
@@ -41,7 +41,7 @@ class ProvenanceDerivedRepoCheck(BaseCheck):
         check_id = "mcn_provenance_derived_repo_1"
         description = "Check whether the repo came from provenance."
         depends_on: list[tuple[str, CheckResultType]] = []
-        eval_reqs = [ReqName.SECURITY]
+        eval_reqs = [ReqName.EXPECTATION]
         super().__init__(
             check_id=check_id,
             description=description,

--- a/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module adds a check that determines whether the repository URL came from provenance."""
+import logging
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from macaron.database.table_definitions import CheckFacts
+from macaron.slsa_analyzer.analyze_context import AnalyzeContext
+from macaron.slsa_analyzer.checks.base_check import BaseCheck
+from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType, Confidence, JustificationType
+from macaron.slsa_analyzer.registry import registry
+from macaron.slsa_analyzer.slsa_req import ReqName
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ProvenanceDerivedRepoFacts(CheckFacts):
+    """The ORM mapping for justifications in the repository from provenance check."""
+
+    __tablename__ = "_provenance_derived_repo_check"
+
+    #: The primary key.
+    id: Mapped[int] = mapped_column(ForeignKey("_check_facts.id"), primary_key=True)  # noqa: A003
+
+    #: The state of the repository.
+    repository_info: Mapped[str] = mapped_column(String, nullable=True, info={"justification": JustificationType.TEXT})
+
+    __mapper_args__ = {
+        "polymorphic_identity": __tablename__,
+    }
+
+
+class ProvenanceDerivedRepoCheck(BaseCheck):
+    """This check tries to extract the repo from the provenance and compare it to what is in the context."""
+
+    def __init__(self) -> None:
+        """Initialize instance."""
+        check_id = "mcn_provenance_derived_repo_1"
+        description = "Check whether the repo came from provenance."
+        depends_on: list[tuple[str, CheckResultType]] = []
+        eval_reqs = [ReqName.SECURITY]
+        super().__init__(
+            check_id=check_id,
+            description=description,
+            depends_on=depends_on,
+            eval_reqs=eval_reqs,
+            result_on_skip=CheckResultType.FAILED,
+        )
+
+    def run_check(self, ctx: AnalyzeContext) -> CheckResultData:
+        """Implement the check in this method.
+
+        Parameters
+        ----------
+        ctx : AnalyzeContext
+            The object containing processed data for the target repo.
+
+        Returns
+        -------
+        CheckResultData
+            The result of the check.
+        """
+        if ctx.dynamic_data["provenance_repo"]:
+            return CheckResultData(
+                result_tables=[
+                    ProvenanceDerivedRepoFacts(
+                        repository_info="The repository URL was found from provenance.", confidence=Confidence.HIGH
+                    )
+                ],
+                result_type=CheckResultType.PASSED,
+            )
+
+        return CheckResultData(result_tables=[], result_type=CheckResultType.FAILED)
+
+
+registry.register(ProvenanceDerivedRepoCheck())

--- a/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
@@ -63,7 +63,7 @@ class ProvenanceDerivedRepoCheck(BaseCheck):
         CheckResultData
             The result of the check.
         """
-        if ctx.dynamic_data["provenance_repo"]:
+        if ctx.dynamic_data["provenance_repo_url"]:
             if not ctx.component.repository:
                 return CheckResultData(
                     result_tables=[],
@@ -72,7 +72,7 @@ class ProvenanceDerivedRepoCheck(BaseCheck):
 
             current_repository = ctx.component.repository.remote_path
 
-            if current_repository == ctx.dynamic_data["provenance_repo"]:
+            if current_repository == ctx.dynamic_data["provenance_repo_url"]:
                 return CheckResultData(
                     result_tables=[
                         ProvenanceDerivedRepoFacts(

--- a/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
@@ -64,14 +64,23 @@ class ProvenanceDerivedRepoCheck(BaseCheck):
             The result of the check.
         """
         if ctx.dynamic_data["provenance_repo"]:
-            return CheckResultData(
-                result_tables=[
-                    ProvenanceDerivedRepoFacts(
-                        repository_info="The repository URL was found from provenance.", confidence=Confidence.HIGH
-                    )
-                ],
-                result_type=CheckResultType.PASSED,
-            )
+            if not ctx.component.repository:
+                return CheckResultData(
+                    result_tables=[],
+                    result_type=CheckResultType.FAILED,
+                )
+
+            current_repository = ctx.component.repository.remote_path
+
+            if current_repository == ctx.dynamic_data["provenance_repo"]:
+                return CheckResultData(
+                    result_tables=[
+                        ProvenanceDerivedRepoFacts(
+                            repository_info="The repository URL was found from provenance.", confidence=Confidence.HIGH
+                        )
+                    ],
+                    result_type=CheckResultType.PASSED,
+                )
 
         return CheckResultData(result_tables=[], result_type=CheckResultType.FAILED)
 

--- a/tests/e2e/compare_e2e_result.py
+++ b/tests/e2e/compare_e2e_result.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module checks the result JSON files against the expected outputs."""
@@ -54,6 +54,7 @@ def compare_check_results(result: dict, expected: dict) -> int:
         # For each requirement the "justification" can be nondeterministic
         # if it contains a path to a file, so we remove it.
         res_req["justification"] = exp_req["justification"] = ""
+        res_req["slsa_requirements"] = exp_req["slsa_requirements"] = ""
 
         if res_req["check_id"] == exp_req["check_id"]:
             for key, value in exp_req.items():

--- a/tests/e2e/expected_results/docker_test/docker_test.json
+++ b/tests/e2e/expected_results/docker_test/docker_test.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-12 17:09:42"
+        "timestamps": "2024-05-07 15:10:13",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -36,11 +69,12 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "Pretend-to-do-stuff",
-                                "stepID": "Push Docker"
+                                "jobID": "pretend-to-do-stuff",
+                                "stepID": "",
+                                "stepName": "Push Docker"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -58,13 +92,14 @@
                             ]
                         }
                     }
-                ]
+                ],
+                "npm Registry": []
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -77,12 +112,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: docker",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.DOCKER",
+                        "deploy_command: [\"docker\", \"push\", \"mock_proj\"]",
                         {
-                            "The target repository uses build tool docker to deploy": "https://github.com/timyarkov/docker_test/blob/404a51a2f38c4470af6b32e4e00b5318c2d7c0cc/.github/workflows/github-actions-basic.yml",
-                            "The build is triggered by": "https://github.com/timyarkov/docker_test/blob/404a51a2f38c4470af6b32e4e00b5318c2d7c0cc/.github/workflows/github-actions-basic.yml"
-                        },
-                        "Deploy command: ['docker', 'push', 'mock_proj']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/timyarkov/docker_test/blob/404a51a2f38c4470af6b32e4e00b5318c2d7c0cc/.github/workflows/github-actions-basic.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -93,7 +129,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: docker",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.DOCKER",
+                        "build_tool_command: [\"docker\", \"build\", \".\", \"-t\", \"mock_proj\", \"--file\", \"Dockerfile.final\"]",
+                        {
+                            "build_trigger": "https://github.com/timyarkov/docker_test/blob/404a51a2f38c4470af6b32e4e00b5318c2d7c0cc/.github/workflows/github-actions-basic.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -104,7 +146,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -116,7 +158,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/timyarkov/docker_test"
+                            "git_repo": "https://github.com/timyarkov/docker_test"
                         }
                     ],
                     "result_type": "PASSED"
@@ -128,7 +170,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -142,7 +184,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -153,7 +217,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -167,7 +231,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -181,7 +245,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -195,7 +259,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -207,7 +271,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -215,19 +279,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -239,11 +307,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/jackson-databind/jackson-databind.json
+++ b/tests/e2e/expected_results/jackson-databind/jackson-databind.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-11-08 09:49:13",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:14:17",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -38,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "build",
-                                "stepID": "Deploy snapshot"
+                                "stepID": "",
+                                "stepName": "Deploy snapshot"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -111,7 +144,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -124,12 +157,16 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"8\", \"11\"]",
+                        "deploy_command: [\"./mvnw\", \"-B\", \"-q\", \"-ff\", \"-DskipTests\", \"-ntp\", \"source:jar\", \"deploy\"]",
                         {
-                            "The target repository uses build tool maven to deploy": "https://github.com/FasterXML/jackson-databind/blob/6e7ff14e2d850bfed2ebf8ebd6b3d71ce668cadd/.github/workflows/main.yml",
-                            "The build is triggered by": "https://github.com/FasterXML/jackson-databind/blob/6e7ff14e2d850bfed2ebf8ebd6b3d71ce668cadd/.github/workflows/main.yml"
-                        },
-                        "Deploy command: ['./mvnw', '-B', '-q', '-ff', '-DskipTests', '-ntp', 'source:jar', 'deploy']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/FasterXML/jackson-databind/blob/6e7ff14e2d850bfed2ebf8ebd6b3d71ce668cadd/.github/workflows/main.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -140,7 +177,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"8\", \"11\"]",
+                        "build_tool_command: [\"./mvnw\", \"-B\", \"-ff\", \"-ntp\", \"clean\", \"verify\"]",
+                        {
+                            "build_trigger": "https://github.com/FasterXML/jackson-databind/blob/6e7ff14e2d850bfed2ebf8ebd6b3d71ce668cadd/.github/workflows/main.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -151,7 +197,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -163,7 +209,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/FasterXML/jackson-databind"
+                            "git_repo": "https://github.com/FasterXML/jackson-databind"
                         }
                     ],
                     "result_type": "PASSED"
@@ -175,7 +221,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a potential workflow run for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -189,7 +235,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -200,7 +268,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -214,7 +282,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -228,7 +296,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -242,7 +310,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -254,19 +322,31 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_witness_level_one_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -278,19 +358,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_witness_level_one_1",
+                "check_id": "mcn_provenance_expectation_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/maven/guava.json
+++ b/tests/e2e/expected_results/maven/guava.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2024-01-03 14:31:23",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:15:48",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -22,7 +54,7 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/google/guava/blob/d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4/./util/deploy_snapshot.sh"
+                                "id": "https://github.com/google/guava/blob/d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4/.github/workflows/ci.yml"
                             },
                             "buildType": "Custom github_actions",
                             "invocation": {
@@ -38,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "publish_snapshot",
-                                "stepID": "Publish"
+                                "stepID": "",
+                                "stepName": "Publish"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -66,7 +99,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -79,12 +112,16 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"zulu\"]",
+                        "language_versions: [\"11\"]",
+                        "deploy_command: [\"mvn\", \"clean\", \"source:jar\", \"javadoc:jar\", \"deploy\", \"-DskipTests=true\", \"\\\"$@\\\"\"]",
                         {
-                            "The target repository uses build tool maven to deploy": "https://github.com/google/guava/blob/d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4/./util/deploy_snapshot.sh",
-                            "The build is triggered by": "https://github.com/google/guava/blob/d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4/.github/workflows/ci.yml"
-                        },
-                        "Deploy command: ['mvn', 'clean', 'source:jar', 'javadoc:jar', 'deploy', '-DskipTests=true', '\"$@\"']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/google/guava/blob/d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4/.github/workflows/ci.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -95,7 +132,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"zulu\"]",
+                        "language_versions: [\"8\", \"11\"]",
+                        "build_tool_command: [\"mvn\", \"-B\", \"-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn\", \"install\", \"-U\", \"-DskipTests=true\", \"-f\", \"$ROOT_POM\"]",
+                        {
+                            "build_trigger": "https://github.com/google/guava/blob/d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4/.github/workflows/ci.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -106,7 +152,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -118,7 +164,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/google/guava"
+                            "git_repo": "https://github.com/google/guava"
                         }
                     ],
                     "result_type": "PASSED"
@@ -130,7 +176,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -144,7 +190,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -155,7 +223,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -169,7 +237,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -183,7 +251,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -197,7 +265,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -209,31 +277,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_as_code_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_level_three_1",
                 "num_deps_pass": 0
             },
             {
@@ -241,11 +285,43 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/maven/maven.json
+++ b/tests/e2e/expected_results/maven/maven.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-11-02 15:56:10",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:15:49",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -27,7 +59,7 @@
                             "buildType": "Custom github_actions",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "https://github.com/apache/maven.git@refs/heads/master",
+                                    "uri": "https://github.com/apache/maven@refs/heads/master",
                                     "digest": {
                                         "sha1": "3fc399318edef0d5ba593723a24fff64291d6f9b"
                                     },
@@ -37,11 +69,12 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "<STRING>",
-                                "stepID": "<STRING>"
+                                "jobID": "",
+                                "stepID": "",
+                                "stepName": ""
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -111,7 +144,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 7,
+                "FAILED": 9,
                 "PASSED": 3,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -124,7 +157,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"11\", \"17\", \"21\"]",
+                        "build_tool_command: [\"mvn\", \"install\", \"-e\", \"-B\", \"-V\", \"-DdistributionFileName=apache-maven\", \"-DskipTests\", \"-f\", \"maven/pom.xml\"]",
+                        {
+                            "build_trigger": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -135,12 +177,16 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "build_command: [\"mvn\", \"install\", \"-e\", \"-B\", \"-V\", \"-DdistributionFileName=apache-maven\", \"-DskipTests\", \"-f\", \"maven/pom.xml\"]",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"11\", \"17\", \"21\"]",
                         {
-                            "The target repository uses build tool maven to build": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml",
-                            "The build is triggered by": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml"
-                        },
-                        "Build command: ['mvn', 'verify', '-e', '-B', '-V', '-DdistributionFileName=apache-maven']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -152,7 +198,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/apache/maven"
+                            "git_repo": "https://github.com/apache/maven"
                         }
                     ],
                     "result_type": "PASSED"
@@ -164,7 +210,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use maven to deploy."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -175,7 +221,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -189,7 +235,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -200,7 +268,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -214,7 +282,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -228,7 +296,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -242,7 +310,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -250,16 +318,12 @@
         }
     },
     "dependencies": {
-        "analyzed_deps": 45,
-        "unique_dep_repos": 36,
+        "analyzed_deps": 0,
+        "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 30
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 1
+                "check_id": "mcn_provenance_available_1",
+                "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_provenance_witness_level_one_1",
@@ -267,18 +331,22 @@
             },
             {
                 "check_id": "mcn_build_as_code_1",
-                "num_deps_pass": 2
+                "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 24
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 30
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -286,285 +354,22 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_provenance_expectation_1",
                 "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
+                "num_deps_pass": 0
             }
         ],
-        "dep_status": [
-            {
-                "id": "org.junit.jupiter:junit-jupiter-api",
-                "description": "Analysis Completed.",
-                "report": "junit-jupiter-api.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.hamcrest:hamcrest-core",
-                "description": "Analysis Completed.",
-                "report": "hamcrest-core.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.eclipse.sisu:org.eclipse.sisu.plexus",
-                "description": "Analysis Completed.",
-                "report": "org_eclipse_sisu_plexus.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "commons-cli:commons-cli",
-                "description": "Analysis Completed.",
-                "report": "commons-cli.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.wagon:wagon-http",
-                "description": "Analysis Completed.",
-                "report": "wagon-http.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.wagon:wagon-file",
-                "description": "Analysis Completed.",
-                "report": "wagon-file.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.slf4j:jcl-over-slf4j",
-                "description": "Analysis Completed.",
-                "report": "jcl-over-slf4j.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-connector-basic",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-connector-basic.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-transport-file",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-transport-file.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-transport-http",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-transport-http.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-transport-wagon",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-transport-wagon.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.fusesource.jansi:jansi",
-                "description": "Analysis Completed.",
-                "report": "jansi.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.ow2.asm:asm",
-                "description": "Analysis Completed.",
-                "report": "asm.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-api",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-api.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-util",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-util.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-impl",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-impl.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "javax.inject:javax.inject",
-                "description": "Analysis Completed.",
-                "report": "javax_inject.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.codehaus.plexus:plexus-interpolation",
-                "description": "Analysis Completed.",
-                "report": "plexus-interpolation.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.wagon:wagon-provider-api",
-                "description": "Analysis Completed.",
-                "report": "wagon-provider-api.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.codehaus.plexus:plexus-testing",
-                "description": "Analysis Completed.",
-                "report": "plexus-testing.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.mockito:mockito-core",
-                "description": "Analysis Completed.",
-                "report": "mockito-core.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.apache.maven.resolver:maven-resolver-spi",
-                "description": "Analysis Completed.",
-                "report": "maven-resolver-spi.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "commons-io:commons-io",
-                "description": "Analysis Completed.",
-                "report": "commons-io.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.eclipse.sisu:org.eclipse.sisu.inject",
-                "description": "Analysis Completed.",
-                "report": "org_eclipse_sisu_inject.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "com.google.inject:guice",
-                "description": "Analysis Completed.",
-                "report": "guice.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "com.google.guava:guava",
-                "description": "Analysis Completed.",
-                "report": "guava.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "com.google.guava:failureaccess",
-                "description": "https://github.com/google/guava is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "org.codehaus.plexus:plexus-classworlds",
-                "description": "Analysis Completed.",
-                "report": "plexus-classworlds.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.slf4j:slf4j-api",
-                "description": "https://github.com/qos-ch/slf4j is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "org.slf4j:slf4j-simple",
-                "description": "https://github.com/qos-ch/slf4j is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "commons-jxpath:commons-jxpath",
-                "description": "Analysis Completed.",
-                "report": "commons-jxpath.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.mockito:mockito-inline",
-                "description": "https://github.com/mockito/mockito is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "org.hamcrest:hamcrest-library",
-                "description": "https://github.com/hamcrest/JavaHamcrest is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "org.xmlunit:xmlunit-assertj",
-                "description": "Analysis Completed.",
-                "report": "xmlunit-assertj.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.junit.jupiter:junit-jupiter-params",
-                "description": "https://github.com/junit-team/junit5 is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "javax.annotation:javax.annotation-api",
-                "description": "Analysis Completed.",
-                "report": "javax_annotation-api.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.codehaus.plexus:plexus-sec-dispatcher",
-                "description": "Analysis Completed.",
-                "report": "plexus-sec-dispatcher.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.codehaus.plexus:plexus-cipher",
-                "description": "Analysis Completed.",
-                "report": "plexus-cipher.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "ch.qos.logback:logback-classic",
-                "description": "Analysis Completed.",
-                "report": "logback-classic.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.xmlunit:xmlunit-core",
-                "description": "https://github.com/xmlunit/xmlunit is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "org.xmlunit:xmlunit-matchers",
-                "description": "https://github.com/xmlunit/xmlunit is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "org.codehaus.plexus:plexus-xml",
-                "description": "Analysis Completed.",
-                "report": "plexus-xml.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.openjdk.jmh:jmh-core",
-                "description": "Analysis Completed.",
-                "report": "jmh-core.html",
-                "status": "AVAILABLE"
-            },
-            {
-                "id": "org.openjdk.jmh:jmh-generator-annprocess",
-                "description": "https://github.com/openjdk/jmh is already analyzed.",
-                "report": "",
-                "status": "DUPLICATED REPO URL"
-            },
-            {
-                "id": "com.fasterxml.woodstox:woodstox-core",
-                "description": "Analysis Completed.",
-                "report": "woodstox-core.html",
-                "status": "AVAILABLE"
-            }
-        ]
+        "dep_status": []
     }
 }

--- a/tests/e2e/expected_results/maven/mockito.json
+++ b/tests/e2e/expected_results/maven/mockito.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-12 17:28:04"
+        "timestamps": "2024-05-07 15:15:48",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -37,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "release",
-                                "stepID": "Build and release"
+                                "stepID": "",
+                                "stepName": "Build and release"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -65,7 +99,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -78,12 +112,16 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"zulu\"]",
+                        "language_versions: [\"11\"]",
+                        "deploy_command: [\"./gradlew\", \"githubRelease\", \"publishToSonatype\", \"closeAndReleaseStagingRepository\", \"releaseSummary\"]",
                         {
-                            "The target repository uses build tool gradle to deploy": "https://github.com/mockito/mockito/blob/512ee3949484e4765038a0410cd7a7f1b73cc655/.github/workflows/ci.yml",
-                            "The build is triggered by": "https://github.com/mockito/mockito/blob/512ee3949484e4765038a0410cd7a7f1b73cc655/.github/workflows/ci.yml"
-                        },
-                        "Deploy command: ['./gradlew', 'githubRelease', 'publishToSonatype', 'closeAndReleaseStagingRepository', 'releaseSummary']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/mockito/mockito/blob/512ee3949484e4765038a0410cd7a7f1b73cc655/.github/workflows/ci.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -94,7 +132,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"zulu\"]",
+                        "language_versions: [\"8\", \"11\", \"17\"]",
+                        "build_tool_command: [\"./gradlew\", \"--no-build-cache\", \"clean\", \"assemble\"]",
+                        {
+                            "build_trigger": "https://github.com/mockito/mockito/blob/512ee3949484e4765038a0410cd7a7f1b73cc655/.github/workflows/ci.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -105,7 +152,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -117,7 +164,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/mockito/mockito"
+                            "git_repo": "https://github.com/mockito/mockito"
                         }
                     ],
                     "result_type": "PASSED"
@@ -129,7 +176,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -143,7 +190,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -154,7 +223,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -168,7 +237,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -182,7 +251,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -196,7 +265,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -208,7 +277,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -216,19 +285,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -240,11 +313,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/micronaut-test/caffeine.json
+++ b/tests/e2e/expected_results/micronaut-test/caffeine.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-12-22 01:32:17",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:12:39",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -22,7 +54,7 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/build.yml"
+                                "id": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/release.yml"
                             },
                             "buildType": "Custom github_actions",
                             "invocation": {
@@ -31,17 +63,18 @@
                                     "digest": {
                                         "sha1": "05a040c2478341bab8a58a02b3dc1fe14d626d72"
                                     },
-                                    "entryPoint": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/build.yml"
+                                    "entryPoint": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/release.yml"
                                 },
                                 "parameters": {},
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "build",
-                                "stepID": "Publish Snapshot"
+                                "jobID": "release",
+                                "stepID": "",
+                                "stepName": "Releasing"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -111,7 +144,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -124,13 +157,15 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_versions: [\"8\"]",
+                        "deploy_command: [\"./gradlew\", \"publishToSonatype\", \"closeAndReleaseSonatypeStagingRepository\", \"-Prelease\"]",
                         {
-                            "The target repository uses build tool gradle to deploy": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/build.yml",
-                            "The build is triggered by": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/build.yml"
-                        },
-                        "Deploy command: ['./gradlew', 'publishToSonatype']",
-                        "However, could not find a passing workflow run.",
-                        "The target repository does not use maven to deploy."
+                            "build_trigger": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/release.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -141,7 +176,15 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_versions: [\"8\", \"15\"]",
+                        "build_tool_command: [\"./gradlew\", \"coveralls\"]",
+                        {
+                            "build_trigger": "https://github.com/ben-manes/caffeine/blob/05a040c2478341bab8a58a02b3dc1fe14d626d72/.github/workflows/build.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -152,7 +195,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -164,7 +207,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/ben-manes/caffeine"
+                            "git_repo": "https://github.com/ben-manes/caffeine"
                         }
                     ],
                     "result_type": "PASSED"
@@ -176,7 +219,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -190,7 +233,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -201,7 +266,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -215,7 +280,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -229,7 +294,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -243,7 +308,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -255,7 +320,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -267,6 +332,18 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
@@ -275,11 +352,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
@@ -287,11 +364,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/micronaut-test/micronaut-test.json
+++ b/tests/e2e/expected_results/micronaut-test/micronaut-test.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-12-22 01:32:17",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:12:39",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -21,82 +53,82 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "subject": [
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-bom/4.1.1/micronaut-test-bom-4.1.1.pom",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-bom/4.3.0/micronaut-test-bom-4.3.0.pom",
                                 "digest": {
-                                    "sha256": "df0ac294009fb49a90d3b43eb6866b118d4e63f1e41f43b85ef472278835171e"
+                                    "sha256": "901fb8c7adaf5938d7f066d44caa796a1eeadb55424c5370a16ac82c8c122501"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-core/4.1.1/micronaut-test-core-4.1.1.jar",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-core/4.3.0/micronaut-test-core-4.3.0.jar",
                                 "digest": {
-                                    "sha256": "374a135cd10f5dc3affb7c69129f51907260d5d09c40fe1c612a3f2967c1db82"
+                                    "sha256": "4875038a3c7f012952217866ad8bea95241d10679881c465e71d249885d7c282"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-core/4.1.1/micronaut-test-core-4.1.1.pom",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-core/4.3.0/micronaut-test-core-4.3.0.pom",
                                 "digest": {
-                                    "sha256": "de4735ef53a4019584c4f16cc17e476cecdd9e44efc37c3ba9c9cedeafe23e43"
+                                    "sha256": "f81ebf05a0043b96103b83cd899d599373fb12ba31bbefdac73f995510d5d48e"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-junit5/4.1.1/micronaut-test-junit5-4.1.1.jar",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-junit5/4.3.0/micronaut-test-junit5-4.3.0.jar",
                                 "digest": {
-                                    "sha256": "655a851b405ed4fa8d86927591f0860fe600458b5e311f5074096f6cfa8ac596"
+                                    "sha256": "cabca491d9af7c64931ee09d08f017b2c90547e6358f96b331215f65fe582788"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-junit5/4.1.1/micronaut-test-junit5-4.1.1.pom",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-junit5/4.3.0/micronaut-test-junit5-4.3.0.pom",
                                 "digest": {
-                                    "sha256": "9210cec65c1050305497f4c7751d951964cfb1f1f60c1e21434f74d60345a487"
+                                    "sha256": "dd30cade14531f235e5eef9aa4e38291b6e767833db2da338cdf41ddcec781a0"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-kotest5/4.1.1/micronaut-test-kotest5-4.1.1.jar",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-kotest5/4.3.0/micronaut-test-kotest5-4.3.0.jar",
                                 "digest": {
-                                    "sha256": "b80e3b51b9a5af5ceab3c4e424069081872107d5fdd1e005811b204ea497e399"
+                                    "sha256": "3e56d9d03588a83c7664a134aa0b3a71023db6fc5213b2632dc11cb88c8a0932"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-kotest5/4.1.1/micronaut-test-kotest5-4.1.1.pom",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-kotest5/4.3.0/micronaut-test-kotest5-4.3.0.pom",
                                 "digest": {
-                                    "sha256": "f9146d727be9811ff4dac12b0a96c60849cda063b51d534d2c4415766b438c45"
+                                    "sha256": "8db9148ce33e90b6c09246a78d9856a1cab4a56a65915fe551cb4dbcc988a663"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-rest-assured/4.1.1/micronaut-test-rest-assured-4.1.1.jar",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-rest-assured/4.3.0/micronaut-test-rest-assured-4.3.0.jar",
                                 "digest": {
-                                    "sha256": "39aaef0081f064468125446a1fab1da68e49f1af4cd396445dab6b89ec9f778c"
+                                    "sha256": "fc41bcfbc1ac6818b01f695dfc3e7b668ee48778c3233221465a843aaa71b619"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-rest-assured/4.1.1/micronaut-test-rest-assured-4.1.1.pom",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-rest-assured/4.3.0/micronaut-test-rest-assured-4.3.0.pom",
                                 "digest": {
-                                    "sha256": "9fc1c1f0c4824d990310234e223acba57cb7c3dbbcebbb194382989f5bd4145b"
+                                    "sha256": "099b25513c7637733f63106dffa59fe7dc1f7a9ef8f047737ff227824a824e77"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-spock/4.1.1/micronaut-test-spock-4.1.1.jar",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-spock/4.3.0/micronaut-test-spock-4.3.0.jar",
                                 "digest": {
-                                    "sha256": "ba34b2238565a5d5737aabcc4e96dde1d328348b7fcbbc123c3f37cb3884c7fc"
+                                    "sha256": "7f25e6fedb7d02c05389dacf62c6a7ea19282e2e46f9ec9bde3a56a58dab7720"
                                 }
                             },
                             {
-                                "name": "build/repo/io/micronaut/test/micronaut-test-spock/4.1.1/micronaut-test-spock-4.1.1.pom",
+                                "name": "build/repo/io/micronaut/test/micronaut-test-spock/4.3.0/micronaut-test-spock-4.3.0.pom",
                                 "digest": {
-                                    "sha256": "6ad7b0bc411fa8e0dcd3de9fb27aa8f1f23c5c946f738c607ecb873314ba86b4"
+                                    "sha256": "3f6de3130f30d9867302fa397936a80b62a3768683e279777e8f7c2c2789f80d"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/generic@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/micronaut-projects/micronaut-test@refs/tags/v4.1.1",
+                                    "uri": "git+https://github.com/micronaut-projects/micronaut-test@refs/tags/v4.3.0",
                                     "digest": {
-                                        "sha1": "0ad6b0e87e695e90ab9f0c8df28a49101cd00d70"
+                                        "sha1": "f241676bbf3f6072d18f1efd92060f51cb1c0d9b"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -124,7 +156,7 @@
                                         },
                                         "release": {
                                             "assets": [],
-                                            "assets_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/releases/132296768/assets",
+                                            "assets_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/releases/150098778/assets",
                                             "author": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/864788?v=4",
                                                 "events_url": "https://api.github.com/users/sdelamo/events{/privacy}",
@@ -145,22 +177,22 @@
                                                 "type": "User",
                                                 "url": "https://api.github.com/users/sdelamo"
                                             },
-                                            "body": "<!-- Release notes generated using configuration in .github/release.yml at 4.1.x -->\r\n\r\n## What's Changed\r\n### Improvements \u2b50\r\n* check if bean of type ResourceLoader exists by @sdelamo in https://github.com/micronaut-projects/micronaut-test/pull/906\r\n### Dependency updates \ud83d\ude80\r\n* fix(deps): update junit5 monorepo to v5.10.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/885\r\n* chore(deps): update graalvm/setup-graalvm action to v1.1.5 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/884\r\n\r\n\r\n**Full Changelog**: https://github.com/micronaut-projects/micronaut-test/compare/v4.1.0...v4.1.1",
-                                            "created_at": "2023-12-01T14:49:53Z",
+                                            "body": "<!-- Release notes generated using configuration in .github/release.yml at 4.3.x -->\r\n\r\n## What's Changed\r\n### Bug Fixes \ud83d\udc1e\r\n* fix: TestSqlAnnotationHandler fails if context stopped in test by @timyates in https://github.com/micronaut-projects/micronaut-test/pull/951\r\n* fix: add interceptor around parameterized features by @timyates in https://github.com/micronaut-projects/micronaut-test/pull/953\r\n### Docs \ud83d\udcd6\r\n* Mention the annotation config when misconfigured by @timyates in https://github.com/micronaut-projects/micronaut-test/pull/957\r\n* Update settingUpJUnit5.adoc by @goodnic in https://github.com/micronaut-projects/micronaut-test/pull/970\r\n### Dependency updates \ud83d\ude80\r\n\r\n#### Mock\r\n* fix(deps): update dependency io.mockk:mockk to v1.13.10 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/963\r\n#### Mockito\r\n* fix(deps): update mockito monorepo to v5.10.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/942\r\n* fix(deps): update mockito monorepo to v5.11.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/966\r\n#### JUnit 5\r\n* fix(deps): update junit5 monorepo to v5.10.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/944\r\n#### AssertJ\r\n* fix(deps): update dependency org.assertj:assertj-core to v3.25.3 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/934\r\n\r\n#### KoTest\r\n* fix(deps): update managed.kotest to v5.8.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/977\r\n#### Kotlin \r\n* fix(deps): update kotlin monorepo to v1.9.23 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/969\r\n#### Micronaut Modules\r\n\r\n##### Micronaut Core\r\n* fix(deps): update dependency io.micronaut:micronaut-core-bom to v4.3.5 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/941\r\n* fix(deps): update dependency io.micronaut:micronaut-core-bom to v4.3.7 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/956\r\n* fix(deps): update dependency io.micronaut:micronaut-core-bom to v4.3.10 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/962\r\n* fix(deps): update dependency io.micronaut:micronaut-core-bom to v4.4.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/980\r\n##### Micronaut Serialization\r\n* fix(deps): update dependency io.micronaut.serde:micronaut-serde-bom to v2.8.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/931\r\n* fix(deps): update dependency io.micronaut.serde:micronaut-serde-bom to v2.8.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/976\r\n* fix(deps): update dependency io.micronaut.serde:micronaut-serde-bom to v2.9.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/995\r\n##### Micronaut Test resources\r\n* fix(deps): update dependency io.micronaut.testresources:micronaut-test-resources-bom to v2.4.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/965\r\n##### Micronaut Platform\r\n* fix(deps): update dependency io.micronaut.platform:micronaut-platform to v4.3.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/932\r\n* fix(deps): update dependency io.micronaut.platform:micronaut-platform to v4.3.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/952\r\n* fix(deps): update dependency io.micronaut.platform:micronaut-platform to v4.3.5 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/961\r\n* fix(deps): update dependency io.micronaut.platform:micronaut-platform to v4.3.7 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/979\r\n##### Micronaut sql\r\n* fix(deps): update dependency io.micronaut.sql:micronaut-sql-bom to v5.5.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/929\r\n* fix(deps): update dependency io.micronaut.sql:micronaut-sql-bom to v5.5.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/985\r\n##### Micronaut hibernate-validator\r\n* fix(deps): update dependency io.micronaut.beanvalidation:micronaut-hibernate-validator to v4.2.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/925\r\n* fix(deps): update dependency io.micronaut.beanvalidation:micronaut-hibernate-validator to v4.2.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/958\r\n* fix(deps): update dependency io.micronaut.beanvalidation:micronaut-hibernate-validator to v4.3.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/992\r\n##### Micronaut Test\r\n* fix(deps): update dependency io.micronaut.test:micronaut-test-bom to v4.2.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/928\r\n* fix(deps): update dependency io.micronaut.test:micronaut-test-bom to v4.2.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/955\r\n\r\n##### Micronaut Spring \r\n* fix(deps): update dependency io.micronaut.spring:micronaut-spring-bom to v5.4.1 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/949\r\n* fix(deps): update dependency io.micronaut.spring:micronaut-spring-bom to v5.5.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/971\r\n##### Micronaut R2DBC\r\n* fix(deps): update dependency io.micronaut.r2dbc:micronaut-r2dbc-bom to v5.3.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/939\r\n* fix(deps): update dependency io.micronaut.r2dbc:micronaut-r2dbc-bom to v5.4.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/991\r\n\r\n##### Micronaut Data\r\n* fix(deps): update dependency io.micronaut.data:micronaut-data-bom to v4.6.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/930\r\n##### Micronaut Reactor\r\n* fix(deps): update dependency io.micronaut.reactor:micronaut-reactor-bom to v3.3.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/989\r\n### CI \u2699\ufe0fBuild \ud83d\udc18\r\n* chore(deps): update dependency gradle to v8.7 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/986\r\n* chore(deps): update gradle/gradle-build-action action to v3.2.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/993\r\n* chore(deps): update gradle/gradle-build-action action to v3.1.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/946\r\n\r\n\r\n### GraalVM\r\n* chore(deps): update graalvm/setup-graalvm action to v1.1.8 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/940\r\n#### Junit Report\r\n\r\n#### SLSA\r\n* chore(deps): update slsa-framework/slsa-github-generator action to v1.10.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/987\r\n\r\n#### Micronaut Build Plugin\r\n* chore(deps): update plugin io.micronaut.build.shared.settings to v6.6.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/924\r\n* chore(deps): update plugin io.micronaut.build.shared.settings to v6.6.4 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/964\r\n* chore(deps): update plugin io.micronaut.build.shared.settings to v6.7.0 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/981\r\n#### Micronaut Gradle Plugin\r\n* fix(deps): update dependency io.micronaut.library:io.micronaut.library.gradle.plugin to v4.3.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/945\r\n* fix(deps): update dependency io.micronaut.library:io.micronaut.library.gradle.plugin to v4.3.4 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/959\r\n* fix(deps): update dependency io.micronaut.library:io.micronaut.library.gradle.plugin to v4.3.5 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/984\r\n* fix(deps): update dependency io.micronaut.library:io.micronaut.library.gradle.plugin to v4.3.6 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/994\r\n#### SVM\r\n* fix(deps): update dependency org.graalvm.nativeimage:svm to v23.1.2 by @renovate in https://github.com/micronaut-projects/micronaut-test/pull/927\r\n\r\n### Other Changes \ud83d\udca1\r\n* Move junit libs to managed block. by @altro3 in https://github.com/micronaut-projects/micronaut-test/pull/936\r\n\r\n## New Contributors\r\n* @goodnic made their first contribution in https://github.com/micronaut-projects/micronaut-test/pull/970\r\n\r\n**Full Changelog**: https://github.com/micronaut-projects/micronaut-test/compare/v4.2.1...v4.3.0",
+                                            "created_at": "2024-04-07T07:31:30Z",
                                             "draft": false,
-                                            "html_url": "https://github.com/micronaut-projects/micronaut-test/releases/tag/v4.1.1",
-                                            "id": 132296768,
-                                            "mentions_count": 2,
-                                            "name": "Micronaut Test 4.1.1",
-                                            "node_id": "RE_kwDOCPx9Ys4H4rBA",
+                                            "html_url": "https://github.com/micronaut-projects/micronaut-test/releases/tag/v4.3.0",
+                                            "id": 150098778,
+                                            "mentions_count": 4,
+                                            "name": "Micronaut Test 4.3.0",
+                                            "node_id": "RE_kwDOCPx9Ys4I8lNa",
                                             "prerelease": false,
-                                            "published_at": "2023-12-01T14:50:40Z",
-                                            "tag_name": "v4.1.1",
-                                            "tarball_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/tarball/v4.1.1",
-                                            "target_commitish": "4.1.x",
-                                            "upload_url": "https://uploads.github.com/repos/micronaut-projects/micronaut-test/releases/132296768/assets{?name,label}",
-                                            "url": "https://api.github.com/repos/micronaut-projects/micronaut-test/releases/132296768",
-                                            "zipball_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/zipball/v4.1.1"
+                                            "published_at": "2024-04-07T07:36:17Z",
+                                            "tag_name": "v4.3.0",
+                                            "tarball_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/tarball/v4.3.0",
+                                            "target_commitish": "4.3.x",
+                                            "upload_url": "https://uploads.github.com/repos/micronaut-projects/micronaut-test/releases/150098778/assets{?name,label}",
+                                            "url": "https://api.github.com/repos/micronaut-projects/micronaut-test/releases/150098778",
+                                            "zipball_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/zipball/v4.3.0"
                                         },
                                         "repository": {
                                             "allow_forking": true,
@@ -178,15 +210,15 @@
                                             "contributors_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/contributors",
                                             "created_at": "2018-09-28T16:07:55Z",
                                             "custom_properties": {},
-                                            "default_branch": "master",
+                                            "default_branch": "4.3.x",
                                             "deployments_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/deployments",
                                             "description": "Repository for Test Related Utilities for Micronaut",
                                             "disabled": false,
                                             "downloads_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/downloads",
                                             "events_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/events",
                                             "fork": false,
-                                            "forks": 58,
-                                            "forks_count": 58,
+                                            "forks": 61,
+                                            "forks_count": 61,
                                             "forks_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/forks",
                                             "full_name": "micronaut-projects/micronaut-test",
                                             "git_commits_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/git/commits{/sha}",
@@ -224,8 +256,8 @@
                                             "name": "micronaut-test",
                                             "node_id": "MDEwOlJlcG9zaXRvcnkxNTA3NjQ4OTg=",
                                             "notifications_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/notifications{?since,all,participating}",
-                                            "open_issues": 44,
-                                            "open_issues_count": 44,
+                                            "open_issues": 42,
+                                            "open_issues_count": 42,
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/36880643?v=4",
                                                 "events_url": "https://api.github.com/users/micronaut-projects/events{/privacy}",
@@ -248,11 +280,11 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/pulls{/number}",
-                                            "pushed_at": "2023-12-01T14:50:39Z",
+                                            "pushed_at": "2024-04-07T07:31:30Z",
                                             "releases_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/releases{/id}",
-                                            "size": 23465,
+                                            "size": 23749,
                                             "ssh_url": "git@github.com:micronaut-projects/micronaut-test.git",
-                                            "stargazers_count": 78,
+                                            "stargazers_count": 76,
                                             "stargazers_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/stargazers",
                                             "statuses_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/subscribers",
@@ -262,11 +294,11 @@
                                             "teams_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/git/trees{/sha}",
-                                            "updated_at": "2023-11-26T20:02:46Z",
+                                            "updated_at": "2024-03-31T14:21:35Z",
                                             "url": "https://api.github.com/repos/micronaut-projects/micronaut-test",
                                             "visibility": "public",
-                                            "watchers": 78,
-                                            "watchers_count": 78,
+                                            "watchers": 76,
+                                            "watchers_count": 76,
                                             "web_commit_signoff_required": false
                                         },
                                         "sender": {
@@ -291,19 +323,19 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v4.1.1",
+                                    "github_ref": "refs/tags/v4.3.0",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "150764898",
                                     "github_repository_owner": "micronaut-projects",
                                     "github_repository_owner_id": "36880643",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "7061527707",
-                                    "github_run_number": "74",
-                                    "github_sha1": "0ad6b0e87e695e90ab9f0c8df28a49101cd00d70"
+                                    "github_run_id": "8587137858",
+                                    "github_run_number": "77",
+                                    "github_sha1": "f241676bbf3f6072d18f1efd92060f51cb1c0d9b"
                                 }
                             },
                             "metadata": {
-                                "buildInvocationID": "7061527707-1",
+                                "buildInvocationID": "8587137858-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -313,9 +345,9 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/micronaut-projects/micronaut-test@refs/tags/v4.1.1",
+                                    "uri": "git+https://github.com/micronaut-projects/micronaut-test@refs/tags/v4.3.0",
                                     "digest": {
-                                        "sha1": "0ad6b0e87e695e90ab9f0c8df28a49101cd00d70"
+                                        "sha1": "f241676bbf3f6072d18f1efd92060f51cb1c0d9b"
                                     }
                                 }
                             ]
@@ -328,7 +360,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 3,
+                "FAILED": 5,
                 "PASSED": 6,
                 "SKIPPED": 0,
                 "UNKNOWN": 1
@@ -341,7 +373,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "No expectation defined for this repository."
+                        "Not Available."
                     ],
                     "result_type": "UNKNOWN"
                 },
@@ -352,12 +384,16 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"17\"]",
+                        "deploy_command: [\"./gradlew\", \"publishAllPublicationsToBuildRepository\", \"publishToSonatype\", \"closeAndReleaseSonatypeStagingRepository\"]",
                         {
-                            "The target repository uses build tool gradle to deploy": "https://github.com/micronaut-projects/micronaut-test/blob/7679d10b4073a3b842b6c56877c35fa8cd10acff/.github/workflows/gradle.yml",
-                            "The build is triggered by": "https://github.com/micronaut-projects/micronaut-test/blob/7679d10b4073a3b842b6c56877c35fa8cd10acff/.github/workflows/gradle.yml"
-                        },
-                        "Deploy command: ['./gradlew', 'publishToSonatype', 'docs', '--no-daemon']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/micronaut-projects/micronaut-test/blob/7679d10b4073a3b842b6c56877c35fa8cd10acff/.github/workflows/release.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -368,7 +404,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"17\"]",
+                        "build_tool_command: [\"./gradlew\", \"publishToSonatype\", \"closeAndReleaseSonatypeStagingRepository\"]",
+                        {
+                            "build_trigger": "https://github.com/micronaut-projects/micronaut-test/blob/7679d10b4073a3b842b6c56877c35fa8cd10acff/.github/workflows/central-sync.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -379,7 +424,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -393,8 +438,10 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Found provenance in release assets:",
-                        "https://api.github.com/repos/micronaut-projects/micronaut-test/releases/assets/138429786"
+                        "asset_name: multiple.intoto.jsonl",
+                        {
+                            "asset_url": "https://api.github.com/repos/micronaut-projects/micronaut-test/releases/assets/160750342"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -408,8 +455,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Successfully verified level 3: ",
-                        "verify passed : build/repo/micronaut-test-bom/4.1.1/micronaut-test-bom-4.1.1.pom,verify passed : build/repo/micronaut-test-core/4.1.1/micronaut-test-core-4.1.1.jar,verify passed : build/repo/micronaut-test-core/4.1.1/micronaut-test-core-4.1.1.pom,verify passed : build/repo/micronaut-test-junit5/4.1.1/micronaut-test-junit5-4.1.1.jar,verify passed : build/repo/micronaut-test-junit5/4.1.1/micronaut-test-junit5-4.1.1.pom,verify passed : build/repo/micronaut-test-kotest5/4.1.1/micronaut-test-kotest5-4.1.1.jar,verify passed : build/repo/micronaut-test-kotest5/4.1.1/micronaut-test-kotest5-4.1.1.pom,verify passed : build/repo/micronaut-test-rest-assured/4.1.1/micronaut-test-rest-assured-4.1.1.jar,verify passed : build/repo/micronaut-test-rest-assured/4.1.1/micronaut-test-rest-assured-4.1.1.pom,verify passed : build/repo/micronaut-test-spock/4.1.1/micronaut-test-spock-4.1.1.jar,verify passed : build/repo/micronaut-test-spock/4.1.1/micronaut-test-spock-4.1.1.pom"
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -421,7 +467,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/micronaut-projects/micronaut-test"
+                            "git_repo": "https://github.com/micronaut-projects/micronaut-test"
                         }
                     ],
                     "result_type": "PASSED"
@@ -433,7 +479,29 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -447,7 +515,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Failed to discover any witness provenance."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -461,7 +529,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -473,8 +541,8 @@
         "unique_dep_repos": 2,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 2
+                "check_id": "mcn_provenance_available_1",
+                "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_provenance_witness_level_one_1",
@@ -485,6 +553,18 @@
                 "num_deps_pass": 1
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 2
+            },
+            {
                 "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
@@ -493,11 +573,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
-                "num_deps_pass": 0
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 2
             },
             {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 2
             },
             {
@@ -505,12 +585,8 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 2
             }
         ],
         "dep_status": [

--- a/tests/e2e/expected_results/micronaut-test/slf4j.json
+++ b/tests/e2e/expected_results/micronaut-test/slf4j.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-12-22 01:32:17",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:12:39",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -37,8 +69,9 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "<STRING>",
-                                "stepID": "<STRING>"
+                                "jobID": "",
+                                "stepID": "",
+                                "stepName": ""
                             },
                             "metadata": {
                                 "buildInvocationId": "<STRING>",
@@ -66,7 +99,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 7,
+                "FAILED": 9,
                 "PASSED": 3,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -79,7 +112,7 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -90,7 +123,10 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "The target repository uses build tool maven in travis_ci to build."
+                        "build_tool_name: maven",
+                        "ci_service_name: travis_ci",
+                        "build_command: jdk",
+                        "language: java"
                     ],
                     "result_type": "PASSED"
                 },
@@ -102,7 +138,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/qos-ch/slf4j"
+                            "git_repo": "https://github.com/qos-ch/slf4j"
                         }
                     ],
                     "result_type": "PASSED"
@@ -114,7 +150,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use maven to deploy."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -125,7 +161,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -139,7 +175,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -150,7 +208,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -164,7 +222,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -178,7 +236,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -192,7 +250,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -204,7 +262,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -216,6 +274,18 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
@@ -224,11 +294,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
@@ -236,11 +306,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/multibuild_test/multibuild_test.json
+++ b/tests/e2e/expected_results/multibuild_test/multibuild_test.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-12 17:09:38"
+        "timestamps": "2024-05-07 15:10:11",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -36,11 +69,12 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "Pretend-to-do-stuff",
-                                "stepID": "Publish Gradle Project"
+                                "jobID": "pretend-to-do-stuff",
+                                "stepID": "",
+                                "stepName": "Publish Gradle Project"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -65,7 +99,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -78,13 +112,16 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"17\"]",
+                        "deploy_command: [\"gradle\", \"publish\"]",
                         {
-                            "The target repository uses build tool gradle to deploy": "https://github.com/timyarkov/multibuild_test/blob/a8b0efe24298bc81f63217aaa84776c3d48976c5/.github/workflows/github-actions-basic.yml",
-                            "The build is triggered by": "https://github.com/timyarkov/multibuild_test/blob/a8b0efe24298bc81f63217aaa84776c3d48976c5/.github/workflows/github-actions-basic.yml"
-                        },
-                        "Deploy command: ['gradle', 'publish']",
-                        "However, could not find a passing workflow run.",
-                        "The target repository does not use maven to deploy."
+                            "build_trigger": "https://github.com/timyarkov/multibuild_test/blob/a8b0efe24298bc81f63217aaa84776c3d48976c5/.github/workflows/github-actions-basic.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -95,7 +132,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"17\"]",
+                        "build_tool_command: [\"gradle\", \"publish\"]",
+                        {
+                            "build_trigger": "https://github.com/timyarkov/multibuild_test/blob/a8b0efe24298bc81f63217aaa84776c3d48976c5/.github/workflows/github-actions-basic.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -106,7 +152,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -118,7 +164,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/timyarkov/multibuild_test"
+                            "git_repo": "https://github.com/timyarkov/multibuild_test"
                         }
                     ],
                     "result_type": "PASSED"
@@ -130,7 +176,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -144,7 +190,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -155,7 +223,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -169,7 +237,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -183,7 +251,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -197,7 +265,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -209,7 +277,7 @@
         "unique_dep_repos": 2,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -217,20 +285,24 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
                 "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_version_control_system_1",
                 "num_deps_pass": 2
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_trusted_builder_level_three_1",
@@ -241,12 +313,16 @@
                 "num_deps_pass": 2
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 1
+            },
+            {
+                "check_id": "mcn_provenance_expectation_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 2
+                "check_id": "mcn_provenance_derived_repo_1",
+                "num_deps_pass": 0
             }
         ],
         "dep_status": [
@@ -254,19 +330,19 @@
                 "id": "org.springframework.boot:spring-boot-starter-thymeleaf",
                 "description": "Analysis Completed.",
                 "report": "spring-boot-starter-thymeleaf.html",
-                "status": "AVAILABLE"
+                "repo_url_status": "AVAILABLE"
             },
             {
                 "id": "org.springframework.boot:spring-boot-starter-web",
                 "description": "https://github.com/spring-projects/spring-boot is already analyzed.",
                 "report": "",
-                "status": "DUPLICATED REPO URL"
+                "repo_url_status": "DUPLICATED REPO URL"
             },
             {
                 "id": "com.google.code.gson:gson",
                 "description": "Analysis Completed.",
                 "report": "gson.html",
-                "status": "AVAILABLE"
+                "repo_url_status": "AVAILABLE"
             }
         ]
     }

--- a/tests/e2e/expected_results/onu-ui/onu-ui.json
+++ b/tests/e2e/expected_results/onu-ui/onu-ui.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-30 15:56:04"
+        "timestamps": "2024-05-07 15:10:20",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -37,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "release",
-                                "stepID": "Publish to npm"
+                                "stepID": "",
+                                "stepName": "Publish to npm"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -58,13 +92,14 @@
                             ]
                         }
                     }
-                ]
+                ],
+                "npm Registry": []
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -77,13 +112,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "deploy_command: [\"pnpm\", \"-r\", \"publish\", \"--access\", \"public\", \"--no-git-checks\"]",
                         {
-                            "The target repository uses build tool npm to deploy": "https://github.com/onu-ui/onu-ui/blob/e3f2825c3940002a920d65476116a64684b3d95e/.github/workflows/release.yml",
-                            "The build is triggered by": "https://github.com/onu-ui/onu-ui/blob/e3f2825c3940002a920d65476116a64684b3d95e/.github/workflows/release.yml"
-                        },
-                        "Deploy command: ['pnpm', '-r', 'publish', '--access', 'public', '--no-git-checks']",
-                        "However, could not find a passing workflow run.",
-                        "The target repository does not use yarn to deploy."
+                            "build_trigger": "https://github.com/onu-ui/onu-ui/blob/e3f2825c3940002a920d65476116a64684b3d95e/.github/workflows/release.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -94,7 +129,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "build_tool_command: [\"pnpm\", \"install\", \"--no-frozen-lockfile\"]",
+                        {
+                            "build_trigger": "https://github.com/onu-ui/onu-ui/blob/e3f2825c3940002a920d65476116a64684b3d95e/.github/workflows/ci.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -105,7 +146,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -117,7 +158,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/onu-ui/onu-ui"
+                            "git_repo": "https://github.com/onu-ui/onu-ui"
                         }
                     ],
                     "result_type": "PASSED"
@@ -129,7 +170,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -143,7 +184,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -154,7 +217,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -168,7 +231,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -182,7 +245,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -196,7 +259,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -208,23 +271,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -232,11 +279,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_commit_1",
                 "num_deps_pass": 0
             },
             {
@@ -244,7 +291,31 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/plot-plugin/plot-plugin.json
+++ b/tests/e2e/expected_results/plot-plugin/plot-plugin.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-12 17:07:15"
+        "timestamps": "2024-05-07 15:09:39",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -81,8 +114,9 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "<STRING>",
-                                "stepID": "<STRING>"
+                                "jobID": "",
+                                "stepID": "",
+                                "stepName": ""
                             },
                             "metadata": {
                                 "buildInvocationId": "<STRING>",
@@ -110,7 +144,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 7,
+                "FAILED": 9,
                 "PASSED": 3,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -123,7 +157,7 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -134,7 +168,10 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "The target repository uses build tool maven in jenkins to build."
+                        "build_tool_name: maven",
+                        "ci_service_name: jenkins",
+                        "build_command: buildPlugin",
+                        "language: java"
                     ],
                     "result_type": "PASSED"
                 },
@@ -146,7 +183,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/jenkinsci/plot-plugin"
+                            "git_repo": "https://github.com/jenkinsci/plot-plugin"
                         }
                     ],
                     "result_type": "PASSED"
@@ -158,7 +195,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use maven to deploy."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -169,7 +206,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -183,7 +220,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -194,7 +253,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -208,7 +267,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -222,7 +281,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -236,7 +295,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -248,7 +307,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -256,19 +315,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -280,11 +343,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/com_google_guava/guava/guava.json
+++ b/tests/e2e/expected_results/purl/com_google_guava/guava/guava.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2024-01-03 15:57:20",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:14:23",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -22,7 +54,7 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/google/guava/blob/db74bd2fdac443223d45e6fc5c66548542be1081/./util/deploy_snapshot.sh"
+                                "id": "https://github.com/google/guava/blob/db74bd2fdac443223d45e6fc5c66548542be1081/.github/workflows/ci.yml"
                             },
                             "buildType": "Custom github_actions",
                             "invocation": {
@@ -38,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "publish_snapshot",
-                                "stepID": "Publish"
+                                "stepID": "",
+                                "stepName": "Publish"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -66,7 +99,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 5,
+                "FAILED": 7,
                 "PASSED": 5,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -79,13 +112,16 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use gradle to deploy.",
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"zulu\"]",
+                        "language_versions: [\"11\"]",
+                        "deploy_command: [\"mvn\", \"clean\", \"source:jar\", \"javadoc:jar\", \"deploy\", \"-DskipTests=true\", \"\\\"$@\\\"\"]",
                         {
-                            "The target repository uses build tool maven to deploy": "https://github.com/google/guava/blob/db74bd2fdac443223d45e6fc5c66548542be1081/./util/deploy_snapshot.sh",
-                            "The build is triggered by": "https://github.com/google/guava/blob/db74bd2fdac443223d45e6fc5c66548542be1081/.github/workflows/ci.yml"
-                        },
-                        "Deploy command: ['mvn', 'clean', 'source:jar', 'javadoc:jar', 'deploy', '-DskipTests=true', '\"$@\"']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/google/guava/blob/db74bd2fdac443223d45e6fc5c66548542be1081/.github/workflows/ci.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -96,7 +132,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"zulu\"]",
+                        "language_versions: [\"8\", \"11\", \"17\"]",
+                        "build_tool_command: [\"./gradlew\", \"testClasspath\"]",
+                        {
+                            "build_trigger": "https://github.com/google/guava/blob/db74bd2fdac443223d45e6fc5c66548542be1081/.github/workflows/ci.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -107,7 +152,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -118,8 +163,10 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "deploy_job: publish_snapshot",
+                        "deploy_step: Publish",
                         {
-                            "The artifact is potentially published by workflow job 'publish_snapshot' at step 'Publish' triggered by": "https://github.com/google/guava/actions/runs/5719444145"
+                            "run_url": "https://github.com/google/guava/actions/runs/5719444145"
                         }
                     ],
                     "result_type": "PASSED"
@@ -132,7 +179,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/google/guava"
+                            "git_repo": "https://github.com/google/guava"
                         }
                     ],
                     "result_type": "PASSED"
@@ -147,7 +194,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -158,7 +227,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -172,7 +241,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -186,7 +255,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -200,7 +269,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -212,31 +281,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_as_code_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_level_three_1",
                 "num_deps_pass": 0
             },
             {
@@ -244,11 +289,43 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/maven/com_example_nonexistent/nonexistent.json
+++ b/tests/e2e/expected_results/purl/maven/com_example_nonexistent/nonexistent.json
@@ -1,34 +1,38 @@
 {
     "metadata": {
-        "timestamps": "2024-04-11 10:55:11",
+        "timestamps": "2024-05-07 15:12:19",
         "has_passing_check": false,
         "run_checks": [
             "mcn_provenance_available_1",
-            "mcn_build_as_code_1",
             "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
             "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
             "mcn_build_service_1",
             "mcn_provenance_expectation_1",
-            "mcn_infer_artifact_pipeline_1",
-            "mcn_build_script_1",
-            "mcn_provenance_level_three_1",
-            "mcn_version_control_system_1"
+            "mcn_provenance_derived_repo_1"
         ],
         "check_tree": {
             "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
                 "mcn_provenance_level_three_1": {},
-                "mcn_provenance_expectation_1": {},
-                "mcn_provenance_witness_level_one_1": {}
+                "mcn_provenance_expectation_1": {}
             },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
-                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
                         "mcn_infer_artifact_pipeline_1": {},
                         "mcn_build_service_1": {}
                     }
-                }
-            }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -47,17 +51,17 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 10,
+                "FAILED": 12,
                 "PASSED": 0,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
             },
             "results": [
                 {
-                    "check_id": "mcn_build_script_1",
-                    "check_description": "Check if the target repo has a valid build script.",
+                    "check_id": "mcn_build_as_code_1",
+                    "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
                     "slsa_requirements": [
-                        "Scripted Build - SLSA Level 1"
+                        "Build as code - SLSA Level 3"
                     ],
                     "justification": [
                         "Not Available."
@@ -65,10 +69,10 @@
                     "result_type": "FAILED"
                 },
                 {
-                    "check_id": "mcn_build_as_code_1",
-                    "check_description": "The build definition and configuration executed by the build service is verifiably derived from text file definitions stored in a version control system.",
+                    "check_id": "mcn_build_script_1",
+                    "check_description": "Check if the target repo has a valid build script.",
                     "slsa_requirements": [
-                        "Build as code - SLSA Level 3"
+                        "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
                         "Not Available."
@@ -108,6 +112,28 @@
                     ],
                     "justification": [
                         "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -187,15 +213,35 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_witness_level_one_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
@@ -207,19 +253,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/maven/maven.json
+++ b/tests/e2e/expected_results/purl/maven/maven.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-11-03 10:55:56",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:10:31",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -27,7 +59,7 @@
                             "buildType": "Custom github_actions",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "https://github.com/apache/maven.git@refs/heads/master",
+                                    "uri": "https://github.com/apache/maven@refs/heads/master",
                                     "digest": {
                                         "sha1": "3fc399318edef0d5ba593723a24fff64291d6f9b"
                                     },
@@ -37,11 +69,12 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "<STRING>",
-                                "stepID": "<STRING>"
+                                "jobID": "",
+                                "stepID": "",
+                                "stepName": ""
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -111,7 +144,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 7,
+                "FAILED": 9,
                 "PASSED": 3,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -124,7 +157,16 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"11\", \"17\", \"21\"]",
+                        "build_tool_command: [\"mvn\", \"install\", \"-e\", \"-B\", \"-V\", \"-DdistributionFileName=apache-maven\", \"-DskipTests\", \"-f\", \"maven/pom.xml\"]",
+                        {
+                            "build_trigger": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -135,12 +177,16 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
+                        "build_tool_name: maven",
+                        "ci_service_name: github_actions",
+                        "build_command: [\"mvn\", \"install\", \"-e\", \"-B\", \"-V\", \"-DdistributionFileName=apache-maven\", \"-DskipTests\", \"-f\", \"maven/pom.xml\"]",
+                        "language: BuildLanguage.JAVA",
+                        "language_distributions: [\"temurin\"]",
+                        "language_versions: [\"11\", \"17\", \"21\"]",
                         {
-                            "The target repository uses build tool maven to build": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml",
-                            "The build is triggered by": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml"
-                        },
-                        "Build command: ['mvn', 'verify', '-e', '-B', '-V', '-DdistributionFileName=apache-maven']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/apache/maven/blob/3fc399318edef0d5ba593723a24fff64291d6f9b/.github/workflows/maven.yml",
+                            "language_url": "https://github.com/actions/setup-java"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -152,7 +198,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/apache/maven"
+                            "git_repo": "https://github.com/apache/maven"
                         }
                     ],
                     "result_type": "PASSED"
@@ -164,7 +210,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use maven to deploy."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -175,7 +221,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -189,7 +235,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -200,7 +268,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -214,7 +282,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -228,7 +296,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -242,7 +310,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -254,11 +322,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -270,11 +334,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_provenance_derived_commit_1",
                 "num_deps_pass": 0
             },
             {
@@ -282,15 +342,31 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_trusted_builder_level_three_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/maven/micronaut-core/micronaut-core.json
+++ b/tests/e2e/expected_results/purl/maven/micronaut-core/micronaut-core.json
@@ -1,29 +1,33 @@
 {
     "metadata": {
-        "timestamps": "2024-03-25 10:37:16",
+        "timestamps": "2024-05-07 15:09:31",
         "has_passing_check": true,
         "run_checks": [
-            "mcn_build_service_1",
-            "mcn_build_as_code_1",
-            "mcn_build_script_1",
+            "mcn_trusted_builder_level_three_1",
             "mcn_version_control_system_1",
-            "mcn_trusted_builder_level_three_1"
+            "mcn_provenance_derived_repo_1",
+            "mcn_build_service_1",
+            "mcn_build_script_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_build_as_code_1"
         ],
         "check_tree": {
             "mcn_provenance_available_1": {
-                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
                 "mcn_provenance_level_three_1": {},
-                "mcn_provenance_expectation_1": {}
+                "mcn_provenance_witness_level_one_1": {}
             },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
-                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_build_service_1": {},
-                        "mcn_infer_artifact_pipeline_1": {}
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
                     }
-                }
-            }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -90,7 +94,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 1,
+                "FAILED": 3,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -161,6 +165,28 @@
                     "result_type": "PASSED"
                 },
                 {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
                     "check_id": "mcn_trusted_builder_level_three_1",
                     "check_description": "Check whether the target uses a trusted SLSA level 3 builder.",
                     "slsa_requirements": [
@@ -186,15 +212,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_expectation_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_witness_level_one_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -202,7 +220,19 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -214,11 +244,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/npm/semver/semver.json
+++ b/tests/e2e/expected_results/purl/npm/semver/semver.json
@@ -1,35 +1,38 @@
 {
     "metadata": {
-        "timestamps": "2024-03-22 09:02:56",
+        "timestamps": "2024-05-07 15:27:34",
         "has_passing_check": true,
         "run_checks": [
             "mcn_provenance_available_1",
-            "mcn_provenance_expectation_1",
             "mcn_provenance_witness_level_one_1",
-            "mcn_trusted_builder_level_three_1",
             "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
             "mcn_build_script_1",
             "mcn_build_service_1",
-            "mcn_infer_artifact_pipeline_1",
-            "mcn_provenance_level_three_1",
-            "mcn_version_control_system_1"
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
         ],
         "check_tree": {
             "mcn_provenance_available_1": {
-                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {},
                 "mcn_provenance_expectation_1": {},
-                "mcn_provenance_witness_level_one_1": {}
+                "mcn_provenance_level_three_1": {}
             },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_build_service_1": {
-                            "mcn_build_script_1": {}
-                        },
-                        "mcn_infer_artifact_pipeline_1": {}
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
                     }
                 }
-            }
+            },
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -42,7 +45,7 @@
             "commit_date": "2024-02-05T09:03:38-08:00"
         },
         "provenances": {
-            "is_inferred": false,
+            "is_inferred": true,
             "content": {
                 "github_actions": [
                     {
@@ -51,23 +54,24 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "<URI>"
+                                "id": "https://github.com/npm/node-semver/blob/377f709718053a477ed717089c4403c4fec332a1/.github/workflows/release-integration.yml"
                             },
-                            "buildType": "<URI>",
+                            "buildType": "Custom github_actions",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "<URI>",
+                                    "uri": "https://github.com/npm/node-semver@refs/heads/None",
                                     "digest": {
-                                        "sha1": "<STING>"
+                                        "sha1": "377f709718053a477ed717089c4403c4fec332a1"
                                     },
-                                    "entryPoint": "<STRING>"
+                                    "entryPoint": "https://github.com/npm/node-semver/blob/377f709718053a477ed717089c4403c4fec332a1/.github/workflows/release-integration.yml"
                                 },
                                 "parameters": {},
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "<STRING>",
-                                "stepID": "<STRING>"
+                                "jobID": "publish",
+                                "stepID": "",
+                                "stepName": "Publish"
                             },
                             "metadata": {
                                 "buildInvocationId": "<STRING>",
@@ -89,62 +93,14 @@
                         }
                     }
                 ],
-                "npm Registry": [
-                    {
-                        "_type": "https://in-toto.io/Statement/v1",
-                        "subject": [
-                            {
-                                "name": "pkg:npm/semver@7.6.0",
-                                "digest": {
-                                    "sha512": "127c1786b9705cc93d80abb9fdf971e6cbff6a7e7b024469946de14caebc5bb1510cdfa4f8e5818fae4cefbd7d3a403cd972c1c6b717d0a4878fe5f908e84e56"
-                                }
-                            }
-                        ],
-                        "predicateType": "https://slsa.dev/provenance/v1",
-                        "predicate": {
-                            "buildDefinition": {
-                                "buildType": "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
-                                "externalParameters": {
-                                    "workflow": {
-                                        "ref": "refs/heads/main",
-                                        "repository": "https://github.com/npm/node-semver",
-                                        "path": ".github/workflows/release.yml"
-                                    }
-                                },
-                                "internalParameters": {
-                                    "github": {
-                                        "event_name": "push",
-                                        "repository_id": "1357199",
-                                        "repository_owner_id": "6078720"
-                                    }
-                                },
-                                "resolvedDependencies": [
-                                    {
-                                        "uri": "git+https://github.com/npm/node-semver@refs/heads/main",
-                                        "digest": {
-                                            "gitCommit": "377f709718053a477ed717089c4403c4fec332a1"
-                                        }
-                                    }
-                                ]
-                            },
-                            "runDetails": {
-                                "builder": {
-                                    "id": "https://github.com/actions/runner/github-hosted"
-                                },
-                                "metadata": {
-                                    "invocationId": "https://github.com/npm/node-semver/actions/runs/7788106733/attempts/1"
-                                }
-                            }
-                        }
-                    }
-                ]
+                "npm Registry": []
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
                 "FAILED": 4,
-                "PASSED": 5,
+                "PASSED": 7,
                 "SKIPPED": 0,
                 "UNKNOWN": 1
             },
@@ -169,6 +125,7 @@
                     "justification": [
                         "build_tool_name: npm",
                         "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
                         "deploy_command: [\"npm\", \"publish\", \"--provenance\", \"--tag=\\\"$1\\\"\"]",
                         {
                             "build_trigger": "https://github.com/npm/node-semver/blob/377f709718053a477ed717089c4403c4fec332a1/.github/workflows/release-integration.yml"
@@ -183,7 +140,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Not Available."
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "build_tool_command: [\"npm\", \"audit\", \"--audit-level=none\"]",
+                        {
+                            "build_trigger": "https://github.com/npm/node-semver/blob/377f709718053a477ed717089c4403c4fec332a1/.github/workflows/audit.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -208,10 +171,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "asset_name: semver",
-                        {
-                            "asset_url": "https://registry.npmjs.org/-/npm/v1/attestations/semver@7.6.0"
-                        }
+                        "Not Available."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: The commit was found from provenance."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: The repository URL was found from provenance."
                     ],
                     "result_type": "PASSED"
                 },
@@ -293,19 +275,31 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_expectation_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_witness_level_one_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
                 "num_deps_pass": 0
             },
             {
@@ -317,15 +311,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
+                "check_id": "mcn_provenance_expectation_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/npm/sigstore/mock/mock.json
+++ b/tests/e2e/expected_results/purl/npm/sigstore/mock/mock.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-11-14 13:14:10",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:27:41",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -124,7 +156,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 4,
+                "FAILED": 6,
                 "PASSED": 5,
                 "SKIPPED": 0,
                 "UNKNOWN": 1
@@ -137,7 +169,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "No expectation defined for this repository."
+                        "Not Available."
                     ],
                     "result_type": "UNKNOWN"
                 },
@@ -148,13 +180,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: javascript",
+                        "deploy_command: changesets/action",
                         {
-                            "The target repository uses build tool npm to deploy": "https://github.com/sigstore/sigstore-js/blob/ebdcfdfbdfeb9c9aeee6df53674ef230613629f5/.github/workflows/release.yml",
-                            "The build is triggered by": "https://github.com/sigstore/sigstore-js/blob/ebdcfdfbdfeb9c9aeee6df53674ef230613629f5/.github/workflows/release.yml"
-                        },
-                        "Deploy action: changesets/action",
-                        "However, could not find a passing workflow run.",
-                        "The target repository does not use yarn to deploy."
+                            "build_trigger": "https://github.com/sigstore/sigstore-js/blob/ebdcfdfbdfeb9c9aeee6df53674ef230613629f5/.github/workflows/release.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -165,7 +197,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "build_tool_command: [\"npm\", \"ci\"]",
+                        {
+                            "build_trigger": "https://github.com/sigstore/sigstore-js/blob/ebdcfdfbdfeb9c9aeee6df53674ef230613629f5/.github/workflows/ci.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -176,7 +214,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -190,8 +228,10 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Found provenance in release assets:",
-                        "https://registry.npmjs.org/-/npm/v1/attestations/@sigstore/mock@0.1.0"
+                        "asset_name: mock",
+                        {
+                            "asset_url": "https://registry.npmjs.org/-/npm/v1/attestations/@sigstore/mock@0.1.0"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -203,7 +243,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/sigstore/sigstore-js"
+                            "git_repo": "https://github.com/sigstore/sigstore-js"
                         }
                     ],
                     "result_type": "PASSED"
@@ -215,7 +255,29 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -229,7 +291,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Could not verify level 3 provenance."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -243,7 +305,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Failed to discover any witness provenance."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -257,7 +319,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -269,7 +331,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -277,19 +339,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -301,11 +367,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/purl/org_tinymediamanager/tinyMediaManager.json
+++ b/tests/e2e/expected_results/purl/org_tinymediamanager/tinyMediaManager.json
@@ -1,7 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2024-02-02 15:39:30",
-        "has_passing_check": true
+        "timestamps": "2024-05-07 15:14:25",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -66,7 +98,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 8,
+                "FAILED": 10,
                 "PASSED": 2,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -79,8 +111,7 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "The target repository uses build tool maven.",
-                        "The target repository uses build tool docker."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -92,7 +123,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://gitlab.com/tinyMediaManager/tinyMediaManager"
+                            "git_repo": "https://gitlab.com/tinyMediaManager/tinyMediaManager"
                         }
                     ],
                     "result_type": "PASSED"
@@ -104,8 +135,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use maven to deploy.",
-                        "The target repository does not use docker to deploy."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -116,9 +146,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "The target repository does not have a build service for maven.",
-                        "The target repository does not have a build service for docker.",
-                        "The target repository does not have a build service for at least one build tool."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -129,7 +157,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -143,7 +171,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -154,7 +204,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -168,7 +218,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -182,7 +232,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -196,7 +246,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -208,7 +258,35 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
+                "check_id": "mcn_provenance_available_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_witness_level_one_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
                 "num_deps_pass": 0
             },
             {
@@ -220,31 +298,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_expectation_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_witness_level_one_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/react-pdf/react-pdf.json
+++ b/tests/e2e/expected_results/react-pdf/react-pdf.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-20 20:15:39"
+        "timestamps": "2024-05-07 15:10:26",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -37,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "publish",
-                                "stepID": "Publish with latest tag"
+                                "stepID": "",
+                                "stepName": "Publish with latest tag"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -58,13 +92,14 @@
                             ]
                         }
                     }
-                ]
+                ],
+                "npm Registry": []
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -77,13 +112,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use npm to deploy.",
+                        "build_tool_name: yarn",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "deploy_command: [\"yarn\", \"npm\", \"publish\", \"--tag\", \"latest\"]",
                         {
-                            "The target repository uses build tool yarn to deploy": "https://github.com/wojtekmaj/react-pdf/blob/be18436b7be827eb993b2e1e4bd9230dd835a9a3/.github/workflows/publish.yml",
-                            "The build is triggered by": "https://github.com/wojtekmaj/react-pdf/blob/be18436b7be827eb993b2e1e4bd9230dd835a9a3/.github/workflows/publish.yml"
-                        },
-                        "Deploy command: ['yarn', 'npm', 'publish', '--tag', 'latest']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/wojtekmaj/react-pdf/blob/be18436b7be827eb993b2e1e4bd9230dd835a9a3/.github/workflows/publish.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -94,7 +129,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: yarn",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "build_tool_command: [\"yarn\", \"--immutable\"]",
+                        {
+                            "build_trigger": "https://github.com/wojtekmaj/react-pdf/blob/be18436b7be827eb993b2e1e4bd9230dd835a9a3/.github/workflows/ci.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -105,7 +146,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -117,7 +158,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/wojtekmaj/react-pdf"
+                            "git_repo": "https://github.com/wojtekmaj/react-pdf"
                         }
                     ],
                     "result_type": "PASSED"
@@ -129,7 +170,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -143,7 +184,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -154,7 +217,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -168,7 +231,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -182,7 +245,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -196,7 +259,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -208,23 +271,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -232,11 +279,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_commit_1",
                 "num_deps_pass": 0
             },
             {
@@ -244,7 +291,31 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/scorecard/scorecard.json
+++ b/tests/e2e/expected_results/scorecard/scorecard.json
@@ -1,30 +1,31 @@
 {
     "metadata": {
-        "timestamps": "2024-02-16 14:41:29",
+        "timestamps": "2024-05-07 15:16:22",
         "has_passing_check": true,
         "run_checks": [
+            "mcn_provenance_available_1",
             "mcn_provenance_level_three_1",
-            "mcn_trusted_builder_level_three_1",
-            "mcn_version_control_system_1",
             "mcn_provenance_expectation_1",
-            "mcn_provenance_available_1"
+            "mcn_version_control_system_1",
+            "mcn_trusted_builder_level_three_1"
         ],
         "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_infer_artifact_pipeline_1": {},
-                        "mcn_build_service_1": {
-                            "mcn_build_script_1": {}
-                        }
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
                     }
                 }
             },
-            "mcn_provenance_available_1": {
-                "mcn_provenance_level_three_1": {},
-                "mcn_provenance_witness_level_one_1": {},
-                "mcn_provenance_expectation_1": {}
-            }
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -334,8 +335,10 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Found provenance in release assets:",
-                        "https://api.github.com/repos/ossf/scorecard/releases/assets/131611370"
+                        "asset_name: multiple.intoto.jsonl",
+                        {
+                            "asset_url": "https://api.github.com/repos/ossf/scorecard/releases/assets/131611370"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -346,7 +349,9 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Successfully verified the expectation against provenance."
+                        {
+                            "asset_url": "https://api.github.com/repos/ossf/scorecard/releases/assets/131611370"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -360,8 +365,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Successfully verified level 3: ",
-                        "verify passed : scorecard_4.13.1_linux_amd64.tar.gz,verify passed : scorecard_4.13.1_darwin_arm64.tar.gz,verify passed : scorecard_4.13.1_darwin_amd64.tar.gz,verify passed : scorecard_4.13.1_windows_arm64.tar.gz,verify passed : scorecard_4.13.1_windows_amd64.tar.gz,verify passed : scorecard_4.13.1_linux_arm64.tar.gz"
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -375,10 +379,11 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0",
+                        "ci_service_name: github_actions",
                         {
-                            "Found trusted builder GitHub Actions: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0 triggered by": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/.github/workflows/slsa-goreleaser.yml"
-                        },
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/.github/workflows/slsa-goreleaser.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -390,7 +395,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/ossf/scorecard"
+                            "git_repo": "https://github.com/ossf/scorecard"
                         }
                     ],
                     "result_type": "PASSED"
@@ -403,7 +408,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -415,6 +420,18 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
@@ -423,11 +440,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
@@ -435,11 +452,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/sget/sget.json
+++ b/tests/e2e/expected_results/sget/sget.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-10-05 10:57:32"
+        "timestamps": "2024-05-07 15:10:28",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -36,11 +69,12 @@
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "<STRING>",
-                                "stepID": "<STRING>"
+                                "jobID": "release",
+                                "stepID": "",
+                                "stepName": ""
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -64,7 +98,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -77,12 +111,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: go",
+                        "ci_service_name: github_actions",
+                        "language: go",
+                        "deploy_command: goreleaser/goreleaser-action",
                         {
-                            "The target repository uses build tool go to deploy": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml",
-                            "The build is triggered by": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml"
-                        },
-                        "Deploy action: goreleaser/goreleaser-action",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/release.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -93,7 +128,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: go",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.GO",
+                        "build_tool_command: [\"go\", \"build\", \"./...\"]",
+                        {
+                            "build_trigger": "https://github.com/sigstore/sget/blob/99e7b91204d391ccc76507f7079b6d2a7957489e/.github/workflows/build.yaml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -104,7 +145,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -116,7 +157,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/sigstore/sget"
+                            "git_repo": "https://github.com/sigstore/sget"
                         }
                     ],
                     "result_type": "PASSED"
@@ -128,7 +169,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -142,7 +183,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -153,7 +216,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -167,7 +230,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -181,7 +244,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -195,7 +258,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -207,7 +270,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -215,19 +278,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -239,11 +306,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/slsa-verifier/slsa-verifier_cue_PASS.json
+++ b/tests/e2e/expected_results/slsa-verifier/slsa-verifier_cue_PASS.json
@@ -1,34 +1,37 @@
 {
     "metadata": {
-        "timestamps": "2024-02-16 16:19:18",
+        "timestamps": "2024-05-07 15:16:35",
         "has_passing_check": true,
         "run_checks": [
-            "mcn_trusted_builder_level_three_1",
-            "mcn_provenance_expectation_1",
             "mcn_provenance_witness_level_one_1",
             "mcn_version_control_system_1",
             "mcn_build_script_1",
-            "mcn_build_as_code_1",
             "mcn_build_service_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_expectation_1",
             "mcn_infer_artifact_pipeline_1",
+            "mcn_provenance_derived_repo_1",
+            "mcn_build_as_code_1",
+            "mcn_trusted_builder_level_three_1",
             "mcn_provenance_available_1"
         ],
         "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_infer_artifact_pipeline_1": {},
-                        "mcn_build_service_1": {
-                            "mcn_build_script_1": {}
-                        }
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
                     }
                 }
             },
-            "mcn_provenance_available_1": {
-                "mcn_provenance_expectation_1": {},
-                "mcn_provenance_witness_level_one_1": {},
-                "mcn_provenance_level_three_1": {}
-            }
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -51,20 +54,20 @@
                             {
                                 "name": "slsa-verifier-darwin-amd64",
                                 "digest": {
-                                    "sha256": "69fa1ea5bb734e765aae1fa855f50e823c2b90b019994610960b7eb3c83feeb3"
+                                    "sha256": "6246ff80cbd3d272bf843d72d1562cafb7c59b45b5b555fbee92df90547b4256"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.8.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/go@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -76,13 +79,25 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                        "after": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                         "base_ref": "refs/heads/main",
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.4.1",
+                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.5.1",
                                         "created": true,
                                         "deleted": false,
+                                        "enterprise": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/b/102459?v=4",
+                                            "created_at": "2023-12-08T05:54:26Z",
+                                            "description": "Open Source Security Foundation (OpenSSF)",
+                                            "html_url": "https://github.com/enterprises/openssf",
+                                            "id": 102459,
+                                            "name": "Open Source Security Foundation",
+                                            "node_id": "E_kgDOAAGQOw",
+                                            "slug": "openssf",
+                                            "updated_at": "2024-01-06T00:47:02Z",
+                                            "website_url": "https://openssf.org/"
+                                        },
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
@@ -96,11 +111,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
-                                            "message": "docs: update release doc and rm binary (#716)\n\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
-                                            "timestamp": "2023-10-16T13:44:13-07:00",
-                                            "tree_id": "b70b194feb7247be9885bfff95f9640c84d0b8f5",
-                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                            "id": "eb7007070baa04976cb9e25a0d8034f8db030a86",
+                                            "message": "feat: Update verifier version in GHA installer (#747)\n\nThis is part of the release tests in\r\nhttps://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#dry-run\r\nto verify that the Action installer works.\r\n\r\nA follow up PR will be sent prior to release to update to `v2.5.0`\r\n\r\n---------\r\n\r\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
+                                            "timestamp": "2024-03-25T14:54:53Z",
+                                            "tree_id": "821166b47987861864888c07fde313b8be8ffc4c",
+                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/eb7007070baa04976cb9e25a0d8034f8db030a86"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -120,7 +135,7 @@
                                             "email": "64505099+laurentsimon@users.noreply.github.com",
                                             "name": "laurentsimon"
                                         },
-                                        "ref": "refs/tags/v2.4.1",
+                                        "ref": "refs/tags/v2.5.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/{archive_format}{/ref}",
@@ -144,8 +159,8 @@
                                             "downloads_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/downloads",
                                             "events_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/events",
                                             "fork": false,
-                                            "forks": 35,
-                                            "forks_count": 35,
+                                            "forks": 40,
+                                            "forks_count": 40,
                                             "forks_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/forks",
                                             "full_name": "slsa-framework/slsa-verifier",
                                             "git_commits_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/commits{/sha}",
@@ -184,8 +199,8 @@
                                             "name": "slsa-verifier",
                                             "node_id": "R_kgDOHEMl0g",
                                             "notifications_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/notifications{?since,all,participating}",
-                                            "open_issues": 123,
-                                            "open_issues_count": 123,
+                                            "open_issues": 129,
+                                            "open_issues_count": 129,
                                             "organization": "slsa-framework",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -211,12 +226,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/pulls{/number}",
-                                            "pushed_at": 1699396985,
+                                            "pushed_at": 1711379651,
                                             "releases_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases{/id}",
-                                            "size": 88467,
+                                            "size": 91684,
                                             "ssh_url": "git@github.com:slsa-framework/slsa-verifier.git",
-                                            "stargazers": 170,
-                                            "stargazers_count": 170,
+                                            "stargazers": 198,
+                                            "stargazers_count": 198,
                                             "stargazers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/stargazers",
                                             "statuses_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/subscribers",
@@ -226,11 +241,11 @@
                                             "teams_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/trees{/sha}",
-                                            "updated_at": "2023-10-17T17:58:10Z",
+                                            "updated_at": "2024-03-12T15:03:34Z",
                                             "url": "https://github.com/slsa-framework/slsa-verifier",
                                             "visibility": "public",
-                                            "watchers": 170,
-                                            "watchers_count": 170,
+                                            "watchers": 198,
+                                            "watchers_count": 198,
                                             "web_commit_signoff_required": true
                                         },
                                         "sender": {
@@ -255,15 +270,15 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.4.1",
+                                    "github_ref": "refs/tags/v2.5.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "474162642",
                                     "github_repository_owner": "slsa-framework",
                                     "github_repository_owner_id": "80431187",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6791195934",
-                                    "github_run_number": "511",
-                                    "github_sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                    "github_run_id": "8422431506",
+                                    "github_run_number": "655",
+                                    "github_sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                     "os": "ubuntu22"
                                 }
                             },
@@ -272,7 +287,7 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "mod",
                                             "vendor"
                                         ],
@@ -281,27 +296,27 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "build",
                                             "-mod=vendor",
                                             "-trimpath",
                                             "-tags=netgo",
-                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.4.1",
+                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.5.1",
                                             "-o",
                                             "slsa-verifier-darwin-amd64"
                                         ],
                                         "env": [
                                             "GOOS=darwin",
                                             "GOARCH=amd64",
-                                            "GO111MODULE=on",
-                                            "CGO_ENABLED=0"
+                                            "CGO_ENABLED=0",
+                                            "GO111MODULE=on"
                                         ]
                                     }
                                 ],
                                 "version": 1
                             },
                             "metadata": {
-                                "buildInvocationID": "6791195934-1",
+                                "buildInvocationID": "8422431506-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -311,13 +326,13 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     }
                                 },
                                 {
-                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20231030.2.0"
+                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20240317.1.0"
                                 }
                             ]
                         }
@@ -329,20 +344,20 @@
                             {
                                 "name": "slsa-verifier-darwin-arm64",
                                 "digest": {
-                                    "sha256": "ce1de214cb5ae24dfafce18640a0e7c4d2fbbd014bf4b2944a0c1b7b3cfa803a"
+                                    "sha256": "a4da3c85025f31f8a6de09c8261ec1c0793299fd82bc225c9608b0413083354f"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.8.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/go@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -354,13 +369,25 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                        "after": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                         "base_ref": "refs/heads/main",
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.4.1",
+                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.5.1",
                                         "created": true,
                                         "deleted": false,
+                                        "enterprise": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/b/102459?v=4",
+                                            "created_at": "2023-12-08T05:54:26Z",
+                                            "description": "Open Source Security Foundation (OpenSSF)",
+                                            "html_url": "https://github.com/enterprises/openssf",
+                                            "id": 102459,
+                                            "name": "Open Source Security Foundation",
+                                            "node_id": "E_kgDOAAGQOw",
+                                            "slug": "openssf",
+                                            "updated_at": "2024-01-06T00:47:02Z",
+                                            "website_url": "https://openssf.org/"
+                                        },
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
@@ -374,11 +401,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
-                                            "message": "docs: update release doc and rm binary (#716)\n\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
-                                            "timestamp": "2023-10-16T13:44:13-07:00",
-                                            "tree_id": "b70b194feb7247be9885bfff95f9640c84d0b8f5",
-                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                            "id": "eb7007070baa04976cb9e25a0d8034f8db030a86",
+                                            "message": "feat: Update verifier version in GHA installer (#747)\n\nThis is part of the release tests in\r\nhttps://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#dry-run\r\nto verify that the Action installer works.\r\n\r\nA follow up PR will be sent prior to release to update to `v2.5.0`\r\n\r\n---------\r\n\r\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
+                                            "timestamp": "2024-03-25T14:54:53Z",
+                                            "tree_id": "821166b47987861864888c07fde313b8be8ffc4c",
+                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/eb7007070baa04976cb9e25a0d8034f8db030a86"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -398,7 +425,7 @@
                                             "email": "64505099+laurentsimon@users.noreply.github.com",
                                             "name": "laurentsimon"
                                         },
-                                        "ref": "refs/tags/v2.4.1",
+                                        "ref": "refs/tags/v2.5.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/{archive_format}{/ref}",
@@ -422,8 +449,8 @@
                                             "downloads_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/downloads",
                                             "events_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/events",
                                             "fork": false,
-                                            "forks": 35,
-                                            "forks_count": 35,
+                                            "forks": 40,
+                                            "forks_count": 40,
                                             "forks_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/forks",
                                             "full_name": "slsa-framework/slsa-verifier",
                                             "git_commits_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/commits{/sha}",
@@ -462,8 +489,8 @@
                                             "name": "slsa-verifier",
                                             "node_id": "R_kgDOHEMl0g",
                                             "notifications_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/notifications{?since,all,participating}",
-                                            "open_issues": 123,
-                                            "open_issues_count": 123,
+                                            "open_issues": 129,
+                                            "open_issues_count": 129,
                                             "organization": "slsa-framework",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -489,12 +516,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/pulls{/number}",
-                                            "pushed_at": 1699396985,
+                                            "pushed_at": 1711379651,
                                             "releases_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases{/id}",
-                                            "size": 88467,
+                                            "size": 91684,
                                             "ssh_url": "git@github.com:slsa-framework/slsa-verifier.git",
-                                            "stargazers": 170,
-                                            "stargazers_count": 170,
+                                            "stargazers": 198,
+                                            "stargazers_count": 198,
                                             "stargazers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/stargazers",
                                             "statuses_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/subscribers",
@@ -504,11 +531,11 @@
                                             "teams_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/trees{/sha}",
-                                            "updated_at": "2023-10-17T17:58:10Z",
+                                            "updated_at": "2024-03-12T15:03:34Z",
                                             "url": "https://github.com/slsa-framework/slsa-verifier",
                                             "visibility": "public",
-                                            "watchers": 170,
-                                            "watchers_count": 170,
+                                            "watchers": 198,
+                                            "watchers_count": 198,
                                             "web_commit_signoff_required": true
                                         },
                                         "sender": {
@@ -533,15 +560,15 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.4.1",
+                                    "github_ref": "refs/tags/v2.5.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "474162642",
                                     "github_repository_owner": "slsa-framework",
                                     "github_repository_owner_id": "80431187",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6791195934",
-                                    "github_run_number": "511",
-                                    "github_sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                    "github_run_id": "8422431506",
+                                    "github_run_number": "655",
+                                    "github_sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                     "os": "ubuntu22"
                                 }
                             },
@@ -550,7 +577,7 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "mod",
                                             "vendor"
                                         ],
@@ -559,27 +586,27 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "build",
                                             "-mod=vendor",
                                             "-trimpath",
                                             "-tags=netgo",
-                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.4.1",
+                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.5.1",
                                             "-o",
                                             "slsa-verifier-darwin-arm64"
                                         ],
                                         "env": [
                                             "GOOS=darwin",
                                             "GOARCH=arm64",
-                                            "CGO_ENABLED=0",
-                                            "GO111MODULE=on"
+                                            "GO111MODULE=on",
+                                            "CGO_ENABLED=0"
                                         ]
                                     }
                                 ],
                                 "version": 1
                             },
                             "metadata": {
-                                "buildInvocationID": "6791195934-1",
+                                "buildInvocationID": "8422431506-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -589,13 +616,13 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     }
                                 },
                                 {
-                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20231030.2.0"
+                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20240317.1.0"
                                 }
                             ]
                         }
@@ -607,20 +634,20 @@
                             {
                                 "name": "slsa-verifier-linux-amd64",
                                 "digest": {
-                                    "sha256": "e81900c9f11a44276e1552afb7c1f6ea7b13ad9c6efdb920d97f23a76659e25f"
+                                    "sha256": "54e4f40bf120bce1cef1ff123fef3456e8c526f315c47e22ed6acfe02a06b9a8"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.8.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/go@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -632,13 +659,25 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                        "after": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                         "base_ref": "refs/heads/main",
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.4.1",
+                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.5.1",
                                         "created": true,
                                         "deleted": false,
+                                        "enterprise": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/b/102459?v=4",
+                                            "created_at": "2023-12-08T05:54:26Z",
+                                            "description": "Open Source Security Foundation (OpenSSF)",
+                                            "html_url": "https://github.com/enterprises/openssf",
+                                            "id": 102459,
+                                            "name": "Open Source Security Foundation",
+                                            "node_id": "E_kgDOAAGQOw",
+                                            "slug": "openssf",
+                                            "updated_at": "2024-01-06T00:47:02Z",
+                                            "website_url": "https://openssf.org/"
+                                        },
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
@@ -652,11 +691,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
-                                            "message": "docs: update release doc and rm binary (#716)\n\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
-                                            "timestamp": "2023-10-16T13:44:13-07:00",
-                                            "tree_id": "b70b194feb7247be9885bfff95f9640c84d0b8f5",
-                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                            "id": "eb7007070baa04976cb9e25a0d8034f8db030a86",
+                                            "message": "feat: Update verifier version in GHA installer (#747)\n\nThis is part of the release tests in\r\nhttps://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#dry-run\r\nto verify that the Action installer works.\r\n\r\nA follow up PR will be sent prior to release to update to `v2.5.0`\r\n\r\n---------\r\n\r\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
+                                            "timestamp": "2024-03-25T14:54:53Z",
+                                            "tree_id": "821166b47987861864888c07fde313b8be8ffc4c",
+                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/eb7007070baa04976cb9e25a0d8034f8db030a86"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -676,7 +715,7 @@
                                             "email": "64505099+laurentsimon@users.noreply.github.com",
                                             "name": "laurentsimon"
                                         },
-                                        "ref": "refs/tags/v2.4.1",
+                                        "ref": "refs/tags/v2.5.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/{archive_format}{/ref}",
@@ -700,8 +739,8 @@
                                             "downloads_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/downloads",
                                             "events_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/events",
                                             "fork": false,
-                                            "forks": 35,
-                                            "forks_count": 35,
+                                            "forks": 40,
+                                            "forks_count": 40,
                                             "forks_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/forks",
                                             "full_name": "slsa-framework/slsa-verifier",
                                             "git_commits_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/commits{/sha}",
@@ -740,8 +779,8 @@
                                             "name": "slsa-verifier",
                                             "node_id": "R_kgDOHEMl0g",
                                             "notifications_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/notifications{?since,all,participating}",
-                                            "open_issues": 123,
-                                            "open_issues_count": 123,
+                                            "open_issues": 129,
+                                            "open_issues_count": 129,
                                             "organization": "slsa-framework",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -767,12 +806,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/pulls{/number}",
-                                            "pushed_at": 1699396985,
+                                            "pushed_at": 1711379651,
                                             "releases_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases{/id}",
-                                            "size": 88467,
+                                            "size": 91684,
                                             "ssh_url": "git@github.com:slsa-framework/slsa-verifier.git",
-                                            "stargazers": 170,
-                                            "stargazers_count": 170,
+                                            "stargazers": 198,
+                                            "stargazers_count": 198,
                                             "stargazers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/stargazers",
                                             "statuses_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/subscribers",
@@ -782,11 +821,11 @@
                                             "teams_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/trees{/sha}",
-                                            "updated_at": "2023-10-17T17:58:10Z",
+                                            "updated_at": "2024-03-12T15:03:34Z",
                                             "url": "https://github.com/slsa-framework/slsa-verifier",
                                             "visibility": "public",
-                                            "watchers": 170,
-                                            "watchers_count": 170,
+                                            "watchers": 198,
+                                            "watchers_count": 198,
                                             "web_commit_signoff_required": true
                                         },
                                         "sender": {
@@ -811,15 +850,15 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.4.1",
+                                    "github_ref": "refs/tags/v2.5.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "474162642",
                                     "github_repository_owner": "slsa-framework",
                                     "github_repository_owner_id": "80431187",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6791195934",
-                                    "github_run_number": "511",
-                                    "github_sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                    "github_run_id": "8422431506",
+                                    "github_run_number": "655",
+                                    "github_sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                     "os": "ubuntu22"
                                 }
                             },
@@ -828,7 +867,7 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "mod",
                                             "vendor"
                                         ],
@@ -837,12 +876,12 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "build",
                                             "-mod=vendor",
                                             "-trimpath",
                                             "-tags=netgo",
-                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.4.1",
+                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.5.1",
                                             "-o",
                                             "slsa-verifier-linux-amd64"
                                         ],
@@ -857,7 +896,7 @@
                                 "version": 1
                             },
                             "metadata": {
-                                "buildInvocationID": "6791195934-1",
+                                "buildInvocationID": "8422431506-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -867,13 +906,13 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     }
                                 },
                                 {
-                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20231030.2.0"
+                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20240317.1.0"
                                 }
                             ]
                         }
@@ -885,20 +924,20 @@
                             {
                                 "name": "slsa-verifier-linux-arm64",
                                 "digest": {
-                                    "sha256": "8b9bcc51576a8f962a0f91f50bed8ca769563ef568a2e9997ca4cd59dc2e341a"
+                                    "sha256": "5dd8a396c285c4d0d66dcb4eff82c12cd388049106aacd4f2552546f85100064"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.8.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/go@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -910,13 +949,25 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                        "after": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                         "base_ref": "refs/heads/main",
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.4.1",
+                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.5.1",
                                         "created": true,
                                         "deleted": false,
+                                        "enterprise": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/b/102459?v=4",
+                                            "created_at": "2023-12-08T05:54:26Z",
+                                            "description": "Open Source Security Foundation (OpenSSF)",
+                                            "html_url": "https://github.com/enterprises/openssf",
+                                            "id": 102459,
+                                            "name": "Open Source Security Foundation",
+                                            "node_id": "E_kgDOAAGQOw",
+                                            "slug": "openssf",
+                                            "updated_at": "2024-01-06T00:47:02Z",
+                                            "website_url": "https://openssf.org/"
+                                        },
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
@@ -930,11 +981,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
-                                            "message": "docs: update release doc and rm binary (#716)\n\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
-                                            "timestamp": "2023-10-16T13:44:13-07:00",
-                                            "tree_id": "b70b194feb7247be9885bfff95f9640c84d0b8f5",
-                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                            "id": "eb7007070baa04976cb9e25a0d8034f8db030a86",
+                                            "message": "feat: Update verifier version in GHA installer (#747)\n\nThis is part of the release tests in\r\nhttps://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#dry-run\r\nto verify that the Action installer works.\r\n\r\nA follow up PR will be sent prior to release to update to `v2.5.0`\r\n\r\n---------\r\n\r\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
+                                            "timestamp": "2024-03-25T14:54:53Z",
+                                            "tree_id": "821166b47987861864888c07fde313b8be8ffc4c",
+                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/eb7007070baa04976cb9e25a0d8034f8db030a86"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -954,7 +1005,7 @@
                                             "email": "64505099+laurentsimon@users.noreply.github.com",
                                             "name": "laurentsimon"
                                         },
-                                        "ref": "refs/tags/v2.4.1",
+                                        "ref": "refs/tags/v2.5.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/{archive_format}{/ref}",
@@ -978,8 +1029,8 @@
                                             "downloads_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/downloads",
                                             "events_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/events",
                                             "fork": false,
-                                            "forks": 35,
-                                            "forks_count": 35,
+                                            "forks": 40,
+                                            "forks_count": 40,
                                             "forks_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/forks",
                                             "full_name": "slsa-framework/slsa-verifier",
                                             "git_commits_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/commits{/sha}",
@@ -1018,8 +1069,8 @@
                                             "name": "slsa-verifier",
                                             "node_id": "R_kgDOHEMl0g",
                                             "notifications_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/notifications{?since,all,participating}",
-                                            "open_issues": 123,
-                                            "open_issues_count": 123,
+                                            "open_issues": 129,
+                                            "open_issues_count": 129,
                                             "organization": "slsa-framework",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -1045,12 +1096,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/pulls{/number}",
-                                            "pushed_at": 1699396985,
+                                            "pushed_at": 1711379651,
                                             "releases_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases{/id}",
-                                            "size": 88467,
+                                            "size": 91684,
                                             "ssh_url": "git@github.com:slsa-framework/slsa-verifier.git",
-                                            "stargazers": 170,
-                                            "stargazers_count": 170,
+                                            "stargazers": 198,
+                                            "stargazers_count": 198,
                                             "stargazers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/stargazers",
                                             "statuses_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/subscribers",
@@ -1060,11 +1111,11 @@
                                             "teams_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/trees{/sha}",
-                                            "updated_at": "2023-10-17T17:58:10Z",
+                                            "updated_at": "2024-03-12T15:03:34Z",
                                             "url": "https://github.com/slsa-framework/slsa-verifier",
                                             "visibility": "public",
-                                            "watchers": 170,
-                                            "watchers_count": 170,
+                                            "watchers": 198,
+                                            "watchers_count": 198,
                                             "web_commit_signoff_required": true
                                         },
                                         "sender": {
@@ -1089,15 +1140,15 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.4.1",
+                                    "github_ref": "refs/tags/v2.5.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "474162642",
                                     "github_repository_owner": "slsa-framework",
                                     "github_repository_owner_id": "80431187",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6791195934",
-                                    "github_run_number": "511",
-                                    "github_sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                    "github_run_id": "8422431506",
+                                    "github_run_number": "655",
+                                    "github_sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                     "os": "ubuntu22"
                                 }
                             },
@@ -1106,7 +1157,7 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "mod",
                                             "vendor"
                                         ],
@@ -1115,12 +1166,12 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "build",
                                             "-mod=vendor",
                                             "-trimpath",
                                             "-tags=netgo",
-                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.4.1",
+                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.5.1",
                                             "-o",
                                             "slsa-verifier-linux-arm64"
                                         ],
@@ -1135,7 +1186,7 @@
                                 "version": 1
                             },
                             "metadata": {
-                                "buildInvocationID": "6791195934-1",
+                                "buildInvocationID": "8422431506-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -1145,13 +1196,13 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     }
                                 },
                                 {
-                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20231030.2.0"
+                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20240317.1.0"
                                 }
                             ]
                         }
@@ -1163,20 +1214,20 @@
                             {
                                 "name": "slsa-verifier-windows-amd64.exe",
                                 "digest": {
-                                    "sha256": "cda4a71f6e6fbfb32aa5b461b650d807503ad509145dc0df9b68adb9e23e674f"
+                                    "sha256": "e635c8f27d9a485cae3c9846550511fef78ed2b57902ef62ad49d37e1df22e98"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.8.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/go@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -1188,13 +1239,25 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                        "after": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                         "base_ref": "refs/heads/main",
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.4.1",
+                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.5.1",
                                         "created": true,
                                         "deleted": false,
+                                        "enterprise": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/b/102459?v=4",
+                                            "created_at": "2023-12-08T05:54:26Z",
+                                            "description": "Open Source Security Foundation (OpenSSF)",
+                                            "html_url": "https://github.com/enterprises/openssf",
+                                            "id": 102459,
+                                            "name": "Open Source Security Foundation",
+                                            "node_id": "E_kgDOAAGQOw",
+                                            "slug": "openssf",
+                                            "updated_at": "2024-01-06T00:47:02Z",
+                                            "website_url": "https://openssf.org/"
+                                        },
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
@@ -1208,11 +1271,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
-                                            "message": "docs: update release doc and rm binary (#716)\n\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
-                                            "timestamp": "2023-10-16T13:44:13-07:00",
-                                            "tree_id": "b70b194feb7247be9885bfff95f9640c84d0b8f5",
-                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                            "id": "eb7007070baa04976cb9e25a0d8034f8db030a86",
+                                            "message": "feat: Update verifier version in GHA installer (#747)\n\nThis is part of the release tests in\r\nhttps://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#dry-run\r\nto verify that the Action installer works.\r\n\r\nA follow up PR will be sent prior to release to update to `v2.5.0`\r\n\r\n---------\r\n\r\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
+                                            "timestamp": "2024-03-25T14:54:53Z",
+                                            "tree_id": "821166b47987861864888c07fde313b8be8ffc4c",
+                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/eb7007070baa04976cb9e25a0d8034f8db030a86"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -1232,7 +1295,7 @@
                                             "email": "64505099+laurentsimon@users.noreply.github.com",
                                             "name": "laurentsimon"
                                         },
-                                        "ref": "refs/tags/v2.4.1",
+                                        "ref": "refs/tags/v2.5.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/{archive_format}{/ref}",
@@ -1256,8 +1319,8 @@
                                             "downloads_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/downloads",
                                             "events_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/events",
                                             "fork": false,
-                                            "forks": 35,
-                                            "forks_count": 35,
+                                            "forks": 40,
+                                            "forks_count": 40,
                                             "forks_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/forks",
                                             "full_name": "slsa-framework/slsa-verifier",
                                             "git_commits_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/commits{/sha}",
@@ -1296,8 +1359,8 @@
                                             "name": "slsa-verifier",
                                             "node_id": "R_kgDOHEMl0g",
                                             "notifications_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/notifications{?since,all,participating}",
-                                            "open_issues": 123,
-                                            "open_issues_count": 123,
+                                            "open_issues": 129,
+                                            "open_issues_count": 129,
                                             "organization": "slsa-framework",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -1323,12 +1386,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/pulls{/number}",
-                                            "pushed_at": 1699396985,
+                                            "pushed_at": 1711379651,
                                             "releases_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases{/id}",
-                                            "size": 88467,
+                                            "size": 91684,
                                             "ssh_url": "git@github.com:slsa-framework/slsa-verifier.git",
-                                            "stargazers": 170,
-                                            "stargazers_count": 170,
+                                            "stargazers": 198,
+                                            "stargazers_count": 198,
                                             "stargazers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/stargazers",
                                             "statuses_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/subscribers",
@@ -1338,11 +1401,11 @@
                                             "teams_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/trees{/sha}",
-                                            "updated_at": "2023-10-17T17:58:10Z",
+                                            "updated_at": "2024-03-12T15:03:34Z",
                                             "url": "https://github.com/slsa-framework/slsa-verifier",
                                             "visibility": "public",
-                                            "watchers": 170,
-                                            "watchers_count": 170,
+                                            "watchers": 198,
+                                            "watchers_count": 198,
                                             "web_commit_signoff_required": true
                                         },
                                         "sender": {
@@ -1367,15 +1430,15 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.4.1",
+                                    "github_ref": "refs/tags/v2.5.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "474162642",
                                     "github_repository_owner": "slsa-framework",
                                     "github_repository_owner_id": "80431187",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6791195934",
-                                    "github_run_number": "511",
-                                    "github_sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                    "github_run_id": "8422431506",
+                                    "github_run_number": "655",
+                                    "github_sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                     "os": "ubuntu22"
                                 }
                             },
@@ -1384,7 +1447,7 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "mod",
                                             "vendor"
                                         ],
@@ -1393,12 +1456,12 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "build",
                                             "-mod=vendor",
                                             "-trimpath",
                                             "-tags=netgo",
-                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.4.1",
+                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.5.1",
                                             "-o",
                                             "slsa-verifier-windows-amd64.exe"
                                         ],
@@ -1413,7 +1476,7 @@
                                 "version": 1
                             },
                             "metadata": {
-                                "buildInvocationID": "6791195934-1",
+                                "buildInvocationID": "8422431506-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -1423,13 +1486,13 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     }
                                 },
                                 {
-                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20231030.2.0"
+                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20240317.1.0"
                                 }
                             ]
                         }
@@ -1441,20 +1504,20 @@
                             {
                                 "name": "slsa-verifier-windows-arm64.exe",
                                 "digest": {
-                                    "sha256": "8f0b03c01271c7228e99f21c89b99c0b02dc0cc7bdce0fe842af1dc7554d644f"
+                                    "sha256": "9b08bc2ba25a84e06ecfeecdcabc7e8339da15d272cfd647aa7e3f7f09cb55d5"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.8.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.10.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/go@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     },
                                     "entryPoint": ".github/workflows/release.yml"
                                 },
@@ -1466,13 +1529,25 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                        "after": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                         "base_ref": "refs/heads/main",
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.4.1",
+                                        "compare": "https://github.com/slsa-framework/slsa-verifier/compare/v2.5.1",
                                         "created": true,
                                         "deleted": false,
+                                        "enterprise": {
+                                            "avatar_url": "https://avatars.githubusercontent.com/b/102459?v=4",
+                                            "created_at": "2023-12-08T05:54:26Z",
+                                            "description": "Open Source Security Foundation (OpenSSF)",
+                                            "html_url": "https://github.com/enterprises/openssf",
+                                            "id": 102459,
+                                            "name": "Open Source Security Foundation",
+                                            "node_id": "E_kgDOAAGQOw",
+                                            "slug": "openssf",
+                                            "updated_at": "2024-01-06T00:47:02Z",
+                                            "website_url": "https://openssf.org/"
+                                        },
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
@@ -1486,11 +1561,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
-                                            "message": "docs: update release doc and rm binary (#716)\n\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
-                                            "timestamp": "2023-10-16T13:44:13-07:00",
-                                            "tree_id": "b70b194feb7247be9885bfff95f9640c84d0b8f5",
-                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                            "id": "eb7007070baa04976cb9e25a0d8034f8db030a86",
+                                            "message": "feat: Update verifier version in GHA installer (#747)\n\nThis is part of the release tests in\r\nhttps://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#dry-run\r\nto verify that the Action installer works.\r\n\r\nA follow up PR will be sent prior to release to update to `v2.5.0`\r\n\r\n---------\r\n\r\nSigned-off-by: laurentsimon <laurentsimon@google.com>",
+                                            "timestamp": "2024-03-25T14:54:53Z",
+                                            "tree_id": "821166b47987861864888c07fde313b8be8ffc4c",
+                                            "url": "https://github.com/slsa-framework/slsa-verifier/commit/eb7007070baa04976cb9e25a0d8034f8db030a86"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -1510,7 +1585,7 @@
                                             "email": "64505099+laurentsimon@users.noreply.github.com",
                                             "name": "laurentsimon"
                                         },
-                                        "ref": "refs/tags/v2.4.1",
+                                        "ref": "refs/tags/v2.5.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/{archive_format}{/ref}",
@@ -1534,8 +1609,8 @@
                                             "downloads_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/downloads",
                                             "events_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/events",
                                             "fork": false,
-                                            "forks": 35,
-                                            "forks_count": 35,
+                                            "forks": 40,
+                                            "forks_count": 40,
                                             "forks_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/forks",
                                             "full_name": "slsa-framework/slsa-verifier",
                                             "git_commits_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/commits{/sha}",
@@ -1574,8 +1649,8 @@
                                             "name": "slsa-verifier",
                                             "node_id": "R_kgDOHEMl0g",
                                             "notifications_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/notifications{?since,all,participating}",
-                                            "open_issues": 123,
-                                            "open_issues_count": 123,
+                                            "open_issues": 129,
+                                            "open_issues_count": 129,
                                             "organization": "slsa-framework",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/80431187?v=4",
@@ -1601,12 +1676,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/pulls{/number}",
-                                            "pushed_at": 1699396985,
+                                            "pushed_at": 1711379651,
                                             "releases_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases{/id}",
-                                            "size": 88467,
+                                            "size": 91684,
                                             "ssh_url": "git@github.com:slsa-framework/slsa-verifier.git",
-                                            "stargazers": 170,
-                                            "stargazers_count": 170,
+                                            "stargazers": 198,
+                                            "stargazers_count": 198,
                                             "stargazers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/stargazers",
                                             "statuses_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/subscribers",
@@ -1616,11 +1691,11 @@
                                             "teams_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/teams",
                                             "topics": [],
                                             "trees_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/git/trees{/sha}",
-                                            "updated_at": "2023-10-17T17:58:10Z",
+                                            "updated_at": "2024-03-12T15:03:34Z",
                                             "url": "https://github.com/slsa-framework/slsa-verifier",
                                             "visibility": "public",
-                                            "watchers": 170,
-                                            "watchers_count": 170,
+                                            "watchers": 198,
+                                            "watchers_count": 198,
                                             "web_commit_signoff_required": true
                                         },
                                         "sender": {
@@ -1645,15 +1720,15 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.4.1",
+                                    "github_ref": "refs/tags/v2.5.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "474162642",
                                     "github_repository_owner": "slsa-framework",
                                     "github_repository_owner_id": "80431187",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6791195934",
-                                    "github_run_number": "511",
-                                    "github_sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95",
+                                    "github_run_id": "8422431506",
+                                    "github_run_number": "655",
+                                    "github_sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86",
                                     "os": "ubuntu22"
                                 }
                             },
@@ -1662,7 +1737,7 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "mod",
                                             "vendor"
                                         ],
@@ -1671,27 +1746,27 @@
                                     {
                                         "workingDir": "/home/runner/work/slsa-verifier/slsa-verifier/__PROJECT_CHECKOUT_DIR__/cli/slsa-verifier",
                                         "command": [
-                                            "/opt/hostedtoolcache/go/1.20.10/x64/bin/go",
+                                            "/opt/hostedtoolcache/go/1.21.8/x64/bin/go",
                                             "build",
                                             "-mod=vendor",
                                             "-trimpath",
                                             "-tags=netgo",
-                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.4.1",
+                                            "-ldflags=-X sigs.k8s.io/release-utils/version.gitVersion=2.5.1",
                                             "-o",
                                             "slsa-verifier-windows-arm64.exe"
                                         ],
                                         "env": [
                                             "GOOS=windows",
                                             "GOARCH=arm64",
-                                            "CGO_ENABLED=0",
-                                            "GO111MODULE=on"
+                                            "GO111MODULE=on",
+                                            "CGO_ENABLED=0"
                                         ]
                                     }
                                 ],
                                 "version": 1
                             },
                             "metadata": {
-                                "buildInvocationID": "6791195934-1",
+                                "buildInvocationID": "8422431506-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -1701,13 +1776,13 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.4.1",
+                                    "uri": "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.5.1",
                                     "digest": {
-                                        "sha1": "7e1e47d7d793930ab0082c15c2b971fdb53a3c95"
+                                        "sha1": "eb7007070baa04976cb9e25a0d8034f8db030a86"
                                     }
                                 },
                                 {
-                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20231030.2.0"
+                                    "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu22/20240317.1.0"
                                 }
                             ]
                         }
@@ -1719,7 +1794,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 2,
+                "FAILED": 4,
                 "PASSED": 7,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -1732,7 +1807,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_build_as_code_1 is set to PASSED because mcn_trusted_builder_level_three_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -1743,7 +1818,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: go",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.GO",
+                        "build_tool_command: [\"go\", \"build\", \"-mod=vendor\", \"-o\", \"service\", \"./cli/experimental/service/\"]",
+                        {
+                            "build_trigger": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/pre-submit.cli.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -1754,7 +1835,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -1768,13 +1849,10 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Found provenance in release assets:",
-                        "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/134437052",
-                        "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/134437111",
-                        "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/134437099",
-                        "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/134437059",
-                        "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/134437166",
-                        "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/134437048"
+                        "asset_name: slsa-verifier-darwin-amd64.intoto.jsonl",
+                        {
+                            "asset_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/158521660"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -1785,7 +1863,9 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Successfully verified the expectation against provenance."
+                        {
+                            "asset_url": "https://api.github.com/repos/slsa-framework/slsa-verifier/releases/assets/158521660"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -1799,10 +1879,11 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.0",
+                        "ci_service_name: github_actions",
                         {
-                            "Found trusted builder GitHub Actions: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.0 triggered by": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/release.yml"
-                        },
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/release.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -1814,7 +1895,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/slsa-framework/slsa-verifier"
+                            "git_repo": "https://github.com/slsa-framework/slsa-verifier"
                         }
                     ],
                     "result_type": "PASSED"
@@ -1826,7 +1907,29 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -1840,7 +1943,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Failed to discover any witness provenance."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -1852,7 +1955,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -1864,6 +1967,18 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
@@ -1872,11 +1987,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
@@ -1884,11 +1999,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/slsa-verifier/slsa-verifier_explicitly_provided_cue_PASS.json
+++ b/tests/e2e/expected_results/slsa-verifier/slsa-verifier_explicitly_provided_cue_PASS.json
@@ -1,33 +1,37 @@
 {
     "metadata": {
-        "timestamps": "2024-04-18 13:30:07",
+        "timestamps": "2024-05-07 15:16:38",
         "has_passing_check": true,
         "run_checks": [
-            "mcn_provenance_expectation_1",
-            "mcn_build_as_code_1",
-            "mcn_infer_artifact_pipeline_1",
-            "mcn_provenance_witness_level_one_1",
-            "mcn_provenance_available_1",
-            "mcn_build_service_1",
-            "mcn_trusted_builder_level_three_1",
             "mcn_build_script_1",
-            "mcn_version_control_system_1"
+            "mcn_build_service_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_provenance_derived_repo_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_available_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_provenance_expectation_1",
+            "mcn_version_control_system_1",
+            "mcn_provenance_witness_level_one_1"
         ],
         "check_tree": {
             "mcn_provenance_available_1": {
-                "mcn_provenance_level_three_1": {},
                 "mcn_provenance_expectation_1": {},
-                "mcn_provenance_witness_level_one_1": {}
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_level_three_1": {}
             },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
                 "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_infer_artifact_pipeline_1": {},
-                        "mcn_build_service_1": {}
+                        "mcn_build_service_1": {},
+                        "mcn_infer_artifact_pipeline_1": {}
                     }
                 }
-            }
+            },
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -94,8 +98,8 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 2,
-                "PASSED": 7,
+                "FAILED": 3,
+                "PASSED": 8,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
             },
@@ -154,6 +158,17 @@
                     "result_type": "PASSED"
                 },
                 {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: The repository URL was found from provenance."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
                     "check_id": "mcn_provenance_expectation_1",
                     "check_description": "Check whether the SLSA provenance for the produced artifact conforms to the expected value.",
                     "slsa_requirements": [
@@ -207,6 +222,17 @@
                     "result_type": "FAILED"
                 },
                 {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: The analysis commit did not match the provenance commit."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
                     "check_id": "mcn_provenance_witness_level_one_1",
                     "check_description": "Check whether the target has a level-1 witness provenance.",
                     "slsa_requirements": [
@@ -232,15 +258,35 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_witness_level_one_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
@@ -252,19 +298,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_provenance_level_three_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/snakeyaml/snakeyaml.json
+++ b/tests/e2e/expected_results/snakeyaml/snakeyaml.json
@@ -1,34 +1,38 @@
 {
     "metadata": {
-        "timestamps": "2024-04-10 11:28:34",
+        "timestamps": "2024-05-07 15:14:26",
         "has_passing_check": true,
         "run_checks": [
             "mcn_provenance_available_1",
-            "mcn_version_control_system_1",
             "mcn_provenance_witness_level_one_1",
             "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
             "mcn_infer_artifact_pipeline_1",
             "mcn_trusted_builder_level_three_1",
-            "mcn_provenance_level_three_1",
             "mcn_build_script_1",
+            "mcn_build_service_1",
             "mcn_provenance_expectation_1",
-            "mcn_build_service_1"
+            "mcn_provenance_derived_repo_1"
         ],
         "check_tree": {
             "mcn_provenance_available_1": {
                 "mcn_provenance_level_three_1": {},
-                "mcn_provenance_expectation_1": {},
-                "mcn_provenance_witness_level_one_1": {}
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {}
             },
+            "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_build_service_1": {},
-                        "mcn_infer_artifact_pipeline_1": {}
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
                     }
-                },
-                "mcn_build_script_1": {}
-            }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
@@ -49,7 +53,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 8,
+                "FAILED": 10,
                 "PASSED": 2,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -127,6 +131,28 @@
                     "result_type": "FAILED"
                 },
                 {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
                     "check_id": "mcn_provenance_expectation_1",
                     "check_description": "Check whether the SLSA provenance for the produced artifact conforms to the expected value.",
                     "slsa_requirements": [
@@ -191,15 +217,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_provenance_witness_level_one_1",
                 "num_deps_pass": 0
             },
             {
                 "check_id": "mcn_build_as_code_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_version_control_system_1",
                 "num_deps_pass": 0
             },
             {
@@ -211,11 +245,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_script_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_script_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
@@ -223,7 +257,7 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/tinyMediaManager/tinyMediaManager.json
+++ b/tests/e2e/expected_results/tinyMediaManager/tinyMediaManager.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-12 17:07:11"
+        "timestamps": "2024-05-07 15:09:37",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -65,7 +98,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 8,
+                "FAILED": 10,
                 "PASSED": 2,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -78,8 +111,7 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "The target repository uses build tool maven.",
-                        "The target repository uses build tool docker."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -91,7 +123,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://gitlab.com/tinyMediaManager/tinyMediaManager"
+                            "git_repo": "https://gitlab.com/tinyMediaManager/tinyMediaManager"
                         }
                     ],
                     "result_type": "PASSED"
@@ -103,8 +135,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "The target repository does not use maven to deploy.",
-                        "The target repository does not use docker to deploy."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -115,9 +146,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "The target repository does not have a build service for maven.",
-                        "The target repository does not have a build service for docker.",
-                        "The target repository does not have a build service for at least one build tool."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -128,7 +157,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_infer_artifact_pipeline_1 is set to FAILED because mcn_build_as_code_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -142,7 +171,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -153,7 +204,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -167,7 +218,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -181,7 +232,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -195,7 +246,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -207,7 +258,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -215,19 +266,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -239,11 +294,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/uiv/uiv.json
+++ b/tests/e2e/expected_results/uiv/uiv.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-21 07:27:24"
+        "timestamps": "2024-05-07 15:10:16",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -37,10 +70,11 @@
                             },
                             "buildConfig": {
                                 "jobID": "deploy_npm",
-                                "stepID": "Publish NPM"
+                                "stepID": "",
+                                "stepName": "Publish NPM"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -58,13 +92,14 @@
                             ]
                         }
                     }
-                ]
+                ],
+                "npm Registry": []
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -77,13 +112,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "deploy_command: [\"npm\", \"publish\"]",
                         {
-                            "The target repository uses build tool npm to deploy": "https://github.com/uiv-lib/uiv/blob/057b25b4db0913edab4cf728c306085e6fc20d49/.github/workflows/publish_npm.yaml",
-                            "The build is triggered by": "https://github.com/uiv-lib/uiv/blob/057b25b4db0913edab4cf728c306085e6fc20d49/.github/workflows/publish_npm.yaml"
-                        },
-                        "Deploy command: ['npm', 'publish']",
-                        "However, could not find a passing workflow run.",
-                        "The target repository does not use yarn to deploy."
+                            "build_trigger": "https://github.com/uiv-lib/uiv/blob/057b25b4db0913edab4cf728c306085e6fc20d49/.github/workflows/publish_npm.yaml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -94,7 +129,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: npm",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVASCRIPT",
+                        "build_tool_command: [\"pnpm\", \"run\", \"dist\"]",
+                        {
+                            "build_trigger": "https://github.com/uiv-lib/uiv/blob/057b25b4db0913edab4cf728c306085e6fc20d49/.github/workflows/main.yaml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -105,7 +146,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -117,7 +158,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/uiv-lib/uiv"
+                            "git_repo": "https://github.com/uiv-lib/uiv"
                         }
                     ],
                     "result_type": "PASSED"
@@ -129,7 +170,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -143,7 +184,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -154,7 +217,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -168,7 +231,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -182,7 +245,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -196,7 +259,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -208,23 +271,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -232,11 +279,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_commit_1",
                 "num_deps_pass": 0
             },
             {
@@ -244,7 +291,31 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/urllib3/urllib3.json
+++ b/tests/e2e/expected_results/urllib3/urllib3.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-22 14:22:34"
+        "timestamps": "2024-05-07 15:09:58",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_build_script_1": {},
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                }
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -20,15 +53,15 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "subject": [
                             {
-                                "name": "urllib3-2.0.5-py3-none-any.whl",
+                                "name": "urllib3-2.2.1-py3-none-any.whl",
                                 "digest": {
-                                    "sha256": "ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
+                                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
                                 }
                             },
                             {
-                                "name": "urllib3-2.0.5.tar.gz",
+                                "name": "urllib3-2.2.1.tar.gz",
                                 "digest": {
-                                    "sha256": "13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594"
+                                    "sha256": "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
                                 }
                             }
                         ],
@@ -39,9 +72,9 @@
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/generic@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/v2.0.5",
+                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/2.2.1",
                                     "digest": {
-                                        "sha1": "d9f85a749488188c286cd50606d159874db94d5f"
+                                        "sha1": "54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                     },
                                     "entryPoint": ".github/workflows/publish.yml"
                                 },
@@ -52,11 +85,11 @@
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "d4e424a471c79f245740a3734567e7402c036620",
+                                        "after": "0b4566e65ca046823dd92a490ae33c17bbb88fcb",
                                         "base_ref": null,
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/urllib3/urllib3/compare/v2.0.5",
+                                        "compare": "https://github.com/urllib3/urllib3/compare/2.2.1",
                                         "created": true,
                                         "deleted": false,
                                         "forced": false,
@@ -72,11 +105,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "d9f85a749488188c286cd50606d159874db94d5f",
-                                            "message": "Release 2.0.5",
-                                            "timestamp": "2023-09-20T08:59:31+02:00",
-                                            "tree_id": "842632ede50bc641555c90779642ab521e0c1401",
-                                            "url": "https://github.com/urllib3/urllib3/commit/d9f85a749488188c286cd50606d159874db94d5f"
+                                            "id": "54d6edf2a671510a5c029d3b76ffe71a5b07147a",
+                                            "message": "Release 2.2.1",
+                                            "timestamp": "2024-02-18T07:44:08+04:00",
+                                            "tree_id": "a702e15d622eccc7cf18243e6a4a62d19e19579d",
+                                            "url": "https://github.com/urllib3/urllib3/commit/54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/26825299?v=4",
@@ -96,7 +129,7 @@
                                             "email": "quentin.pradet@gmail.com",
                                             "name": "pquentin"
                                         },
-                                        "ref": "refs/tags/v2.0.5",
+                                        "ref": "refs/tags/2.2.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/urllib3/urllib3/{archive_format}{/ref}",
@@ -112,6 +145,7 @@
                                             "contents_url": "https://api.github.com/repos/urllib3/urllib3/contents/{+path}",
                                             "contributors_url": "https://api.github.com/repos/urllib3/urllib3/contributors",
                                             "created_at": 1316369308,
+                                            "custom_properties": {},
                                             "default_branch": "main",
                                             "deployments_url": "https://api.github.com/repos/urllib3/urllib3/deployments",
                                             "description": "urllib3 is a user-friendly HTTP client library for Python",
@@ -119,8 +153,8 @@
                                             "downloads_url": "https://api.github.com/repos/urllib3/urllib3/downloads",
                                             "events_url": "https://api.github.com/repos/urllib3/urllib3/events",
                                             "fork": false,
-                                            "forks": 1092,
-                                            "forks_count": 1092,
+                                            "forks": 1134,
+                                            "forks_count": 1134,
                                             "forks_url": "https://api.github.com/repos/urllib3/urllib3/forks",
                                             "full_name": "urllib3/urllib3",
                                             "git_commits_url": "https://api.github.com/repos/urllib3/urllib3/git/commits{/sha}",
@@ -159,8 +193,8 @@
                                             "name": "urllib3",
                                             "node_id": "MDEwOlJlcG9zaXRvcnkyNDEwNjc2",
                                             "notifications_url": "https://api.github.com/repos/urllib3/urllib3/notifications{?since,all,participating}",
-                                            "open_issues": 130,
-                                            "open_issues_count": 130,
+                                            "open_issues": 137,
+                                            "open_issues_count": 137,
                                             "organization": "urllib3",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/26825299?v=4",
@@ -186,12 +220,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/urllib3/urllib3/pulls{/number}",
-                                            "pushed_at": 1695193235,
+                                            "pushed_at": 1708227973,
                                             "releases_url": "https://api.github.com/repos/urllib3/urllib3/releases{/id}",
-                                            "size": 6839,
+                                            "size": 7144,
                                             "ssh_url": "git@github.com:urllib3/urllib3.git",
-                                            "stargazers": 3485,
-                                            "stargazers_count": 3485,
+                                            "stargazers": 3625,
+                                            "stargazers_count": 3625,
                                             "stargazers_url": "https://api.github.com/repos/urllib3/urllib3/stargazers",
                                             "statuses_url": "https://api.github.com/repos/urllib3/urllib3/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/urllib3/urllib3/subscribers",
@@ -206,11 +240,11 @@
                                                 "urllib3"
                                             ],
                                             "trees_url": "https://api.github.com/repos/urllib3/urllib3/git/trees{/sha}",
-                                            "updated_at": "2023-09-19T20:11:25Z",
+                                            "updated_at": "2024-02-16T15:03:16Z",
                                             "url": "https://github.com/urllib3/urllib3",
                                             "visibility": "public",
-                                            "watchers": 3485,
-                                            "watchers_count": 3485,
+                                            "watchers": 3625,
+                                            "watchers_count": 3625,
                                             "web_commit_signoff_required": false
                                         },
                                         "sender": {
@@ -235,19 +269,19 @@
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/v2.0.5",
+                                    "github_ref": "refs/tags/2.2.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "2410676",
                                     "github_repository_owner": "urllib3",
                                     "github_repository_owner_id": "26825299",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "6245105149",
-                                    "github_run_number": "22",
-                                    "github_sha1": "d9f85a749488188c286cd50606d159874db94d5f"
+                                    "github_run_id": "7946373606",
+                                    "github_run_number": "29",
+                                    "github_sha1": "54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                 }
                             },
                             "metadata": {
-                                "buildInvocationID": "6245105149-1",
+                                "buildInvocationID": "7946373606-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -257,9 +291,9 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/v2.0.5",
+                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/2.2.1",
                                     "digest": {
-                                        "sha1": "d9f85a749488188c286cd50606d159874db94d5f"
+                                        "sha1": "54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                     }
                                 }
                             ]
@@ -271,7 +305,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 3,
+                "FAILED": 5,
                 "PASSED": 7,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -284,12 +318,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: pip",
+                        "ci_service_name: github_actions",
+                        "language: python",
+                        "deploy_command: pypa/gh-action-pypi-publish",
                         {
-                            "The target repository uses build tool pip to deploy": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/publish.yml",
-                            "The build is triggered by": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/publish.yml"
-                        },
-                        "Deploy action: pypa/gh-action-pypi-publish",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/publish.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -300,7 +335,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: pip",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.PYTHON",
+                        "build_tool_command: [\"python\", \"-m\", \"build\"]",
+                        {
+                            "build_trigger": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/ci.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -311,7 +352,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -325,8 +366,10 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Found provenance in release assets:",
-                        "multiple.intoto.jsonl"
+                        "asset_name: multiple.intoto.jsonl",
+                        {
+                            "asset_url": "https://api.github.com/repos/urllib3/urllib3/releases/assets/152179165"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -337,7 +380,9 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Successfully verified the expectation against provenance."
+                        {
+                            "asset_url": "https://api.github.com/repos/urllib3/urllib3/releases/assets/152179165"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -351,8 +396,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Successfully verified level 3: ",
-                        "verify passed : urllib3-2.0.5-py3-none-any.whl,verify passed : urllib3-2.0.5.tar.gz"
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -364,7 +408,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/urllib3/urllib3"
+                            "git_repo": "https://github.com/urllib3/urllib3"
                         }
                     ],
                     "result_type": "PASSED"
@@ -376,7 +420,29 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -390,7 +456,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Failed to discover any witness provenance."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -404,7 +470,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -416,23 +482,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -440,11 +490,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_commit_1",
                 "num_deps_pass": 0
             },
             {
@@ -452,7 +502,31 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/urllib3/urllib3_cue_invalid.json
+++ b/tests/e2e/expected_results/urllib3/urllib3_cue_invalid.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-12 17:36:12"
+        "timestamps": "2024-05-07 15:16:47",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_level_three_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_witness_level_one_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -20,51 +53,51 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "subject": [
                             {
-                                "name": "urllib3-2.0.4-py3-none-any.whl",
+                                "name": "urllib3-2.2.1-py3-none-any.whl",
                                 "digest": {
-                                    "sha256": "de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"
+                                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
                                 }
                             },
                             {
-                                "name": "urllib3-2.0.4.tar.gz",
+                                "name": "urllib3-2.2.1.tar.gz",
                                 "digest": {
-                                    "sha256": "8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"
+                                    "sha256": "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
                                 }
                             }
                         ],
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.7.0"
+                                "id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0"
                             },
                             "buildType": "https://github.com/slsa-framework/slsa-github-generator/generic@v1",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/2.0.4",
+                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/2.2.1",
                                     "digest": {
-                                        "sha1": "c9fa144545eedb5dc4a2cc3f255e95602a1d7db0"
+                                        "sha1": "54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                     },
                                     "entryPoint": ".github/workflows/publish.yml"
                                 },
                                 "parameters": {},
                                 "environment": {
-                                    "github_actor": "illia-v",
-                                    "github_actor_id": "17710133",
+                                    "github_actor": "pquentin",
+                                    "github_actor_id": "42327",
                                     "github_base_ref": "",
                                     "github_event_name": "push",
                                     "github_event_payload": {
-                                        "after": "d267c99f7e890ff22e136c34d29be802d9c2e773",
+                                        "after": "0b4566e65ca046823dd92a490ae33c17bbb88fcb",
                                         "base_ref": null,
                                         "before": "0000000000000000000000000000000000000000",
                                         "commits": [],
-                                        "compare": "https://github.com/urllib3/urllib3/compare/2.0.4",
+                                        "compare": "https://github.com/urllib3/urllib3/compare/2.2.1",
                                         "created": true,
                                         "deleted": false,
                                         "forced": false,
                                         "head_commit": {
                                             "author": {
-                                                "email": "64815328+Eutropios@users.noreply.github.com",
-                                                "name": "Noah Jenner",
-                                                "username": "Eutropios"
+                                                "email": "quentin.pradet@gmail.com",
+                                                "name": "Quentin Pradet",
+                                                "username": "pquentin"
                                             },
                                             "committer": {
                                                 "email": "noreply@github.com",
@@ -72,11 +105,11 @@
                                                 "username": "web-flow"
                                             },
                                             "distinct": true,
-                                            "id": "c9fa144545eedb5dc4a2cc3f255e95602a1d7db0",
-                                            "message": "Release version 2.0.4 (#3084)\n\nCo-authored-by: Illia Volochii <illia.volochii@gmail.com>",
-                                            "timestamp": "2023-07-19T17:46:02+03:00",
-                                            "tree_id": "e61f50347e7bb803a0c8942ba63fe917c8424f77",
-                                            "url": "https://github.com/urllib3/urllib3/commit/c9fa144545eedb5dc4a2cc3f255e95602a1d7db0"
+                                            "id": "54d6edf2a671510a5c029d3b76ffe71a5b07147a",
+                                            "message": "Release 2.2.1",
+                                            "timestamp": "2024-02-18T07:44:08+04:00",
+                                            "tree_id": "a702e15d622eccc7cf18243e6a4a62d19e19579d",
+                                            "url": "https://github.com/urllib3/urllib3/commit/54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                         },
                                         "organization": {
                                             "avatar_url": "https://avatars.githubusercontent.com/u/26825299?v=4",
@@ -93,10 +126,10 @@
                                             "url": "https://api.github.com/orgs/urllib3"
                                         },
                                         "pusher": {
-                                            "email": "illia.volochii@gmail.com",
-                                            "name": "illia-v"
+                                            "email": "quentin.pradet@gmail.com",
+                                            "name": "pquentin"
                                         },
-                                        "ref": "refs/tags/2.0.4",
+                                        "ref": "refs/tags/2.2.1",
                                         "repository": {
                                             "allow_forking": true,
                                             "archive_url": "https://api.github.com/repos/urllib3/urllib3/{archive_format}{/ref}",
@@ -112,6 +145,7 @@
                                             "contents_url": "https://api.github.com/repos/urllib3/urllib3/contents/{+path}",
                                             "contributors_url": "https://api.github.com/repos/urllib3/urllib3/contributors",
                                             "created_at": 1316369308,
+                                            "custom_properties": {},
                                             "default_branch": "main",
                                             "deployments_url": "https://api.github.com/repos/urllib3/urllib3/deployments",
                                             "description": "urllib3 is a user-friendly HTTP client library for Python",
@@ -119,8 +153,8 @@
                                             "downloads_url": "https://api.github.com/repos/urllib3/urllib3/downloads",
                                             "events_url": "https://api.github.com/repos/urllib3/urllib3/events",
                                             "fork": false,
-                                            "forks": 1078,
-                                            "forks_count": 1078,
+                                            "forks": 1134,
+                                            "forks_count": 1134,
                                             "forks_url": "https://api.github.com/repos/urllib3/urllib3/forks",
                                             "full_name": "urllib3/urllib3",
                                             "git_commits_url": "https://api.github.com/repos/urllib3/urllib3/git/commits{/sha}",
@@ -159,8 +193,8 @@
                                             "name": "urllib3",
                                             "node_id": "MDEwOlJlcG9zaXRvcnkyNDEwNjc2",
                                             "notifications_url": "https://api.github.com/repos/urllib3/urllib3/notifications{?since,all,participating}",
-                                            "open_issues": 125,
-                                            "open_issues_count": 125,
+                                            "open_issues": 137,
+                                            "open_issues_count": 137,
                                             "organization": "urllib3",
                                             "owner": {
                                                 "avatar_url": "https://avatars.githubusercontent.com/u/26825299?v=4",
@@ -186,12 +220,12 @@
                                             },
                                             "private": false,
                                             "pulls_url": "https://api.github.com/repos/urllib3/urllib3/pulls{/number}",
-                                            "pushed_at": 1689779927,
+                                            "pushed_at": 1708227973,
                                             "releases_url": "https://api.github.com/repos/urllib3/urllib3/releases{/id}",
-                                            "size": 7242,
+                                            "size": 7144,
                                             "ssh_url": "git@github.com:urllib3/urllib3.git",
-                                            "stargazers": 3452,
-                                            "stargazers_count": 3452,
+                                            "stargazers": 3625,
+                                            "stargazers_count": 3625,
                                             "stargazers_url": "https://api.github.com/repos/urllib3/urllib3/stargazers",
                                             "statuses_url": "https://api.github.com/repos/urllib3/urllib3/statuses/{sha}",
                                             "subscribers_url": "https://api.github.com/repos/urllib3/urllib3/subscribers",
@@ -206,48 +240,48 @@
                                                 "urllib3"
                                             ],
                                             "trees_url": "https://api.github.com/repos/urllib3/urllib3/git/trees{/sha}",
-                                            "updated_at": "2023-07-19T02:19:14Z",
+                                            "updated_at": "2024-02-16T15:03:16Z",
                                             "url": "https://github.com/urllib3/urllib3",
                                             "visibility": "public",
-                                            "watchers": 3452,
-                                            "watchers_count": 3452,
+                                            "watchers": 3625,
+                                            "watchers_count": 3625,
                                             "web_commit_signoff_required": false
                                         },
                                         "sender": {
-                                            "avatar_url": "https://avatars.githubusercontent.com/u/17710133?v=4",
-                                            "events_url": "https://api.github.com/users/illia-v/events{/privacy}",
-                                            "followers_url": "https://api.github.com/users/illia-v/followers",
-                                            "following_url": "https://api.github.com/users/illia-v/following{/other_user}",
-                                            "gists_url": "https://api.github.com/users/illia-v/gists{/gist_id}",
+                                            "avatar_url": "https://avatars.githubusercontent.com/u/42327?v=4",
+                                            "events_url": "https://api.github.com/users/pquentin/events{/privacy}",
+                                            "followers_url": "https://api.github.com/users/pquentin/followers",
+                                            "following_url": "https://api.github.com/users/pquentin/following{/other_user}",
+                                            "gists_url": "https://api.github.com/users/pquentin/gists{/gist_id}",
                                             "gravatar_id": "",
-                                            "html_url": "https://github.com/illia-v",
-                                            "id": 17710133,
-                                            "login": "illia-v",
-                                            "node_id": "MDQ6VXNlcjE3NzEwMTMz",
-                                            "organizations_url": "https://api.github.com/users/illia-v/orgs",
-                                            "received_events_url": "https://api.github.com/users/illia-v/received_events",
-                                            "repos_url": "https://api.github.com/users/illia-v/repos",
+                                            "html_url": "https://github.com/pquentin",
+                                            "id": 42327,
+                                            "login": "pquentin",
+                                            "node_id": "MDQ6VXNlcjQyMzI3",
+                                            "organizations_url": "https://api.github.com/users/pquentin/orgs",
+                                            "received_events_url": "https://api.github.com/users/pquentin/received_events",
+                                            "repos_url": "https://api.github.com/users/pquentin/repos",
                                             "site_admin": false,
-                                            "starred_url": "https://api.github.com/users/illia-v/starred{/owner}{/repo}",
-                                            "subscriptions_url": "https://api.github.com/users/illia-v/subscriptions",
+                                            "starred_url": "https://api.github.com/users/pquentin/starred{/owner}{/repo}",
+                                            "subscriptions_url": "https://api.github.com/users/pquentin/subscriptions",
                                             "type": "User",
-                                            "url": "https://api.github.com/users/illia-v"
+                                            "url": "https://api.github.com/users/pquentin"
                                         }
                                     },
                                     "github_head_ref": "",
-                                    "github_ref": "refs/tags/2.0.4",
+                                    "github_ref": "refs/tags/2.2.1",
                                     "github_ref_type": "tag",
                                     "github_repository_id": "2410676",
                                     "github_repository_owner": "urllib3",
                                     "github_repository_owner_id": "26825299",
                                     "github_run_attempt": "1",
-                                    "github_run_id": "5600993171",
-                                    "github_run_number": "21",
-                                    "github_sha1": "c9fa144545eedb5dc4a2cc3f255e95602a1d7db0"
+                                    "github_run_id": "7946373606",
+                                    "github_run_number": "29",
+                                    "github_sha1": "54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                 }
                             },
                             "metadata": {
-                                "buildInvocationID": "5600993171-1",
+                                "buildInvocationID": "7946373606-1",
                                 "completeness": {
                                     "parameters": true,
                                     "environment": false,
@@ -257,9 +291,9 @@
                             },
                             "materials": [
                                 {
-                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/2.0.4",
+                                    "uri": "git+https://github.com/urllib3/urllib3@refs/tags/2.2.1",
                                     "digest": {
-                                        "sha1": "c9fa144545eedb5dc4a2cc3f255e95602a1d7db0"
+                                        "sha1": "54d6edf2a671510a5c029d3b76ffe71a5b07147a"
                                     }
                                 }
                             ]
@@ -271,7 +305,7 @@
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 3,
+                "FAILED": 5,
                 "PASSED": 6,
                 "SKIPPED": 0,
                 "UNKNOWN": 1
@@ -284,7 +318,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "No expectation defined for this repository."
+                        "Not Available."
                     ],
                     "result_type": "UNKNOWN"
                 },
@@ -295,12 +329,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: pip",
+                        "ci_service_name: github_actions",
+                        "language: python",
+                        "deploy_command: pypa/gh-action-pypi-publish",
                         {
-                            "The target repository uses build tool pip to deploy": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/publish.yml",
-                            "The build is triggered by": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/publish.yml"
-                        },
-                        "Deploy action: pypa/gh-action-pypi-publish",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/publish.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -311,7 +346,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: pip",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.PYTHON",
+                        "build_tool_command: [\"python\", \"-m\", \"build\"]",
+                        {
+                            "build_trigger": "https://github.com/urllib3/urllib3/blob/87a0ecee6e691fe5ff93cd000c0158deebef763b/.github/workflows/ci.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -322,7 +363,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -336,8 +377,10 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Found provenance in release assets:",
-                        "multiple.intoto.jsonl"
+                        "asset_name: multiple.intoto.jsonl",
+                        {
+                            "asset_url": "https://api.github.com/repos/urllib3/urllib3/releases/assets/152179165"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -351,8 +394,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Successfully verified level 3: ",
-                        "verify passed : urllib3-2.0.4-py3-none-any.whl,verify passed : urllib3-2.0.4.tar.gz"
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -364,7 +406,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/urllib3/urllib3"
+                            "git_repo": "https://github.com/urllib3/urllib3"
                         }
                     ],
                     "result_type": "PASSED"
@@ -376,7 +418,29 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -390,7 +454,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Failed to discover any witness provenance."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -404,7 +468,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -416,7 +480,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_provenance_expectation_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -424,19 +488,23 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
                 "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_provenance_derived_commit_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
                 "num_deps_pass": 0
             },
             {
@@ -448,11 +516,15 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_level_three_1",
+                "check_id": "mcn_build_service_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_service_1",
+                "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/e2e/expected_results/yoga/yoga.json
+++ b/tests/e2e/expected_results/yoga/yoga.json
@@ -1,6 +1,39 @@
 {
     "metadata": {
-        "timestamps": "2023-09-21 07:28:37"
+        "timestamps": "2024-05-07 15:10:24",
+        "has_passing_check": true,
+        "run_checks": [
+            "mcn_provenance_available_1",
+            "mcn_provenance_witness_level_one_1",
+            "mcn_build_as_code_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_provenance_level_three_1",
+            "mcn_version_control_system_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1",
+            "mcn_provenance_expectation_1",
+            "mcn_provenance_derived_repo_1"
+        ],
+        "check_tree": {
+            "mcn_provenance_available_1": {
+                "mcn_provenance_witness_level_one_1": {},
+                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {}
+            },
+            "mcn_provenance_derived_commit_1": {},
+            "mcn_version_control_system_1": {
+                "mcn_trusted_builder_level_three_1": {
+                    "mcn_build_as_code_1": {
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
+                    }
+                },
+                "mcn_build_script_1": {}
+            },
+            "mcn_provenance_derived_repo_1": {}
+        }
     },
     "target": {
         "info": {
@@ -21,7 +54,7 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-npm-release.yml"
+                                "id": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-android-release.yml"
                             },
                             "buildType": "Custom github_actions",
                             "invocation": {
@@ -30,17 +63,18 @@
                                     "digest": {
                                         "sha1": "f8e2bc0875c145c429d0e865c9b83a40f65b3070"
                                     },
-                                    "entryPoint": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-npm-release.yml"
+                                    "entryPoint": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-android-release.yml"
                                 },
                                 "parameters": {},
                                 "environment": {}
                             },
                             "buildConfig": {
                                 "jobID": "publish",
-                                "stepID": "yarn publish"
+                                "stepID": "",
+                                "stepName": "Publish to the Maven Central"
                             },
                             "metadata": {
-                                "buildInvocationId": "",
+                                "buildInvocationId": "<STRING>",
                                 "buildStartedOn": "<TIMESTAMP>",
                                 "buildFinishedOn": "<TIMESTAMP>",
                                 "completeness": {
@@ -59,13 +93,14 @@
                         }
                     }
                 ],
-                "Maven Central Registry": []
+                "Maven Central Registry": [],
+                "npm Registry": []
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 6,
+                "FAILED": 8,
                 "PASSED": 4,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
@@ -78,19 +113,13 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "deploy_command: [\"./gradlew\", \"publishToSonatype\", \"closeAndReleaseSonatypeStagingRepository\"]",
                         {
-                            "The target repository uses build tool gradle to deploy": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-android-snashot.yml",
-                            "The build is triggered by": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-android-snashot.yml"
-                        },
-                        "Deploy command: ['./gradlew', 'publishToSonatype']",
-                        "However, could not find a passing workflow run.",
-                        "The target repository does not use npm to deploy.",
-                        {
-                            "The target repository uses build tool yarn to deploy": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-npm-release.yml",
-                            "The build is triggered by": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-npm-release.yml"
-                        },
-                        "Deploy command: ['yarn', 'publish']",
-                        "However, could not find a passing workflow run."
+                            "build_trigger": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-android-release.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -101,7 +130,13 @@
                         "Scripted Build - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_build_script_1 is set to PASSED because mcn_build_service_1 PASSED."
+                        "build_tool_name: gradle",
+                        "ci_service_name: github_actions",
+                        "language: BuildLanguage.JAVA",
+                        "build_tool_command: [\"./gradlew\", \"publishToMavenLocal\"]",
+                        {
+                            "build_trigger": "https://github.com/facebook/yoga/blob/f8e2bc0875c145c429d0e865c9b83a40f65b3070/.github/workflows/publish-android-release.yml"
+                        }
                     ],
                     "result_type": "PASSED"
                 },
@@ -112,7 +147,7 @@
                         "Build service - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_build_service_1 is set to PASSED because mcn_build_as_code_1 PASSED."
+                        "Not Available."
                     ],
                     "result_type": "PASSED"
                 },
@@ -124,7 +159,7 @@
                     ],
                     "justification": [
                         {
-                            "This is a Git repository": "https://github.com/facebook/yoga"
+                            "git_repo": "https://github.com/facebook/yoga"
                         }
                     ],
                     "result_type": "PASSED"
@@ -136,7 +171,7 @@
                         "Build as code - SLSA Level 3"
                     ],
                     "justification": [
-                        "Unable to find a publishing timestamp for the artifact."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -150,7 +185,29 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Could not find any SLSA or Witness provenances."
+                        "Not Available."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_digest: No provenance found."
+                    ],
+                    "result_type": "FAILED"
+                },
+                {
+                    "check_id": "mcn_provenance_derived_repo_1",
+                    "check_description": "Check whether the repo came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "repository_url: No provenance found."
                     ],
                     "result_type": "FAILED"
                 },
@@ -161,7 +218,7 @@
                         "Provenance conforms with expectations - SLSA Level 3"
                     ],
                     "justification": [
-                        "Check mcn_provenance_expectation_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -175,7 +232,7 @@
                         "Provenance content - Identifies source code - SLSA Level 2"
                     ],
                     "justification": [
-                        "Check mcn_provenance_level_three_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -189,7 +246,7 @@
                         "Provenance content - Identifies builder - SLSA Level 1"
                     ],
                     "justification": [
-                        "Check mcn_provenance_witness_level_one_1 is set to FAILED because mcn_provenance_available_1 FAILED."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 },
@@ -203,7 +260,7 @@
                         "Ephemeral environment - SLSA Level 3"
                     ],
                     "justification": [
-                        "Could not find a trusted level 3 builder as a GitHub Actions workflow."
+                        "Not Available."
                     ],
                     "result_type": "FAILED"
                 }
@@ -215,23 +272,7 @@
         "unique_dep_repos": 0,
         "checks_summary": [
             {
-                "check_id": "mcn_infer_artifact_pipeline_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_script_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_version_control_system_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_build_service_1",
-                "num_deps_pass": 0
-            },
-            {
-                "check_id": "mcn_trusted_builder_level_three_1",
+                "check_id": "mcn_provenance_available_1",
                 "num_deps_pass": 0
             },
             {
@@ -239,11 +280,11 @@
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_provenance_available_1",
+                "check_id": "mcn_build_as_code_1",
                 "num_deps_pass": 0
             },
             {
-                "check_id": "mcn_build_as_code_1",
+                "check_id": "mcn_provenance_derived_commit_1",
                 "num_deps_pass": 0
             },
             {
@@ -251,7 +292,31 @@
                 "num_deps_pass": 0
             },
             {
+                "check_id": "mcn_version_control_system_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_infer_artifact_pipeline_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_trusted_builder_level_three_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_script_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_build_service_1",
+                "num_deps_pass": 0
+            },
+            {
                 "check_id": "mcn_provenance_expectation_1",
+                "num_deps_pass": 0
+            },
+            {
+                "check_id": "mcn_provenance_derived_repo_1",
                 "num_deps_pass": 0
             }
         ],

--- a/tests/policy_engine/expected_results/example-maven-project/example_maven_project_policy_report.json
+++ b/tests/policy_engine/expected_results/example-maven-project/example_maven_project_policy_report.json
@@ -1,7 +1,7 @@
 {
     "component_satisfies_policy": [
         [
-            "1",
+            "176",
             "pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0-SNAPSHOT?type=jar",
             "example_maven_app_policy"
         ],
@@ -11,11 +11,11 @@
             "example_maven_app_policy"
         ]
     ],
+    "component_violates_policy": [],
+    "failed_policies": [],
     "passed_policies": [
         [
             "example_maven_app_policy"
         ]
-    ],
-    "component_violates_policy": [],
-    "failed_policies": []
+    ]
 }

--- a/tests/slsa_analyzer/checks/test_provenance_repo_commit_checks.py
+++ b/tests/slsa_analyzer/checks/test_provenance_repo_commit_checks.py
@@ -51,8 +51,8 @@ def test_provenance_repo_commit_checks_pass(
 ) -> None:
     """Test combinations of Repository objects and provenance strings against check."""
     context = _prepare_context(macaron_path, repository)
-    context.dynamic_data["provenance_repo"] = repo_url
-    context.dynamic_data["provenance_commit"] = commit_digest
+    context.dynamic_data["provenance_repo_url"] = repo_url
+    context.dynamic_data["provenance_commit_digest"] = commit_digest
 
     # Check Repo
     repo_result = _perform_check_assert_result_return_result(

--- a/tests/slsa_analyzer/checks/test_provenance_repo_commit_checks.py
+++ b/tests/slsa_analyzer/checks/test_provenance_repo_commit_checks.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This modules contains tests for the provenance available check."""
+from pathlib import Path
+from typing import TypeVar
+
+import pytest
+
+from macaron.database.table_definitions import CheckFacts, Repository
+from macaron.slsa_analyzer.analyze_context import AnalyzeContext
+from macaron.slsa_analyzer.checks.base_check import BaseCheck
+from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType
+from macaron.slsa_analyzer.checks.provenance_commit_check import (
+    ProvenanceDerivedCommitCheck,
+    ProvenanceDerivedCommitFacts,
+)
+from macaron.slsa_analyzer.checks.provenance_repo_check import ProvenanceDerivedRepoCheck, ProvenanceDerivedRepoFacts
+from tests.conftest import MockAnalyzeContext
+
+T = TypeVar("T", bound=CheckFacts)
+
+
+@pytest.fixture(name="repo_url")
+def repo_url_() -> str:
+    """Return the repo URL."""
+    return "https://github.com/oracle/macaron"
+
+
+@pytest.fixture(name="commit_digest")
+def commit_digest_() -> str:
+    """Return the commit digest."""
+    return "ba3fcb0c84d6727de343c247a3181908fcd78410"
+
+
+@pytest.fixture(name="repository")
+def repository_(repo_url: str, commit_digest: str) -> Repository:
+    """Return the Repository."""
+    return Repository(
+        complete_name=repo_url.replace("https://", ""),
+        remote_path=repo_url,
+        commit_sha=commit_digest,
+    )
+
+
+def test_provenance_repo_commit_checks_pass(
+    macaron_path: Path,
+    repository: Repository,
+    repo_url: str,
+    commit_digest: str,
+) -> None:
+    """Test combinations of Repository objects and provenance strings against check."""
+    context = _prepare_context(macaron_path, repository)
+    context.dynamic_data["provenance_repo"] = repo_url
+    context.dynamic_data["provenance_commit"] = commit_digest
+
+    # Check Repo
+    repo_result = _perform_check_assert_result_return_result(
+        ProvenanceDerivedRepoCheck(), context, CheckResultType.PASSED
+    )
+    repo_fact = _get_fact(repo_result.result_tables, ProvenanceDerivedRepoFacts)
+    assert repo_fact
+    assert repo_fact.repository_info == "The repository URL was found from provenance."
+
+    # Check Commit
+    commit_result = _perform_check_assert_result_return_result(
+        ProvenanceDerivedCommitCheck(), context, CheckResultType.PASSED
+    )
+    commit_fact = _get_fact(commit_result.result_tables, ProvenanceDerivedCommitFacts)
+    assert commit_fact
+    assert commit_fact.commit_info == "The commit digest was found from provenance."
+
+
+def test_provenance_repo_commit_checks_fail(
+    macaron_path: Path,
+    repository: Repository,
+) -> None:
+    """Test combinations of Repository objects and provenance strings against check."""
+    context = _prepare_context(macaron_path, repository)
+
+    # Check Repo
+    _perform_check_assert_result_return_result(ProvenanceDerivedRepoCheck(), context, CheckResultType.FAILED)
+
+    # Check Commit
+    _perform_check_assert_result_return_result(ProvenanceDerivedCommitCheck(), context, CheckResultType.FAILED)
+
+
+def _prepare_context(macaron_path: Path, repository: Repository) -> AnalyzeContext:
+    """Prepare a mock AnalyzeContext for performing checks with."""
+    context = MockAnalyzeContext(macaron_path=macaron_path, output_dir="")
+    context.component.repository = repository
+    return context
+
+
+def _perform_check_assert_result_return_result(
+    check: BaseCheck, context: AnalyzeContext, expected_outcome: CheckResultType
+) -> CheckResultData:
+    """Run the passed check with the passed context, assert the result matches the expected outcome and return it."""
+    result = check.run_check(context)
+    assert result.result_type == expected_outcome
+    return result
+
+
+def _get_fact(check_facts: list[CheckFacts], fact_type: type[T]) -> T | None:
+    """Return first fact from check result that matches the passed fact type."""
+    for fact in check_facts:
+        if isinstance(fact, fact_type):
+            return fact
+    return None


### PR DESCRIPTION
This PR adds a new check that succeeds if the repository URL and commit of the analysis target match those that can be extracted from the provenance. If the repository or provenance do not exist, or do not contain the needed information, or are not identical, this check will fail.

Closes #677 