### PR TITLE
fix: store language in build as code check for non-GitHub CI services

### DIFF
--- a/src/macaron/slsa_analyzer/checks/build_as_code_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_as_code_check.py
@@ -268,6 +268,7 @@ class BuildAsCodeCheck(BaseCheck):
                             result_tables.append(
                                 BuildAsCodeFacts(
                                     build_tool_name=tool.name,
+                                    language=tool.language.value,
                                     ci_service_name=ci_service.name,
                                     deploy_command=deploy_kw,
                                     confidence=Confidence.LOW,


### PR DESCRIPTION
This PR fixes a bug in the build as code check. The `language` field in `BuildAsCodeFacts` was not set for non-GitHub CI services, which is needed for storing the result in the database.