### PR TITLE
chore: improve commit finder and input handling

### DIFF
--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -262,9 +262,9 @@ echo "apache/maven: Analyzing using a CycloneDx SBOM file of a software componen
 echo -e "----------------------------------------------------------------------------------\n"
 SBOM_FILE=$WORKSPACE/tests/dependency_analyzer/cyclonedx/resources/private_mirror_apache_maven.json
 DEP_EXPECTED=$WORKSPACE/tests/dependency_analyzer/expected_results/private_mirror_apache_maven.json
-DEP_RESULT=$WORKSPACE/output/reports/private_domain_com/apache/maven/dependencies.json
+DEP_RESULT=$WORKSPACE/output/reports/private-domain_com/apache/maven/dependencies.json
 
-$RUN_MACARON analyze -purl pkg:private_domain.com/apache/maven -sbom "$SBOM_FILE" || log_fail
+$RUN_MACARON analyze -purl pkg:private-domain.com/apache/maven -sbom "$SBOM_FILE" || log_fail
 
 check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -4,6 +4,7 @@
 """This module handles the cloning and analyzing a Git repo."""
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -304,6 +305,9 @@ class Analyzer:
         repo_id = config.get_value("id")
         try:
             parsed_purl = Analyzer.parse_purl(config)
+            # Validate PURL type as per https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst
+            if parsed_purl and not re.match(r"^[a-z.+-][a-z0-9.+-]*$", parsed_purl.type):
+                raise InvalidPURLError(f"Invalid purl type: {parsed_purl.type}")
         except InvalidPURLError as error:
             logger.error(error)
             return Record(


### PR DESCRIPTION
This PR improves the commit finder so that it can handle cases where numeric version parts have preceding zeroes. E.g. Version `2024.2.2` -> Tag `2024.02.02`. The trailing zero evaluation (for the version as a whole) has also been updated to accept "long" zeros, e.g. `1.00`, `1.000`.

In addition, PURLs with an invalid type as defined in the spec are rejected before analysis begins.

Partially relates to discussion in #706 