### PR TITLE
chore: validate input repo, commit, provenance to ensure they match

### DIFF
--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -707,7 +707,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/slsa-framework/slsa-verifier/sl
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/slsa_verifier_PASS.cue
 DEFAULTS_FILE=$WORKSPACE/tests/e2e/defaults/slsa_verifier.ini
 PROVENANCE_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/resources/valid_provenances/slsa-verifier-linux-amd64.intoto.jsonl
-$RUN_MACARON -dp $DEFAULTS_FILE analyze -pe $EXPECTATION_FILE -pf $PROVENANCE_FILE -rp https://github.com/slsa-framework/slsa-verifier -b main -d fc50b662fcfeeeb0e97243554b47d9b20b14efac --skip-deps || log_fail
+$RUN_MACARON -dp $DEFAULTS_FILE analyze -pe $EXPECTATION_FILE -pf $PROVENANCE_FILE -rp https://github.com/slsa-framework/slsa-verifier -d 6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6 --skip-deps || log_fail
 
 check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 
@@ -719,7 +719,7 @@ JSON_RESULT=$WORKSPACE/output/reports/github_com/slsa-framework/slsa-verifier/sl
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/slsa_verifier_PASS.cue
 DEFAULTS_FILE=$WORKSPACE/tests/e2e/defaults/allow_url_link_github.ini
 PROVENANCE_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/resources/valid_provenances/slsa-verifier-linux-amd64.intoto.jsonl
-$RUN_MACARON -dp $DEFAULTS_FILE analyze -pe $EXPECTATION_FILE -pf $PROVENANCE_FILE -rp https://github.com/slsa-framework/slsa-verifier -b main -d fc50b662fcfeeeb0e97243554b47d9b20b14efac --skip-deps || log_fail
+$RUN_MACARON -dp $DEFAULTS_FILE analyze -pe $EXPECTATION_FILE -pf $PROVENANCE_FILE -rp https://github.com/slsa-framework/slsa-verifier -d 6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6 --skip-deps || log_fail
 
 check_or_update_expected_output $COMPARE_JSON_OUT $JSON_RESULT $JSON_EXPECTED || log_fail
 

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -762,7 +762,7 @@ check_or_update_expected_output $COMPARE_POLICIES $POLICY_RESULT $POLICY_EXPECTE
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "behnazh-w/example-maven-app as a local and remote repository"
-echo "Test the Witness and GitHub provenances as an input, Cue expectation validation, Policy CLI and VSA generation."
+echo "Test the Witness and GitHub provenances as an input, Cue expectation validation, Policy CLI and VSA generation, User input vs. provenance."
 echo -e "----------------------------------------------------------------------------------\n"
 RUN_POLICY="macaron verify-policy"
 POLICY_FILE=$WORKSPACE/tests/policy_engine/resources/policies/example-maven-project/policy.dl
@@ -787,6 +787,15 @@ GITHUB_PROVENANCE_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/resources/valid
 
 # Check the GitHub provenance.
 $RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -pe $GITHUB_EXPECTATION_FILE -purl pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar --skip-deps || log_fail
+
+# Validate user input of repo and commit vs provenance.
+$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75 --skip-deps || log_fail
+
+# Validate user input of repo and commit (via purl) vs provenance.
+$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
+
+# Validate user input of repo and commit (via purl with tag) vs provenance.
+$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@1.0 --skip-deps || log_fail
 
 # Verify the policy and VSA for all the software components generated from behnazh-w/example-maven-app repo.
 $RUN_POLICY -f $POLICY_FILE -d "$WORKSPACE/output/macaron.db" || log_fail

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -785,17 +785,17 @@ $RUN_MACARON analyze -pf $WITNESS_PROVENANCE_FILE -pe $WITNESS_EXPECTATION_FILE 
 GITHUB_EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/github-example-maven-project.cue
 GITHUB_PROVENANCE_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/resources/valid_provenances/github-example-maven-project.json
 
-# Check the GitHub provenance.
-$RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -pe $GITHUB_EXPECTATION_FILE -purl pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar --skip-deps || log_fail
-
 # Validate user input of repo and commit vs provenance.
-$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75 --skip-deps || log_fail
+$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
 
 # Validate user input of repo and commit (via purl) vs provenance.
-$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
+$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75 --skip-deps || log_fail
 
 # Validate user input of repo and commit (via purl with tag) vs provenance.
 $RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@1.0 --skip-deps || log_fail
+
+# Check the GitHub provenance.
+$RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -pe $GITHUB_EXPECTATION_FILE -purl pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar --skip-deps || log_fail
 
 # Verify the policy and VSA for all the software components generated from behnazh-w/example-maven-app repo.
 $RUN_POLICY -f $POLICY_FILE -d "$WORKSPACE/output/macaron.db" || log_fail

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -786,13 +786,13 @@ GITHUB_EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/c
 GITHUB_PROVENANCE_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/resources/valid_provenances/github-example-maven-project.json
 
 # Validate user input of repo and commit vs provenance.
-$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
+$RUN_MACARON analyze -pf GITHUB_PROVENANCE_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
 
 # Validate user input of repo and commit (via purl) vs provenance.
-$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75 --skip-deps || log_fail
+$RUN_MACARON analyze -pf GITHUB_PROVENANCE_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75 --skip-deps || log_fail
 
 # Validate user input of repo and commit (via purl with tag) vs provenance.
