### PR TITLE
chore: add CLOSER_RELEASE_JOIN_DATE heuristic as a dependency of SUSPICIOUS_SETUP

### DIFF
--- a/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/suspicious_setup.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/suspicious_setup.py
@@ -26,7 +26,11 @@ class SuspiciousSetupAnalyzer(BaseHeuristicAnalyzer):
     """Analyzer checks heuristic."""
 
     def __init__(self) -> None:
-        super().__init__(name="suspicious_setup_analyzer", heuristic=Heuristics.SUSPICIOUS_SETUP, depends_on=None)
+        super().__init__(
+            name="suspicious_setup_analyzer",
+            heuristic=Heuristics.SUSPICIOUS_SETUP,
+            depends_on=[(Heuristics.CLOSER_RELEASE_JOIN_DATE, HeuristicResult.FAIL)],
+        )
         self.blacklist: list = ["base64", "request"]
 
     def _get_setup_source_code(self, pypi_package_json: PyPIPackageJsonAsset) -> str | None:


### PR DESCRIPTION
Right now the `CLOSER_RELEASE_JOIN_DATE` heuristic in the `mcn_detect_malicious_metadata_1` check does not depend on any other heuristic results. However, all the heuristic combinations require the `CLOSER_RELEASE_JOIN_DATE` heuristic to fail. This PR adds the `CLOSER_RELEASE_JOIN_DATE` heuristic as a dependency of `SUSPICIOUS_SETUP` to avoid running `SUSPICIOUS_SETUP` analyzer unnecessarily and improve performance.