### PR TITLE
chore: support versions with one alphanumeric part and a prefix in the commit finder

### DIFF
--- a/src/macaron/repo_finder/commit_finder.py
+++ b/src/macaron/repo_finder/commit_finder.py
@@ -341,8 +341,10 @@ def _build_version_pattern(name: str, version: str) -> tuple[Pattern | None, lis
             # - 3.1.test.2 -> 'test' and '2' become optional.
             has_non_numeric_suffix = True
 
-        if count == len(split) - 1 and has_trailing_zero or has_non_numeric_suffix:
-            # This part will be made optional in the regex, hence the grouping bracket.
+        # This part will be made optional in the regex if it matches the correct requirements.
+        optional = len(split) > 1 and ((count == len(split) - 1 and has_trailing_zero) or has_non_numeric_suffix)
+
+        if optional:
             this_version_pattern = this_version_pattern + "("
 
         if count == 1:
@@ -353,7 +355,7 @@ def _build_version_pattern(name: str, version: str) -> tuple[Pattern | None, lis
         # Add the current part to the pattern.
         this_version_pattern = this_version_pattern + part
 
-        if count == len(split) - 1 and has_trailing_zero or has_non_numeric_suffix:
+        if optional:
             # Complete the optional capture group.
             this_version_pattern = this_version_pattern + ")?"
 

--- a/src/macaron/repo_finder/commit_finder.py
+++ b/src/macaron/repo_finder/commit_finder.py
@@ -341,7 +341,11 @@ def _build_version_pattern(name: str, version: str) -> tuple[Pattern | None, lis
             # - 3.1.test.2 -> 'test' and '2' become optional.
             has_non_numeric_suffix = True
 
-        # This part will be made optional in the regex if it matches the correct requirements.
+        # This part will be made optional in the regex if it matches the correct requirements:
+        # - There is more than one version part, e.g. 1.2 (2), 1.2.3 (3)
+        # - AND either of:
+        #   - This is the last version part and it has a trailing zero, e.g. 10
+        #   - OR has_non_numeric_suffix is True (See its comments above for more details)
         optional = len(split) > 1 and ((count == len(split) - 1 and has_trailing_zero) or has_non_numeric_suffix)
 
         if optional:


### PR DESCRIPTION
This PR includes a fix for the commit finder so that is supports the case where a version has only one part, but also consists of alphanumeric characters. Previously this would cause the only version part to become optional, and therefore allow invalid matches such as matching the entire tag as a prefix.

E.g. 
Version: `2012c`, Tag: `release_2012c`
`2012c` becomes optional allowing `release_2012c` to match as the prefix thereby preventing a proper match because the tag version part is empty.