-$RUN_MACARON analyze -pf $GITHUB_EXPECTATION_FILE -purl pkg:github/behnazh-w/example-maven-app@1.0 --skip-deps || log_fail
+$RUN_MACARON analyze -pf GITHUB_PROVENANCE_FILE -purl pkg:github/behnazh-w/example-maven-app@1.0 --skip-deps || log_fail
 
 # Check the GitHub provenance.
 $RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -pe $GITHUB_EXPECTATION_FILE -purl pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar --skip-deps || log_fail

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -785,15 +785,6 @@ $RUN_MACARON analyze -pf $WITNESS_PROVENANCE_FILE -pe $WITNESS_EXPECTATION_FILE 
 GITHUB_EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/github-example-maven-project.cue
 GITHUB_PROVENANCE_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/resources/valid_provenances/github-example-maven-project.json
 
-# Validate user input of repo and commit vs provenance.
-$RUN_MACARON analyze -pf GITHUB_PROVENANCE_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
-
-# Validate user input of repo and commit (via purl) vs provenance.
-$RUN_MACARON analyze -pf GITHUB_PROVENANCE_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75 --skip-deps || log_fail
-
-# Validate user input of repo and commit (via purl with tag) vs provenance.
-$RUN_MACARON analyze -pf GITHUB_PROVENANCE_FILE -purl pkg:github/behnazh-w/example-maven-app@1.0 --skip-deps || log_fail
-
 # Check the GitHub provenance.
 $RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -pe $GITHUB_EXPECTATION_FILE -purl pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar --skip-deps || log_fail
 
@@ -803,6 +794,14 @@ $RUN_POLICY -f $POLICY_FILE -d "$WORKSPACE/output/macaron.db" || log_fail
 check_or_update_expected_output "$COMPARE_POLICIES" "$POLICY_RESULT" "$POLICY_EXPECTED" || log_fail
 check_or_update_expected_output "$COMPARE_VSA" "$VSA_RESULT" "$VSA_PAYLOAD_EXPECTED" || log_fail
 
+# Validate user input of repo and commit vs provenance.
+$RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -rp https://github.com/behnazh-w/example-maven-app -d 2deca75ed5dd365eaf1558a82347b1f11306135f --skip-deps || log_fail
+
+# Validate user input of repo and commit (via purl) vs provenance.
+$RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -purl pkg:github/behnazh-w/example-maven-app@2deca75 --skip-deps || log_fail
+
+# Validate user input of repo and commit (via purl with tag) vs provenance.
+$RUN_MACARON analyze -pf $GITHUB_PROVENANCE_FILE -purl pkg:github/behnazh-w/example-maven-app@1.0 --skip-deps || log_fail
 
 # Testing the Repo Finder's remote calls.
 # This requires the 'packageurl' Python module

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -69,6 +69,11 @@ repo_pom_paths =
 find_parents = True
 parent_limit = 10
 
+# This is the packageURL expanded repo type hostname spec.
+[package_url]
+github = github.com
+bitbucket = bitbucket.org
+
 # Git services that Macaron has access to clone repositories.
 # For security purposes, Macaron will only clone repositories from the hostnames specified.
 

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -69,11 +69,6 @@ repo_pom_paths =
 find_parents = True
 parent_limit = 10
 
-# This is the packageURL expanded repo type hostname spec.
-[package_url]
-github = github.com
-bitbucket = bitbucket.org
-
 # Git services that Macaron has access to clone repositories.
 # For security purposes, Macaron will only clone repositories from the hostnames specified.
 

--- a/src/macaron/json_tools.py
+++ b/src/macaron/json_tools.py
@@ -5,14 +5,13 @@
 import logging
 from typing import TypeVar
 
-from macaron.util import JsonType
-
+JsonType = int | float | str | None | bool | list["JsonType"] | dict[str, "JsonType"]
 T = TypeVar("T", bound=JsonType)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def json_extract(entry: JsonType, keys: list[str], type_: type[T]) -> T | None:
+def json_extract(entry: JsonType, keys: list, type_: type[T]) -> T | None:
     """Return the value found by following the list of depth-sequential keys inside the passed JSON dictionary.
 
     The value must be of the passed type.
@@ -21,8 +20,8 @@ def json_extract(entry: JsonType, keys: list[str], type_: type[T]) -> T | None:
     ----------
     entry: JsonType
         An entry point into a JSON structure.
-    keys: list[str]
-        The list of depth-sequential keys within the JSON.
+    keys: list
+        The list of depth-sequential keys within the JSON. Can be dict keys or list indices.
     type: type[T]
         The type to check the value against and return it as.
 
@@ -34,12 +33,22 @@ def json_extract(entry: JsonType, keys: list[str], type_: type[T]) -> T | None:
     target = entry
 
     for index, key in enumerate(keys):
-        if not isinstance(target, dict):
-            logger.debug("Expect the value .%s to be a dict.", ".".join(keys[:index]))
+        if isinstance(target, dict):
+            if key not in target:
+                logger.debug("JSON key '%s' not found in .%s", key, ".".join(keys[:index]))
+                return None
+        elif isinstance(target, list):
+            if isinstance(key, str):
+                logger.debug("JSON key '%s' of type 'str' cannot extract from list.", key)
+                return None
+
+            if key < 0 or key >= len(target):
+                logger.debug("JSON key '%s' is outside of list bounds %s.", key, len(target))
+                return None
+        else:
+            logger.debug("Expect the value .%s to be a dict or list.", ".".join(keys[:index]))
             return None
-        if key not in target:
-            logger.debug("JSON key '%s' not found in .%s", key, ".".join(keys[:index]))
-            return None
+
         target = target[key]
 
     if isinstance(target, type_):

--- a/src/macaron/json_tools.py
+++ b/src/macaron/json_tools.py
@@ -3,6 +3,7 @@
 
 """This module provides utility functions for JSON data."""
 import logging
+from collections.abc import Sequence
 from typing import TypeVar
 
 JsonType = int | float | str | None | bool | list["JsonType"] | dict[str, "JsonType"]
@@ -11,17 +12,17 @@ T = TypeVar("T", bound=JsonType)
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def json_extract(entry: JsonType, keys: list, type_: type[T]) -> T | None:
+def json_extract(entry: dict | list, keys: Sequence[str | int], type_: type[T]) -> T | None:
     """Return the value found by following the list of depth-sequential keys inside the passed JSON dictionary.
 
     The value must be of the passed type.
 
     Parameters
     ----------
