### PR TITLE
chore(mypy): remove redundant mypy_path configuration for type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ actions = [
 ]
 dev = [
     "flit >=3.2.0,<4.0.0",
-    "mypy >=1.0.0,<1.11",
+    "mypy >=1.0.0,<1.12",
     "types-pyyaml >=6.0.4,<7.0.0",
     "types-requests >=2.25.6,<3.0.0",
     "types-jsonschema >=4.22.0,<5.0.0",
@@ -172,7 +172,6 @@ skip_gitignore = true
 
 # https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml
 [tool.mypy]
-mypy_path = "src/macaron/:tests/"
 # exclude=
 show_error_codes = true
 show_column_numbers = true


### PR DESCRIPTION
I don't understand why suddenly this issue was picked up by `mypy` because we were using version [`1.10.1`](https://github.com/python/mypy/releases/tag/v1.10.1). Anyway, I have also updated `mypy`'s version range to use [version `1.11.0`](https://github.com/python/mypy/releases/tag/v1.11.0).
Fixes #798 