### PR TITLE
chore: improve token support in run_macaron.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ tests/slsa_analyzer/ci_service/mock_repos/**
 docs/_build
 bin/
 requirements.txt
+.macaron_env_file

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -398,7 +398,7 @@ run_macaron_clean $ANALYZE -purl pkg:maven/io.github.behnazh-w.demo/example-mave
 check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 python ./tests/integration/run.py run \
-    --exclude-tag token_file_clean_up \
+    --exclude-tag docker-only \
     ./tests/integration/cases/... || log_fail
 
 # Important: This should be at the end of the file

--- a/scripts/dev_scripts/integration_tests.sh
+++ b/scripts/dev_scripts/integration_tests.sh
@@ -398,6 +398,7 @@ run_macaron_clean $ANALYZE -purl pkg:maven/io.github.behnazh-w.demo/example-mave
 check_or_update_expected_output $COMPARE_DEPS $DEP_RESULT $DEP_EXPECTED || log_fail
 
 python ./tests/integration/run.py run \
+    --exclude-tag token_file_clean_up \
     ./tests/integration/cases/... || log_fail
 
 # Important: This should be at the end of the file

--- a/scripts/dev_scripts/integration_tests_docker.sh
+++ b/scripts/dev_scripts/integration_tests_docker.sh
@@ -60,7 +60,7 @@ rm -rf "$VIRTUAL_ENV_PATH"
 
 python ./tests/integration/run.py run \
     --macaron scripts/release_scripts/run_macaron.sh \
-    --include-tag docker \
+    --include-tag shared-docker-python \
     ./tests/integration/cases/... || log_fail
 
 if [ $RESULT_CODE -ne 0 ];

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -259,16 +259,6 @@ function mount_file() {
     mounts+=("-v" "${file_on_host}:${file_in_container}:${mount_option}")
 }
 
-# Handle tokens.
-set +u
-echo "" > ${TOKEN_FILE}
-{
-    echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> ${TOKEN_FILE}
-    echo "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}" >> ${TOKEN_FILE}
-    echo "MCN_SELF_HOSTED_GITLAB_TOKEN=${MCN_SELF_HOSTED_GITLAB_TOKEN}"
-} >> ${TOKEN_FILE}
-mount_file "macaron_env_file" ${TOKEN_FILE} ${MACARON_WORKSPACE}/${TOKEN_FILE} "rw,Z"
-set -u
 
 # Parse main arguments.
 while [[ $# -gt 0 ]]; do
@@ -597,6 +587,17 @@ else
         exit 1
     fi
 fi
+
+# Handle tokens.
+set +u
+echo "" > ${TOKEN_FILE}
+{
+    echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> ${TOKEN_FILE}
+    echo "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}" >> ${TOKEN_FILE}
+    echo "MCN_SELF_HOSTED_GITLAB_TOKEN=${MCN_SELF_HOSTED_GITLAB_TOKEN}"
+} >> ${TOKEN_FILE}
+mount_file "macaron_env_file" ${TOKEN_FILE} ${MACARON_WORKSPACE}/${TOKEN_FILE} "rw,Z"
+set -u
 
 # Force docker to use linux/amd64 platform in order to make docker use emulation on ARM host platforms.
 docker run \

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -605,12 +605,11 @@ set +e
 
 # Handle tokens.
 set +u
-echo "" > ${TOKEN_FILE}
 {
-    echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> ${TOKEN_FILE}
-    echo "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}" >> ${TOKEN_FILE}
+    echo "GITHUB_TOKEN=${GITHUB_TOKEN}"
+    echo "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}"
     echo "MCN_SELF_HOSTED_GITLAB_TOKEN=${MCN_SELF_HOSTED_GITLAB_TOKEN}"
-} >> ${TOKEN_FILE}
+} > ${TOKEN_FILE}
 mount_file "macaron_env_file" ${TOKEN_FILE} ${MACARON_WORKSPACE}/${TOKEN_FILE} "rw,Z"
 set -u
 

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -259,6 +259,17 @@ function mount_file() {
     mounts+=("-v" "${file_on_host}:${file_in_container}:${mount_option}")
 }
 
+# Clean up the token file and EXIT this bash script with the given status code.
+#
+# Arguments:
+#   $1: The eventual exit status code.
+#   $2: The path to the token file.
+function clean_up_exit() {
+    status_code=$1
+    token_file_path=$2
+    rm -f "$token_file_path"
+    exit "$status_code"
+}
 
 # Parse main arguments.
 while [[ $# -gt 0 ]]; do
@@ -600,6 +611,9 @@ mount_file "macaron_env_file" ${TOKEN_FILE} ${MACARON_WORKSPACE}/${TOKEN_FILE} "
 set -u
 
 # Force docker to use linux/amd64 platform in order to make docker use emulation on ARM host platforms.
+# We need the `docker run` command to be within `set +e` so that when it returns a non-zero status code,
+# it doesn't exit right away and still run the token file cleaning up command.
+set +e
 docker run \
     --platform=linux/amd64 \
     --network=host \
@@ -613,4 +627,4 @@ docker run \
     "${entrypoint[@]}" \
     "${macaron_args[@]}"
 
-rm -f "$TOKEN_FILE"
+clean_up_exit "$?" "$TOKEN_FILE"

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -599,6 +599,10 @@ else
     fi
 fi
 
+# Make sure commands that need to be cleaned up exist within `set +e` so that when any of them returns a non-zero
+# status code, we don't exit right away and still run the token file cleaning up command.
+set +e
+
 # Handle tokens.
 set +u
 echo "" > ${TOKEN_FILE}
@@ -611,9 +615,6 @@ mount_file "macaron_env_file" ${TOKEN_FILE} ${MACARON_WORKSPACE}/${TOKEN_FILE} "
 set -u
 
 # Force docker to use linux/amd64 platform in order to make docker use emulation on ARM host platforms.
-# We need the `docker run` command to be within `set +e` so that when it returns a non-zero status code,
-# it doesn't exit right away and still run the token file cleaning up command.
-set +e
 docker run \
     --platform=linux/amd64 \
     --network=host \

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -604,14 +604,12 @@ fi
 set +e
 
 # Handle tokens.
-set +u
 {
     echo "GITHUB_TOKEN=${GITHUB_TOKEN}"
     echo "MCN_GITLAB_TOKEN=${MCN_GITLAB_TOKEN}"
     echo "MCN_SELF_HOSTED_GITLAB_TOKEN=${MCN_SELF_HOSTED_GITLAB_TOKEN}"
 } > ${TOKEN_FILE}
 mount_file "macaron_env_file" ${TOKEN_FILE} ${MACARON_WORKSPACE}/${TOKEN_FILE} "rw,Z"
-set -u
 
 # Force docker to use linux/amd64 platform in order to make docker use emulation on ARM host platforms.
 docker run \

--- a/tests/integration/cases/apache_maven_local_repo/test.yaml
+++ b/tests/integration/cases/apache_maven_local_repo/test.yaml
@@ -5,7 +5,7 @@ description: |
   Analyzing with local paths using local_repos_dir without dependency resolution.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Prepare local repo directory

--- a/tests/integration/cases/apache_maven_purl_repo_path/test.yaml
+++ b/tests/integration/cases/apache_maven_purl_repo_path/test.yaml
@@ -21,6 +21,12 @@ steps:
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
     - --skip-deps
+# This to check if run_macaron.sh cleans up the token file after the test case runs for the docker image.
+- name: Check the token file doesn't exist.
+  kind: shell
+  options:
+    cmd: ls .macaron_env_file
+  expect_fail: true
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/apache_maven_purl_repo_path/test.yaml
+++ b/tests/integration/cases/apache_maven_purl_repo_path/test.yaml
@@ -5,7 +5,7 @@ description: |
   Analyze with PURL, repository path, no dependency resolution.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/apache_maven_sbom/test.yaml
+++ b/tests/integration/cases/apache_maven_sbom/test.yaml
@@ -5,7 +5,7 @@ description: |
   Analyzing using a CycloneDx SBOM with target repo path
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/apache_maven_yaml_input_skip_deps/test.yaml
+++ b/tests/integration/cases/apache_maven_yaml_input_skip_deps/test.yaml
@@ -5,7 +5,7 @@ description: |
   Check the e2e output JSON file with config and no dependency analyzing.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/apache_maven_yaml_input_with_dep_resolution/test.yaml
+++ b/tests/integration/cases/apache_maven_yaml_input_with_dep_resolution/test.yaml
@@ -5,7 +5,7 @@ description: |
   Check the resolved dependency output with config for cyclonedx maven plugin
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/behnazh-w_example-maven-app/test.yaml
+++ b/tests/integration/cases/behnazh-w_example-maven-app/test.yaml
@@ -6,7 +6,7 @@ description: |
   Policy CLI, and VSA generation.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Clone the repository

--- a/tests/integration/cases/invalid_purl/test.yaml
+++ b/tests/integration/cases/invalid_purl/test.yaml
@@ -5,7 +5,7 @@ description: >
   Test analyzing with invalid PURL
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/no_branch_or_commit/test.yaml
+++ b/tests/integration/cases/no_branch_or_commit/test.yaml
@@ -5,7 +5,7 @@ description: >
   Test analyzing with both PURL and repository path but no branch or commit is provided
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/no_github_token/test.yaml
+++ b/tests/integration/cases/no_github_token/test.yaml
@@ -5,7 +5,7 @@ description: |
   Test running the analysis without setting the GITHUB_TOKEN environment variables.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/ossf_scorecard/test.yaml
+++ b/tests/integration/cases/ossf_scorecard/test.yaml
@@ -5,7 +5,7 @@ description: >
   Test CUE provenance expectation for ossf/scorecard, policy verification, and VSA generation.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/run_macaron_sh_early_exit/test.yaml
+++ b/tests/integration/cases/run_macaron_sh_early_exit/test.yaml
@@ -5,7 +5,7 @@ description: |
   Running run_macaron.sh on scenarios where the docker image is not available
 
 tags:
-- docker
+- shared-docker-python
 - docker-only
 
 steps:

--- a/tests/integration/cases/run_macaron_sh_early_exit/test.yaml
+++ b/tests/integration/cases/run_macaron_sh_early_exit/test.yaml
@@ -6,7 +6,7 @@ description: |
 
 tags:
 - docker
-- token_file_clean_up
+- docker-only
 
 steps:
 - name: Run run_macaron.sh.py with invalid docker image tag and DOCKER_PULL set to missing.

--- a/tests/integration/cases/run_macaron_sh_early_exit/test.yaml
+++ b/tests/integration/cases/run_macaron_sh_early_exit/test.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Running run_macaron.sh on scenarios where the docker image is not available
+
+tags:
+- docker
+- token_file_clean_up
+
+steps:
+- name: Run run_macaron.sh.py with invalid docker image tag and DOCKER_PULL set to missing.
+  kind: analyze
+  env:
+    MACARON_IMAGE_TAG: this_is_not_a_real_tag
+    DOCKER_PULL: missing
+  options:
+    command_args:
+    - --version
+  expect_fail: true
+- name: Check the token file doesn't exist.
+  kind: shell
+  options:
+    cmd: ls .macaron_env_file
+  expect_fail: true
+- name: Run run_macaron.sh.py with invalid docker image tag and DOCKER_PULL set to always.
+  kind: analyze
+  env:
+    MACARON_IMAGE_TAG: this_is_not_a_real_tag
+    DOCKER_PULL: always
+  options:
+    command_args:
+    - --version
+  expect_fail: true
+- name: Check the token file doesn't exist.
+  kind: shell
+  options:
+    cmd: ls .macaron_env_file
+  expect_fail: true
+- name: Run run_macaron.sh.py with invalid docker image tag and DOCKER_PULL set to never.
+  kind: analyze
+  env:
+    MACARON_IMAGE_TAG: this_is_not_a_real_tag
+    DOCKER_PULL: never
+  options:
+    command_args:
+    - --version
+  expect_fail: true
+- name: Check the token file doesn't exist.
+  kind: shell
+  options:
+    cmd: ls .macaron_env_file
+  expect_fail: true

--- a/tests/integration/cases/run_macaron_sh_with_invalid_docker_pull_env/test.yaml
+++ b/tests/integration/cases/run_macaron_sh_with_invalid_docker_pull_env/test.yaml
@@ -6,7 +6,7 @@ description: |
 
 tags:
 - docker
-- token_file_clean_up
+- docker-only
 
 steps:
 - name: Run run_macaron.sh.py with DOCKER_PULL set to invalid value.

--- a/tests/integration/cases/run_macaron_sh_with_invalid_docker_pull_env/test.yaml
+++ b/tests/integration/cases/run_macaron_sh_with_invalid_docker_pull_env/test.yaml
@@ -5,7 +5,7 @@ description: |
   Making sure run_macaron.sh clean up the token file when it exits because DOCKER_PULL is set to an invalid value.
 
 tags:
-- docker
+- shared-docker-python
 - docker-only
 
 steps:

--- a/tests/integration/cases/run_macaron_sh_with_invalid_docker_pull_env/test.yaml
+++ b/tests/integration/cases/run_macaron_sh_with_invalid_docker_pull_env/test.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Making sure run_macaron.sh clean up the token file when it exits because DOCKER_PULL is set to an invalid value.
+
+tags:
+- docker
+- token_file_clean_up
+
+steps:
+- name: Run run_macaron.sh.py with DOCKER_PULL set to invalid value.
+  kind: analyze
+  env:
+    DOCKER_PULL: invalid_value
+  options:
+    command_args:
+    - --version
+  expect_fail: true
+- name: Check the token file doesn't exist.
+  kind: shell
+  options:
+    cmd: ls .macaron_env_file
+  expect_fail: true

--- a/tests/integration/cases/slsa-framework_slsa-verifier/test.yaml
+++ b/tests/integration/cases/slsa-framework_slsa-verifier/test.yaml
@@ -5,7 +5,7 @@ description: |
   Test CUE provenance expectation check and policy verification.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/timyarkov_multibuild_test_gradle/test.yaml
+++ b/tests/integration/cases/timyarkov_multibuild_test_gradle/test.yaml
@@ -5,7 +5,7 @@ description: |
   Analyze with dependency resolution using cyclonedx Gradle plugin (default)
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/timyarkov_multibuild_test_maven/test.yaml
+++ b/tests/integration/cases/timyarkov_multibuild_test_maven/test.yaml
@@ -6,7 +6,7 @@ description: |
   with dependency resolution using cyclonedx Maven plugins (defaults).
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze

--- a/tests/integration/cases/urllib3_expectation_dir/test.yaml
+++ b/tests/integration/cases/urllib3_expectation_dir/test.yaml
@@ -6,7 +6,7 @@ description: |
   The CUE expectation file should be found via the directory path.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze with expectation directory

--- a/tests/integration/cases/urllib3_expectation_file/test.yaml
+++ b/tests/integration/cases/urllib3_expectation_file/test.yaml
@@ -6,7 +6,7 @@ description: |
   The CUE expectation file is provided as a single file path.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze with expectation file

--- a/tests/integration/cases/urllib3_invalid_expectation/test.yaml
+++ b/tests/integration/cases/urllib3_invalid_expectation/test.yaml
@@ -6,7 +6,7 @@ description: |
   The CUE expectation file is invalid.
 
 tags:
-- docker
+- shared-docker-python
 
 steps:
 - name: Run macaron analyze with invalid expectation file


### PR DESCRIPTION
This Pull Request improves token file operations in `run_macaron.sh`.

- Moved the token file creation to the end of `run_macaron.sh` so that if the script exits early, the token file is not persisted within the file system - https://github.com/oracle/macaron/pull/780/commits/f88f00ab4bf3544e202a8e0e6b7a624473883fbc
- Made sure that `docker run` if returns a non-zero status code doesn't trigger early exit (enable by `set -e`). This enables us to perform the cleaning up before exiting `run_macaron.sh`. Furthermore, the return status code of `run_macaron.sh` follows that of `docker run` - https://github.com/oracle/macaron/pull/780/commits/af4173ecd83a764aed279c41c7a12b84e79aa111
- Added integration test cases to check for token file persistence - https://github.com/oracle/macaron/pull/780/commits/62b8098cfe235a8fc7bb75ff9217d140c1d66d06
- Added the token file to gitignore - https://github.com/oracle/macaron/pull/780/commits/c2b83a5770eb9d07e59077b3d1eee17f53183c45