-    entry: JsonType
+    entry: dict | list
         An entry point into a JSON structure.
-    keys: list
-        The list of depth-sequential keys within the JSON. Can be dict keys or list indices.
+    keys: Sequence[str | int]
+        The sequence of depth-sequential keys within the JSON. Can be dict keys or list indices.
     type: type[T]
         The type to check the value against and return it as.
 
@@ -30,29 +31,28 @@ def json_extract(entry: JsonType, keys: list, type_: type[T]) -> T | None:
     T | None:
         The found value as the type of the type parameter.
     """
-    target = entry
-
-    for index, key in enumerate(keys):
-        if isinstance(target, dict):
+    target: JsonType = entry
+    for key in keys:
+        if isinstance(target, dict) and isinstance(key, str):
             if key not in target:
-                logger.debug("JSON key '%s' not found in .%s", key, ".".join(keys[:index]))
+                logger.debug("JSON key '%s' not found in dict target.", key)
                 return None
-        elif isinstance(target, list):
-            if isinstance(key, str):
-                logger.debug("JSON key '%s' of type 'str' cannot extract from list.", key)
-                return None
-
+        elif isinstance(target, list) and isinstance(key, int):
             if key < 0 or key >= len(target):
-                logger.debug("JSON key '%s' is outside of list bounds %s.", key, len(target))
+                logger.debug("JSON list index '%s' is outside of list bounds %s.", key, len(target))
                 return None
         else:
-            logger.debug("Expect the value .%s to be a dict or list.", ".".join(keys[:index]))
+            logger.debug("Cannot index '%s' (type: %s) in target (type: %s).", key, type(key), type(target))
             return None
 
-        target = target[key]
+        # If statement required for mypy to not complain. The else case can never happen because of the above if block.
+        if isinstance(target, dict) and isinstance(key, str):
+            target = target[key]
+        elif isinstance(target, list) and isinstance(key, int):
+            target = target[key]
 
     if isinstance(target, type_):
         return target
 
-    logger.debug("Expect the value .%s to be of type %s", ".".join(keys), type_)
+    logger.debug("Found value of incorrect type: %s instead of %s.", type(target), type(type_))
     return None

--- a/src/macaron/repo_finder/commit_finder.py
+++ b/src/macaron/repo_finder/commit_finder.py
@@ -198,7 +198,7 @@ def extract_commit_from_version(git_obj: Git, version: str) -> str | None:
     if 7 <= len(version) <= 40 and re.match(hex_only_pattern, version):
         try:
             commit = git_obj.get_commit(version)
-        except BadName as error:
+        except (BadName, ValueError) as error:
             logger.debug("Failed to retrieve commit: %s", error)
 
     if not commit:

--- a/src/macaron/repo_finder/provenance_extractor.py
+++ b/src/macaron/repo_finder/provenance_extractor.py
@@ -5,9 +5,8 @@
 import logging
 
 from macaron.errors import ProvenanceError
-from macaron.json_tools import json_extract
+from macaron.json_tools import JsonType, json_extract
 from macaron.slsa_analyzer.provenance.intoto import InTotoPayload, InTotoV1Payload, InTotoV01Payload
-from macaron.util import JsonType
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -67,16 +66,8 @@ def _extract_from_slsa_v01(payload: InTotoV01Payload) -> tuple[str | None, str |
     if not list_index:
         return None, None
 
-    material_list = json_extract(predicate, ["materials"], list)
-    if not material_list:
-        return None, None
-
-    if list_index >= len(material_list):
-        logger.debug("Material list index outside of material list bounds.")
-        return None, None
-
-    material = material_list[list_index]
-    if not material or not isinstance(material, dict):
+    material = json_extract(predicate, ["materials", list_index], dict)
+    if not material:
         logger.debug("Indexed material list entry is invalid.")
         return None, None
 

--- a/src/macaron/repo_finder/provenance_extractor.py
+++ b/src/macaron/repo_finder/provenance_extractor.py
@@ -235,7 +235,7 @@ def _clean_spdx(uri: str) -> str:
     return url
 
 
-def _check_if_input_repo_commit_provenance_conflict(
+def check_if_input_repo_commit_provenance_conflict(
     repo_path_input: str | None,
     digest_input: str | None,
     provenance_repo_url: str | None,
@@ -282,7 +282,7 @@ def _check_if_input_repo_commit_provenance_conflict(
     return False
 
 
-def _check_if_input_purl_provenance_conflict(
+def check_if_input_purl_provenance_conflict(
     git_obj: Git,
     repo_path_input: bool,
     digest_input: bool,

--- a/src/macaron/repo_finder/provenance_extractor.py
+++ b/src/macaron/repo_finder/provenance_extractor.py
@@ -3,9 +3,19 @@
 
 """This module contains methods for extracting repository and commit metadata from provenance files."""
 import logging
+import urllib.parse
+
+from packageurl import PackageURL
+from pydriller import Git
 
 from macaron.errors import ProvenanceError
 from macaron.json_tools import JsonType, json_extract
+from macaron.repo_finder.commit_finder import (
+    AbstractPurlType,
+    determine_abstract_purl_type,
+    extract_commit_from_version,
+)
+from macaron.repo_finder.repo_finder import to_domain_from_known_purl_types
 from macaron.slsa_analyzer.provenance.intoto import InTotoPayload, InTotoV1Payload, InTotoV01Payload
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -223,3 +233,133 @@ def _clean_spdx(uri: str) -> str:
     """
     url, _, _ = uri.lstrip("git+").rpartition("@")
     return url
