### PR TITLE
fix: modify verify-policy to exits succesfully if a passed policy exists and allow components having no repository to pass policies

### DIFF
--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -457,19 +457,11 @@ echo -e "\n---------------------------------------------------------------------
 echo "apache/maven: Analyzing with local paths using local_repos_dir without dependency resolution."
 echo -e "----------------------------------------------------------------------------------\n"
 # The report files are still stored in the same location.
-EXPECT_DIR=$WORKSPACE/tests/e2e/expected_results/maven
-
-declare -a COMPARE_FILES=(
-    "maven.dl"
-    "guava.dl"
-    "mockito.dl"
-)
+OUTPUT_POLICY=$WORKSPACE/tests/e2e/expected_results/maven/maven.dl
 
 run_macaron_clean -lr $WORKSPACE/output/git_repos/github_com/ $ANALYZE -rp apache/maven -b master -d 3fc399318edef0d5ba593723a24fff64291d6f9b --skip-deps || log_fail
-for i in "${COMPARE_FILES[@]}"
-do
-    $RUN_POLICY -d $DB -f $EXPECT_DIR/$i || log_fail
-done
+
+$RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail
 
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing a repository that was cloned from another local repo."

--- a/scripts/dev_scripts/integration_tests_docker.sh
+++ b/scripts/dev_scripts/integration_tests_docker.sh
@@ -100,7 +100,8 @@ python $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 echo -e "\n----------------------------------------------------------------------------------"
 echo "apache/maven: Analyzing with PURL and repository path without dependency resolution."
 echo -e "----------------------------------------------------------------------------------\n"
-JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/purl/maven/maven.dl
+OUTPUT_POLICY=$WORKSPACE/tests/e2e/expected_results/purl/maven/maven.dl
+
 run_macaron_clean analyze -purl pkg:maven/apache/maven -rp https://github.com/apache/maven -b master -d 3fc399318edef0d5ba593723a24fff64291d6f9b --skip-deps || log_fail
 
 $RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail
@@ -109,8 +110,9 @@ echo -e "\n---------------------------------------------------------------------
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped."
 echo "The CUE expectation file is provided as a single file path."
 echo -e "----------------------------------------------------------------------------------\n"
-JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/urllib3/urllib3.dl
+OUTPUT_POLICY=$WORKSPACE/tests/e2e/expected_results/urllib3/urllib3.dl
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/urllib3_PASS.cue
+
 run_macaron_clean analyze -pe $EXPECTATION_FILE -rp https://github.com/urllib3/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
 $RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail
@@ -119,8 +121,9 @@ echo -e "\n---------------------------------------------------------------------
 echo "urllib3/urllib3: Analyzing the repo path when automatic dependency resolution is skipped."
 echo "The CUE expectation file should be found via the directory path."
 echo -e "----------------------------------------------------------------------------------\n"
-JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/urllib3/urllib3.dl
+OUTPUT_POLICY=$WORKSPACE/tests/e2e/expected_results/urllib3/urllib3.dl
 EXPECTATION_DIR=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/
+
 run_macaron_clean analyze -pe $EXPECTATION_DIR -rp https://github.com/urllib3/urllib3/urllib3 -b main -d 87a0ecee6e691fe5ff93cd000c0158deebef763b --skip-deps || log_fail
 
 $RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail
@@ -128,9 +131,10 @@ $RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail
 echo -e "\n----------------------------------------------------------------------------------"
 echo "Test verifying CUE provenance expectation for ossf/scorecard"
 echo -e "----------------------------------------------------------------------------------\n"
-JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/scorecard/scorecard.dl
+OUTPUT_POLICY=$WORKSPACE/tests/e2e/expected_results/scorecard/scorecard.dl
 DEFAULTS_FILE=$WORKSPACE/tests/e2e/defaults/scorecard.ini
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/scorecard_PASS.cue
+
 run_macaron_clean -dp $DEFAULTS_FILE analyze -pe $EXPECTATION_FILE -purl pkg:github/ossf/scorecard@v4.13.1 --skip-deps || log_fail
 
 $RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail
