### PR TITLE
chore: update provenance status justification note in html report

### DIFF
--- a/src/macaron/output_reporter/templates/macaron.html
+++ b/src/macaron/output_reporter/templates/macaron.html
@@ -228,9 +228,9 @@
     <div class="table_caption">Provenance summary</div>
     <div id= "prov_justification">
         {% if target.provenances.is_inferred == true %}
-        Could not find a provenance for this repository. Below is what Macaron has inferred.
+        Could not find a provenance for the target component. Below is what Macaron has inferred.
         {% else %}
-        This is the provenance found for this repository.
+        This is the provenance found for the target component.
         {% endif %}
     </div>
 


### PR DESCRIPTION
Update the provenance status justification in the HTML report from `repository` to `the target software component`.