+
+
+def _check_if_input_repo_commit_provenance_conflict(
+    repo_path_input: str | None,
+    digest_input: str | None,
+    provenance_repo_url: str | None,
+    provenance_commit_digest: str | None,
+) -> bool:
+    """Test if the input repo and commit match the contents of the provenance.
+
+    Parameters
+    ----------
+    repo_path_input: str | None
+        The repo URL from input.
+    digest_input: str | None
+        The digest from input.
+    provenance_repo_url: str | None
+        The repo URL from provenance.
+    provenance_commit_digest: str | None
+        The commit digest from provenance.
+
+    Returns
+    -------
+    bool
+        True if there is a conflict between the inputs, False otherwise, or if the comparison cannot be performed.
+    """
+    # Check the provenance repo against the input repo.
+    if repo_path_input and provenance_repo_url and repo_path_input != provenance_repo_url:
+        logger.debug(
+            "The repository URL from input does not match what exists in the provenance. "
+            "Input Repo: %s, Provenance Repo: %s.",
+            repo_path_input,
+            provenance_repo_url,
+        )
+        return True
+
+    # Check the provenance commit against the input commit.
+    if digest_input and provenance_commit_digest and digest_input != provenance_commit_digest:
+        logger.debug(
+            "The commit digest from input does not match what exists in the provenance. "
+            "Input Commit: %s, Provenance Commit: %s.",
+            digest_input,
+            provenance_commit_digest,
+        )
+        return True
+
+    return False
+
+
+def _check_if_input_purl_provenance_conflict(
+    git_obj: Git,
+    repo_path_input: bool,
+    digest_input: bool,
+    provenance_repo_url: str | None,
+    provenance_commit_digest: str | None,
+    purl: PackageURL,
+) -> bool:
+    """Test if the input repository type PURL's repo and commit match the contents of the provenance.
+
+    Parameters
+    ----------
+    git_obj: Git
+        The Git object.
+    repo_path_input: bool
+        True if there is a repo as input.
+    digest_input: str
+        True if there is a commit as input.
+    provenance_repo_url: str | None
+        The repo url from provenance.
+    provenance_commit_digest: str | None
+        The commit digest from provenance.
+    purl: PackageURL
+        The input repository PURL.
+
+    Returns
+    -------
+    bool
+        True if there is a conflict between the inputs, False otherwise, or if the comparison cannot be performed.
+    """
+    if determine_abstract_purl_type(purl) != AbstractPurlType.REPOSITORY:
+        return False
+
+    # Check the PURL repo against the provenance.
+    if not repo_path_input and provenance_repo_url:
+        if not check_if_repository_purl_and_url_match(provenance_repo_url, purl):
+            logger.debug(
+                "The repo url passed via purl input does not match what exists in the provenance. "
+                "Purl: %s, Provenance: %s.",
+                purl,
+                provenance_repo_url,
+            )
+            return True
+
+    # Check the PURL commit against the provenance.
+    if not digest_input and provenance_commit_digest and purl.version:
+        purl_commit = extract_commit_from_version(git_obj, purl.version)
+        if purl_commit and purl_commit != provenance_commit_digest:
+            logger.debug(
+                "The commit digest passed via purl input does not match what exists in the "
+                "provenance. Purl Commit: %s, Provenance Commit: %s.",
+                purl_commit,
+                provenance_commit_digest,
+            )
+            return True
+
+    return False
+
+
+def check_if_repository_purl_and_url_match(url: str, repo_purl: PackageURL) -> bool:
+    """Compare a repository PURL and URL for equality.
+
+    Parameters
+    ----------
+    url: str
+        The URL.
+    repo_purl: PackageURL
+        A PURL that is of the repository abstract type. E.g. GitHub.
+
+    Returns
+    -------
+    bool
+        True if the two inputs match in terms of URL netloc/domain and path.
+    """
+    expanded_purl_type = to_domain_from_known_purl_types(repo_purl.type)
+    parsed_url = urllib.parse.urlparse(url)
+    purl_path = repo_purl.name
+    if repo_purl.namespace:
+        purl_path = f"{repo_purl.namespace}/{purl_path}"
+    # Note that the urllib method includes the "/" before path while the PURL method does not.
+    return f"{parsed_url.hostname}{parsed_url.path}".lower() == f"{expanded_purl_type or repo_purl.type}/{purl_path}"

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -9,7 +9,7 @@ from urllib.parse import quote as encode
 
 from packageurl import PackageURL
 
-from macaron.repo_finder.provenance_extractor import json_extract
+from macaron.json_tools import json_extract
 from macaron.repo_finder.repo_finder_base import BaseRepoFinder
 from macaron.repo_finder.repo_validator import find_valid_repository_url
 from macaron.util import send_get_http_raw

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -35,8 +35,8 @@ from macaron.output_reporter.results import Record, Report, SCMStatus
 from macaron.repo_finder import repo_finder
 from macaron.repo_finder.commit_finder import find_commit
 from macaron.repo_finder.provenance_extractor import (
-    _check_if_input_purl_provenance_conflict,
-    _check_if_input_repo_commit_provenance_conflict,
+    check_if_input_purl_provenance_conflict,
+    check_if_input_repo_commit_provenance_conflict,
     extract_repo_and_commit_from_provenance,
 )
 from macaron.repo_finder.provenance_finder import ProvenanceFinder