@@ -152,9 +156,10 @@ echo -e "\n---------------------------------------------------------------------
 echo "slsa-framework/slsa-verifier: Analyzing the repo path when automatic dependency resolution is skipped"
 echo "and CUE file is provided as expectation."
 echo -e "----------------------------------------------------------------------------------\n"
-JSON_EXPECTED=$WORKSPACE/tests/e2e/expected_results/slsa-verifier/slsa-verifier_cue_PASS.dl
+OUTPUT_POLICY=$WORKSPACE/tests/e2e/expected_results/slsa-verifier/slsa-verifier_cue_PASS.dl
 EXPECTATION_FILE=$WORKSPACE/tests/slsa_analyzer/provenance/expectations/cue/resources/valid_expectations/slsa_verifier_PASS.cue
 DEFAULTS_FILE=$WORKSPACE/tests/e2e/defaults/slsa_verifier.ini
+
 run_macaron_clean -dp $DEFAULTS_FILE analyze -pe $EXPECTATION_FILE -rp https://github.com/slsa-framework/slsa-verifier -b main -d fc50b662fcfeeeb0e97243554b47d9b20b14efac --skip-deps || log_fail
 
 $RUN_POLICY -d $DB -f $OUTPUT_POLICY || log_fail

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -191,6 +191,9 @@ def verify_policy(verify_policy_args: argparse.Namespace) -> int:
 
         if ("failed_policies" in result) and any(result["failed_policies"]):
             return os.EX_DATAERR
+        if len(result.get("passed_policies", [])) == 0:
+            logger.error("Found no component passing policies.")
+            return os.EX_DATAERR
 
         return os.EX_OK
 

--- a/src/macaron/policy_engine/prelude/helper_rules.dl
+++ b/src/macaron/policy_engine/prelude/helper_rules.dl
@@ -61,6 +61,13 @@ repository_analysis(analysis_id, component_id, repo_id, repo_name) :-
     is_repo(repo_id, repo_name, component_id).
 
 /**
+ * A convenience relation to find analyses conducted on a specific component.
+ */
+ .decl component_analysis(analysis_id: number, component_id: number)
+component_analysis(analysis_id, component_id) :-
+    component(component_id, _, analysis_id, _, _, _, _, _, _).
+
+/**
  *  ADT recursively describing a JSON object.
  */
 .type JsonType = Int {x : number}

--- a/src/macaron/policy_engine/prelude/policy.dl
+++ b/src/macaron/policy_engine/prelude/policy.dl
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved. */
+/* Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved. */
 /* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
 
 /**
@@ -41,7 +41,7 @@ apply_to_analysis(analysis_id) :-
 policy_applies_to(policy_id, component_id) :-
     apply_policy_to(policy_id, component_id),
     apply_to_analysis(analysis_id),
-    repository_analysis(analysis_id, component_id, _, _).
+    component_analysis(analysis_id, component_id).
 
 /**
  *  Policies that are applied to a component and the requirements are not met.

--- a/tests/e2e/expected_results/purl/maven/com_example_nonexistent/nonexistent.dl
+++ b/tests/e2e/expected_results/purl/maven/com_example_nonexistent/nonexistent.dl
@@ -15,8 +15,7 @@ Policy("test_policy", component_id, "") :-
     check_failed(component_id, "mcn_provenance_level_three_1"),
     check_failed(component_id, "mcn_provenance_witness_level_one_1"),
     check_failed(component_id, "mcn_trusted_builder_level_three_1"),
-    check_failed(component_id, "mcn_version_control_system_1"),
-    is_repo_url(component_id, "").
+    check_failed(component_id, "mcn_version_control_system_1").
 
 apply_policy_to("test_policy", component_id) :-
     is_component(component_id, "pkg:maven/com.example/nonexistent@1.0.0").


### PR DESCRIPTION
This pull request includes the following fixes:
* A fix to the `verify-policy` command to exit with non-zero code when no "passed policy" exists.
* A fix to the policy rules allows components with no repository to pass policies.
* Fixes to some integration tests that did not fail when the component being verified did not pass the policy applied to it.