### PR TITLE
chore: add note for supporting only amd64 architecture at the moment

### DIFF
--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -15,6 +15,7 @@ Prerequisites
   - Macaron has been tested with ``bash 5.1.16(1)-release``.
 
 - Docker (or docker equivalent for your host OS) must be installed, with a docker command line equivalent to Docker 17.06 (Oracle Container Runtime 19.03) and the user should be a member of the operating system group ``docker`` (to run Docker in `rootless mode <https://docs.docker.com/engine/security/rootless/>`_).
+- We only support ``amd64`` / ``x86_64`` platforms at the moment.
 
 .. _download-macaron:
 


### PR DESCRIPTION
Added a note in the Installation documentation page for the supported architecture. We will update it once https://github.com/oracle/macaron/issues/648 is addressed.