@@ -334,7 +334,7 @@ class Analyzer:
                 logger.debug("Failed to extract repo or commit from provenance: %s", error)
 
             # Try to validate the input repo and/or commit against provenance contents.
-            if (provenance_repo_url or provenance_commit_digest) and _check_if_input_repo_commit_provenance_conflict(
+            if (provenance_repo_url or provenance_commit_digest) and check_if_input_repo_commit_provenance_conflict(
                 repo_path_input, digest_input, provenance_repo_url, provenance_commit_digest
             ):
                 return Record(
@@ -371,7 +371,7 @@ class Analyzer:
 
         # Check if only one of the repo or digest came from direct input.
         if git_obj and (provenance_repo_url or provenance_commit_digest) and parsed_purl:
-            if _check_if_input_purl_provenance_conflict(
+            if check_if_input_purl_provenance_conflict(
                 git_obj,
                 bool(repo_path_input),
                 bool(digest_input),

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -324,6 +324,19 @@ class Analyzer:
                 provenance_repo_url, provenance_commit_digest = extract_repo_and_commit_from_provenance(
                     provenance_payload
                 )
+                # Check the provenance repo commit match the input repo commit
+                repo_path_input: str = config.get_value("path")
+                digest_input: str = config.get_value("digest")
+                if (repo_path_input and provenance_repo_url and repo_path_input != provenance_repo_url) or (
+                    digest_input and provenance_commit_digest and digest_input != provenance_commit_digest
+                ):
+                    return Record(
+                        record_id=repo_id,
+                        description="The repository URL or commit digest provided as input do not match what exists "
+                        "in the provenance.",
+                        pre_config=config,
+                        status=SCMStatus.ANALYSIS_FAILED,
+                    )
             except ProvenanceError as error:
                 logger.debug("Failed to extract repo or commit from provenance: %s", error)
 

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -498,7 +498,7 @@ class Analyzer:
         provenance_commit_digest: str | None,
         purl: PackageURL,
     ) -> bool:
-        """Test if the input repo and commit match the contents of the provenance.
+        """Test if the input PURL's repo and commit match the contents of the provenance.
 
         Parameters
         ----------
@@ -512,6 +512,8 @@ class Analyzer:
             The repo url from provenance.
         provenance_commit_digest: str | None
             The commit digest from provenance.
+        purl: PackageURL
+            The input repository PURL.
 
         Returns
         -------

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -498,7 +498,7 @@ class Analyzer:
         provenance_commit_digest: str | None,
         purl: PackageURL,
     ) -> bool:
-        """Test if the input PURL's repo and commit match the contents of the provenance.
+        """Test if the input repository type PURL's repo and commit match the contents of the provenance.
 
         Parameters
         ----------

--- a/src/macaron/slsa_analyzer/package_registry/jfrog_maven_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/jfrog_maven_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Assets on a package registry."""
@@ -14,11 +14,11 @@ import requests
 
 from macaron.config.defaults import defaults
 from macaron.errors import ConfigurationError
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool
 from macaron.slsa_analyzer.build_tool.gradle import Gradle
 from macaron.slsa_analyzer.build_tool.maven import Maven
 from macaron.slsa_analyzer.package_registry.package_registry import PackageRegistry
-from macaron.util import JsonType
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/src/macaron/slsa_analyzer/provenance/expectations/cue/cue_validator.py
+++ b/src/macaron/slsa_analyzer/provenance/expectations/cue/cue_validator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The cue module invokes the CUE schema validator."""
@@ -10,7 +10,7 @@ from collections.abc import Callable
 
 from macaron import MACARON_PATH
 from macaron.errors import CUEExpectationError, CUERuntimeError
-from macaron.util import JsonType
+from macaron.json_tools import JsonType
 
 # Load the CUE shared library.
 cue = ctypes.CDLL(os.path.join(MACARON_PATH, "bin", "cuevalidate.so"))

--- a/src/macaron/slsa_analyzer/provenance/intoto/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/__init__.py
@@ -10,11 +10,11 @@ from typing import NamedTuple, Protocol, TypeVar
 
 from packageurl import PackageURL
 
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.provenance.intoto import v01, v1
 from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
 from macaron.slsa_analyzer.provenance.intoto.v01 import InTotoV01Subject
 from macaron.slsa_analyzer.provenance.intoto.v1 import InTotoV1ResourceDescriptor
-from macaron.util import JsonType
 
 # Type of an in-toto statement.
 # This is currently either a v0.1 statement or v1 statement.

--- a/src/macaron/slsa_analyzer/provenance/intoto/v01/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v01/__init__.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 from typing import TypedDict, TypeGuard
 
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
-from macaron.util import JsonType
 
 
 class InTotoV01Statement(TypedDict):

--- a/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/v1/__init__.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TypedDict, TypeGuard
 
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
-from macaron.util import JsonType
 
 
 class InTotoV1Statement(TypedDict):

--- a/src/macaron/slsa_analyzer/provenance/loader.py
+++ b/src/macaron/slsa_analyzer/provenance/loader.py
@@ -12,9 +12,10 @@ import zlib
 from urllib.parse import urlparse
 
 from macaron.config.defaults import defaults
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.provenance.intoto import InTotoPayload, validate_intoto_payload
 from macaron.slsa_analyzer.provenance.intoto.errors import LoadIntotoAttestationError, ValidateInTotoPayloadError
-from macaron.util import JsonType, send_get_http_raw
+from macaron.util import send_get_http_raw
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/src/macaron/util.py
+++ b/src/macaron/util.py
@@ -260,10 +260,3 @@ def copy_file_bulk(file_list: list, src_path: str, target_path: str) -> bool:
                 return False
 
     return True
-
-
-def compare_urls_for_domain_path_equality(url_a: str, url_b: str) -> bool:
-    """Compare two URLs for equality based on the netloc/domain/hostname and path."""
-    parsed_a = urllib.parse.urlparse(url_a)
-    parsed_b = urllib.parse.urlparse(url_b)
-    return parsed_a.netloc == parsed_b.netloc and parsed_a.path == parsed_b.path

--- a/src/macaron/util.py
+++ b/src/macaron/util.py
@@ -262,17 +262,8 @@ def copy_file_bulk(file_list: list, src_path: str, target_path: str) -> bool:
     return True
 
 
-JsonType = int | float | str | None | bool | list["JsonType"] | dict[str, "JsonType"]
-
-
-def get_if_exists(doc: JsonType, path: list[str | int]) -> JsonType | None:
-    """Get a json dict value if it exists."""
-    while len(path) > 0:
-        this = path.pop(0)
-        if isinstance(this, str) and isinstance(doc, dict) and this in doc:
-            doc = doc[this]
-        elif isinstance(this, int) and isinstance(doc, list) and 0 <= this < len(doc):
-            doc = doc[this]
-        else:
-            return None
-    return doc
+def compare_urls_for_domain_path_equality(url_a: str, url_b: str) -> bool:
+    """Compare two URLs for equality based on the netloc/domain/hostname and path."""
+    parsed_a = urllib.parse.urlparse(url_a)
+    parsed_b = urllib.parse.urlparse(url_b)
+    return parsed_a.netloc == parsed_b.netloc and parsed_a.path == parsed_b.path

--- a/src/macaron/vsa/vsa.py
+++ b/src/macaron/vsa/vsa.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 
 from macaron.database.database_manager import get_db_manager
 from macaron.database.table_definitions import ProvenanceSubject
-from macaron.util import JsonType
+from macaron.json_tools import JsonType
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/tests/e2e/expected_results/slsa-verifier/slsa-verifier_explicitly_provided_cue_PASS.json
+++ b/tests/e2e/expected_results/slsa-verifier/slsa-verifier_explicitly_provided_cue_PASS.json
@@ -1,50 +1,50 @@
 {
     "metadata": {
-        "timestamps": "2024-05-07 15:16:38",
+        "timestamps": "2024-05-14 13:23:14",
         "has_passing_check": true,
         "run_checks": [
-            "mcn_build_script_1",
-            "mcn_build_service_1",
-            "mcn_provenance_derived_commit_1",
-            "mcn_trusted_builder_level_three_1",
+            "mcn_provenance_witness_level_one_1",
             "mcn_provenance_derived_repo_1",
             "mcn_build_as_code_1",
             "mcn_provenance_available_1",
-            "mcn_infer_artifact_pipeline_1",
-            "mcn_provenance_expectation_1",
             "mcn_version_control_system_1",
-            "mcn_provenance_witness_level_one_1"
+            "mcn_provenance_expectation_1",
+            "mcn_trusted_builder_level_three_1",
+            "mcn_infer_artifact_pipeline_1",
+            "mcn_provenance_derived_commit_1",
+            "mcn_build_script_1",
+            "mcn_build_service_1"
         ],
         "check_tree": {
             "mcn_provenance_available_1": {
-                "mcn_provenance_expectation_1": {},
+                "mcn_provenance_level_three_1": {},
                 "mcn_provenance_witness_level_one_1": {},
-                "mcn_provenance_level_three_1": {}
+                "mcn_provenance_expectation_1": {}
             },
             "mcn_provenance_derived_commit_1": {},
             "mcn_version_control_system_1": {
-                "mcn_build_script_1": {},
                 "mcn_trusted_builder_level_three_1": {
                     "mcn_build_as_code_1": {
-                        "mcn_build_service_1": {},
-                        "mcn_infer_artifact_pipeline_1": {}
+                        "mcn_infer_artifact_pipeline_1": {},
+                        "mcn_build_service_1": {}
                     }
-                }
+                },
+                "mcn_build_script_1": {}
             },
             "mcn_provenance_derived_repo_1": {}
         }
     },
     "target": {
         "info": {
-            "full_name": "pkg:github.com/slsa-framework/slsa-verifier@fc50b662fcfeeeb0e97243554b47d9b20b14efac",
+            "full_name": "pkg:github.com/slsa-framework/slsa-verifier@6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6",
             "local_cloned_path": "git_repos/github_com/slsa-framework/slsa-verifier",
             "remote_path": "https://github.com/slsa-framework/slsa-verifier",
-            "branch": "main",
-            "commit_hash": "fc50b662fcfeeeb0e97243554b47d9b20b14efac",
-            "commit_date": "2022-10-04T01:00:02+00:00"
+            "branch": null,
+            "commit_hash": "6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6",
+            "commit_date": "2022-08-25T11:37:20-05:00"
         },
         "provenances": {
-            "is_inferred": true,
+            "is_inferred": false,
             "content": {
                 "github_actions": [
                     {
@@ -53,24 +53,23 @@
                         "predicateType": "https://slsa.dev/provenance/v0.2",
                         "predicate": {
                             "builder": {
-                                "id": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/release.yml"
+                                "id": "<URI>"
                             },
-                            "buildType": "Custom github_actions",
+                            "buildType": "<URI>",
                             "invocation": {
                                 "configSource": {
-                                    "uri": "https://github.com/slsa-framework/slsa-verifier@refs/heads/main",
+                                    "uri": "<URI>",
                                     "digest": {
-                                        "sha1": "fc50b662fcfeeeb0e97243554b47d9b20b14efac"
+                                        "sha1": "<STING>"
                                     },
-                                    "entryPoint": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/release.yml"
+                                    "entryPoint": "<STRING>"
                                 },
                                 "parameters": {},
                                 "environment": {}
                             },
                             "buildConfig": {
-                                "jobID": "",
-                                "stepID": "",
-                                "stepName": ""
+                                "jobID": "<STRING>",
+                                "stepID": "<STRING>"
                             },
                             "metadata": {
                                 "buildInvocationId": "<STRING>",
@@ -91,15 +90,14 @@
                             ]
                         }
                     }
-                ],
-                "npm Registry": []
+                ]
             }
         },
         "checks": {
             "summary": {
                 "DISABLED": 0,
-                "FAILED": 3,
-                "PASSED": 8,
+                "FAILED": 2,
+                "PASSED": 9,
                 "SKIPPED": 0,
                 "UNKNOWN": 0
             },
@@ -125,9 +123,9 @@
                         "build_tool_name: go",
                         "ci_service_name: github_actions",
                         "language: BuildLanguage.GO",
-                        "build_tool_command: [\"go\", \"build\", \"-mod=vendor\", \"-o\", \"service\", \"./cli/experimental/service/\"]",
+                        "build_tool_command: [\"go\", \"build\", \"-mod=vendor\"]",
                         {
-                            "build_trigger": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/pre-submit.cli.yml"
+                            "build_trigger": "https://github.com/slsa-framework/slsa-verifier/blob/6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6/.github/workflows/pre-submit.yml"
                         }
                     ],
                     "result_type": "PASSED"
@@ -158,13 +156,24 @@
                     "result_type": "PASSED"
                 },
                 {
+                    "check_id": "mcn_provenance_derived_commit_1",
+                    "check_description": "Check whether the commit came from provenance.",
+                    "slsa_requirements": [
+                        "Security - SLSA Level 4"
+                    ],
+                    "justification": [
+                        "commit_info: The commit digest was found from provenance."
+                    ],
+                    "result_type": "PASSED"
+                },
+                {
                     "check_id": "mcn_provenance_derived_repo_1",
                     "check_description": "Check whether the repo came from provenance.",
                     "slsa_requirements": [
                         "Security - SLSA Level 4"
                     ],
                     "justification": [
-                        "repository_url: The repository URL was found from provenance."
+                        "repository_info: The repository URL was found from provenance."
                     ],
                     "result_type": "PASSED"
                 },
@@ -192,7 +201,7 @@
                         "build_tool_name: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.0",
                         "ci_service_name: github_actions",
                         {
-                            "build_trigger": "https://github.com/slsa-framework/slsa-verifier/blob/fc50b662fcfeeeb0e97243554b47d9b20b14efac/.github/workflows/release.yml"
+                            "build_trigger": "https://github.com/slsa-framework/slsa-verifier/blob/6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6/.github/workflows/release.yml"
                         }
                     ],
                     "result_type": "PASSED"
