### PR TITLE
fix: force docker to use linux/amd64 platform

### DIFF
--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -584,6 +584,7 @@ else
     fi
 fi
 
+# Force docker to use linux/amd64 platform in order to make docker use emulation on ARM host platforms.
 docker run \
     --platform=linux/amd64 \
     --network=host \

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -585,6 +585,7 @@ else
 fi
 
 docker run \
+    --platform=linux/amd64 \
     --network=host \
     --rm -i "${tty[@]}" \
     -e "USER_UID=${USER_UID}" \


### PR DESCRIPTION
Using `--platform linux/amd64` makes it possible to run amd64 images on arm64 platforms through emulation

Closes #767 