### PR TITLE
docs: update required go version to 1.21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ a detailed commit message body is preferred. Make sure to keep the `Signed-off-b
 ### Prerequisites
 
 - Python 3.11
-- Go 1.20
+- Go 1.21
 - JDK 17
 
 ### Prepare the environment


### PR DESCRIPTION
#749 updated `slsa-verifier` to version `v2.5.1` [which requires Go v1.21](https://github.com/slsa-framework/slsa-verifier/blob/eb7007070baa04976cb9e25a0d8034f8db030a86/go.mod#L5). Using an older Go version (v1.20 or below) causes `make setup` to fail due to a `go.mod` schema change ([specifically, the addition of the `toolchain` directive](https://go.dev/doc/modules/gomod-ref#toolchain)).

This pull request updates the required Go version in `CONTRIBUTING.md`.