@@ -218,17 +227,6 @@
                     ],
                     "justification": [
                         "Not Available."
-                    ],
-                    "result_type": "FAILED"
-                },
-                {
-                    "check_id": "mcn_provenance_derived_commit_1",
-                    "check_description": "Check whether the commit came from provenance.",
-                    "slsa_requirements": [
-                        "Security - SLSA Level 4"
-                    ],
-                    "justification": [
-                        "commit_digest: The analysis commit did not match the provenance commit."
                     ],
                     "result_type": "FAILED"
                 },

--- a/tests/repo_finder/test_provenance_extractor.py
+++ b/tests/repo_finder/test_provenance_extractor.py
@@ -5,10 +5,14 @@
 import json
 
 import pytest
+from packageurl import PackageURL
 
 from macaron.errors import ProvenanceError
 from macaron.json_tools import JsonType, json_extract
-from macaron.repo_finder.provenance_extractor import extract_repo_and_commit_from_provenance
+from macaron.repo_finder.provenance_extractor import (
+    check_if_repository_purl_and_url_match,
+    extract_repo_and_commit_from_provenance,
+)
 from macaron.slsa_analyzer.provenance.intoto import validate_intoto_payload
 
 
@@ -493,6 +497,21 @@ def test_invalid_type_payloads(type_: str, predicate_type: str) -> None:
     payload: dict[str, JsonType] = {"_type": type_, "predicateType": predicate_type, "subject": [], "predicate": {}}
     with pytest.raises(ProvenanceError):
         _test_extract_repo_and_commit_from_provenance(payload)
