### PR TITLE
chore: remove outdated TODO in repo finder function

### DIFF
--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -137,7 +137,7 @@ def to_repo_path(purl: PackageURL, available_domains: list[str]) -> str | None:
         logger.error("Expecting a non-empty namespace from %s.", purl)
         return None
 
-    # TODO: Handle the version tag and commit digest if they are given in the PURL.
+    # If the PURL contains a commit digest or version tag, they will be used after the repository has been resolved.
     return urlunparse(
         ParseResult(
             scheme="https",


### PR DESCRIPTION
This PR was to perform refactoring so that a possibly duplicated function could be removed, while implementing the original's TODO comment. Further investigation has revealed that the possibly duplicated function should remain, and that the TODO comment is outdated. Therefore this PR only removes the TODO comment.

Closes #752 