### PR TITLE
fix: do not fetch from origin/HEAD for local repo targets

### DIFF
--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -304,11 +304,6 @@ An example configuration file for utilising this feature:
 Analyzing a repository on the local file system
 -----------------------------------------------
 
-.. warning::
-  During the analysis, Macaron can check out different commits, which can reset the index and working tree of the repository.
-  Therefore, any uncommitted changes in the repository need to be backed up to prevent loss (these include unstaged changes, staged changes and untracked files).
-  However, Macaron will not modify the history of the repository.
-
 .. note::
   We assume that the ``origin`` remote exists in the cloned repository and checkout the relevant commits from ``origin`` only.
 
@@ -378,7 +373,12 @@ With ``rest_of_args`` being the arguments to the ``analyze`` command (e.g. ``--b
 
 The ``--local-repos-path/-lr`` flag tells Macaron to look into ``./boo/foo`` for local repositories. For more information, please see :ref:`Command Line Usage <cli-usage>`.
 
-.. note:: If ``--local-repos-path/-lr`` is not provided, Macaron will looks inside ``<current_working_directory>/output/git_repos/local_repos/`` whenever you provide a local path to ``--repo-path/-rp``.
+.. note:: If ``--local-repos-path/-lr`` is not provided, Macaron will look inside ``<current_working_directory>/output/git_repos/local_repos/`` whenever you provide a local path to ``--repo-path/-rp``.
+
+.. warning::
+  Macaron by default analyzes the current state of the local repository. However, if the user provides a branch or commit hash as input, Macaron may reset the index and working tree of the repository to check out a specific commit.
+  Therefore, any uncommitted changes in the repository need to be backed up to prevent loss (these include unstaged changes, staged changes and untracked files).
+  However, Macaron will not modify the history of the repository.
 
 -------------------------
 Running the policy engine

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -124,7 +124,7 @@ def check_out_repo_target(
     with the repository specified by origin remote.
 
     If ``offline_mode`` is True and neither ``branch_name`` nor commit are provided, this function will not do anything
-    and the latest local commit will be analyzed. If there are uncommitted local changes, the latest commit will
+    and the HEAD commit will be analyzed. If there are uncommitted local changes, the HEAD commit will
     appear in the report but the repo with local changes will be analyzed. We leave it up to the user to decide
     whether to commit the changes or not.
 
@@ -233,7 +233,7 @@ def check_out_repo_target(
         logger.critical("The current HEAD at %s. Expect %s.", final_head_commit.hexsha, digest)
         return False
 
-    logger.info("The latest commit is %s.", final_head_commit.hexsha)
+    logger.info("The HEAD commit is %s.", final_head_commit.hexsha)
     return True
 
 

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -123,9 +123,10 @@ def check_out_repo_target(
     will prune and update all references (e.g. tags, branches) to make sure that the local repository is up-to-date
     with the repository specified by origin remote.
 
-    If ``branch_name`` and a commit are not provided, this function will not do anything and the latest local commit
-    will be analyzed. If there are uncommitted local changes, the latest commit will appear in the report but the repo
-    with local changes will be analyzed. We leave it up to the user to decide whether to commit the changes or not.
+    If ``offline_mode`` is True and neither ``branch_name`` nor commit are provided, this function will not do anything
+    and the latest local commit will be analyzed. If there are uncommitted local changes, the latest commit will
+    appear in the report but the repo with local changes will be analyzed. We leave it up to the user to decide
+    whether to commit the changes or not.
 
     If ``branch_name`` is provided and a commit is not provided, this function will checkout that branch from origin
     remote (i.e. origin/<branch_name).
@@ -182,6 +183,15 @@ def check_out_repo_target(
             logger.error("Unable to fetch from the origin remote of the repository.")
             return False
 
+        # By default check out the commit at origin/HEAD only when offline_mode is False.
+        if not branch_name and not digest:
+            try:
+                git_obj.repo.git.checkout("--force", "origin/HEAD")
+            except GitCommandError:
+                logger.debug("Cannot checkout the default branch at origin/HEAD")
+                return False
+
+    # The following checkout operations will be done whether offline_mode is False or not.
     if branch_name and not digest:
         try:
             git_obj.repo.git.checkout("--force", f"origin/{branch_name}")
@@ -223,7 +233,7 @@ def check_out_repo_target(
         logger.critical("The current HEAD at %s. Expect %s.", final_head_commit.hexsha, digest)
         return False
 
-    logger.info("Successfully checked out commit %s.", final_head_commit.hexsha)
+    logger.info("The latest commit is %s.", final_head_commit.hexsha)
     return True
 
 

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -123,8 +123,9 @@ def check_out_repo_target(
     will prune and update all references (e.g. tags, branches) to make sure that the local repository is up-to-date
     with the repository specified by origin remote.
 
-    If ``branch_name`` and a commit are not provided, this function will checkout the latest commit of the
-    default branch (i.e. origin/HEAD).
+    If ``branch_name`` and a commit are not provided, this function will not do anything and the latest local commit
+    will be analyzed. If there are uncommitted local changes, the latest commit will appear in the report but the repo
+    with local changes will be analyzed. We leave it up to the user to decide whether to commit the changes or not.
 
     If ``branch_name`` is provided and a commit is not provided, this function will checkout that branch from origin
     remote (i.e. origin/<branch_name).
@@ -179,13 +180,6 @@ def check_out_repo_target(
             )
         except GitCommandError:
             logger.error("Unable to fetch from the origin remote of the repository.")
-            return False
-
-    if not branch_name and not digest:
-        try:
-            git_obj.repo.git.checkout("--force", "origin/HEAD")
-        except GitCommandError:
-            logger.debug("Cannot checkout the default branch at origin/HEAD")
             return False
 
     if branch_name and not digest:


### PR DESCRIPTION
For analyzing local repositories in offline mode, we should not fetch from `origin/HEAD` because user might want to run Macaron on the local changes. This PR changes the `check_out_repo_target` function to fix this issue: if `branch_name` and a commit are not provided, this function will not do anything and the latest local commit will be analyzed. If there are uncommitted local changes, the latest commit will appear in the report but the repo with local changes will be analyzed. We leave it up to the user to decide whether to commit the changes or not.