+
+
+@pytest.mark.parametrize(
+    ("url", "purl_string", "expected"),
+    [
+        ("https://github.com:9000/oracle/macaron", "pkg:github/oracle/macaron", True),
+        ("http://user:pass@github.com/oracle/macaron", "pkg:github.com/oracle/macaron", True),
+        ("https://bitbucket.org:9000/example/test", "pkg:bitbucket/example/test", True),
+        ("http://bitbucket.org/example;key1=1?key2=2#key3=3", "pkg:bitbucket.org/example", True),
+    ],
+)
+def test_compare_purl_and_url(url: str, purl_string: str, expected: bool) -> None:
+    """Test comparison of repository type PURLs against matching URLs."""
+    purl = PackageURL.from_string(purl_string)
+    assert expected == check_if_repository_purl_and_url_match(url, purl)
 
 
 def _test_extract_repo_and_commit_from_provenance(

--- a/tests/repo_finder/test_provenance_extractor.py
+++ b/tests/repo_finder/test_provenance_extractor.py
@@ -7,10 +7,9 @@ import json
 import pytest
 
 from macaron.errors import ProvenanceError
-from macaron.json_tools import json_extract
+from macaron.json_tools import JsonType, json_extract
 from macaron.repo_finder.provenance_extractor import extract_repo_and_commit_from_provenance
 from macaron.slsa_analyzer.provenance.intoto import validate_intoto_payload
-from macaron.util import JsonType
 
 
 @pytest.fixture(name="slsa_v1_gcb_1_provenance")

--- a/tests/repo_finder/test_provenance_extractor.py
+++ b/tests/repo_finder/test_provenance_extractor.py
@@ -505,7 +505,7 @@ def _test_extract_repo_and_commit_from_provenance(
     assert expected_commit == commit
 
 
-def _json_modify(entry: JsonType, keys: list[str], new_value: JsonType) -> None:
+def _json_modify(entry: dict | list, keys: list[str], new_value: JsonType) -> None:
     """Modify the value found by following the list of depth-sequential keys inside the passed JSON dictionary.
 
     The found value will be overwritten by the `new_value` parameter.

--- a/tests/slsa_analyzer/provenance/intoto/v01/test_validate.py
+++ b/tests/slsa_analyzer/provenance/intoto/v01/test_validate.py
@@ -1,13 +1,13 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for validation of in-toto attestation version 0.1."""
 
 import pytest
 
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
 from macaron.slsa_analyzer.provenance.intoto.v01 import validate_intoto_statement, validate_intoto_subject
-from macaron.util import JsonType
 
 
 @pytest.mark.parametrize(

--- a/tests/slsa_analyzer/provenance/intoto/v1/test_validate.py
+++ b/tests/slsa_analyzer/provenance/intoto/v1/test_validate.py
@@ -5,9 +5,9 @@
 
 import pytest
 
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.provenance.intoto.errors import ValidateInTotoPayloadError
 from macaron.slsa_analyzer.provenance.intoto.v1 import validate_intoto_statement
-from macaron.util import JsonType
 
 
 @pytest.mark.parametrize(

--- a/tests/slsa_analyzer/test_analyze_context.py
+++ b/tests/slsa_analyzer/test_analyze_context.py
@@ -9,13 +9,13 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
+from macaron.json_tools import JsonType
 from macaron.slsa_analyzer.asset import VirtualReleaseAsset
 from macaron.slsa_analyzer.ci_service.github_actions.github_actions_ci import GitHubActions
 from macaron.slsa_analyzer.provenance.intoto import validate_intoto_payload
 from macaron.slsa_analyzer.provenance.slsa import SLSAProvenanceData
 from macaron.slsa_analyzer.slsa_req import ReqName, SLSAReqStatus
 from macaron.slsa_analyzer.specs.ci_spec import CIInfo
-from macaron.util import JsonType
 from tests.conftest import MockAnalyzeContext
 
 

--- a/tests/slsa_analyzer/test_analyzer.py
+++ b/tests/slsa_analyzer/test_analyzer.py
@@ -155,3 +155,18 @@ def test_resolve_analysis_target_no_purl_or_repository() -> None:
     """Test creation of an Analysis Target when no PURL or repository path is provided."""
     with pytest.raises(InvalidAnalysisTargetError):
         Analyzer.to_analysis_target(Configuration(), [], None)
+
+
+@pytest.mark.parametrize(
+    ("url", "purl_string", "expected"),
+    [
+        ("https://github.com:9000/oracle/macaron", "pkg:github/oracle/macaron", True),
+        ("http://user:pass@github.com/oracle/macaron", "pkg:github.com/oracle/macaron", True),
+        ("https://bitbucket.org:9000/example/test", "pkg:bitbucket/example/test", True),
+        ("http://bitbucket.org/example;key1=1?key2=2#key3=3", "pkg:bitbucket.org/example", True),
+    ],
+)
+def test_compare_purl_and_url(url: str, purl_string: str, expected: bool) -> None:
+    """Test comparison of repository type PURLs against matching URLs."""
+    purl = PackageURL.from_string(purl_string)
+    assert expected == Analyzer.check_if_repository_purl_and_url_match(url, purl)

--- a/tests/slsa_analyzer/test_analyzer.py
+++ b/tests/slsa_analyzer/test_analyzer.py
@@ -155,18 +155,3 @@ def test_resolve_analysis_target_no_purl_or_repository() -> None:
     """Test creation of an Analysis Target when no PURL or repository path is provided."""
     with pytest.raises(InvalidAnalysisTargetError):
         Analyzer.to_analysis_target(Configuration(), [], None)
-
-
-@pytest.mark.parametrize(
-    ("url", "purl_string", "expected"),
-    [
-        ("https://github.com:9000/oracle/macaron", "pkg:github/oracle/macaron", True),
-        ("http://user:pass@github.com/oracle/macaron", "pkg:github.com/oracle/macaron", True),
-        ("https://bitbucket.org:9000/example/test", "pkg:bitbucket/example/test", True),
-        ("http://bitbucket.org/example;key1=1?key2=2#key3=3", "pkg:bitbucket.org/example", True),
-    ],
-)
-def test_compare_purl_and_url(url: str, purl_string: str, expected: bool) -> None:
-    """Test comparison of repository type PURLs against matching URLs."""
-    purl = PackageURL.from_string(purl_string)
-    assert expected == Analyzer.check_if_repository_purl_and_url_match(url, purl)

--- a/tests/vsa/test_compare_vsa.py
+++ b/tests/vsa/test_compare_vsa.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from macaron.util import JsonType
+from macaron.json_tools import JsonType
 from tests.vsa.compare_vsa import compare_json, skip_compare
 
 


### PR DESCRIPTION
Adds a validation step to analysis that ensures the passed repo and commit match those found in the passed provenance, if all of those exist.