### PR TITLE
chore(deps-dev): add test-docker dependencies to pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ upgrade-go:
 setup-github-actions:
 	python -m pip install --upgrade pip
 	python -m pip install --upgrade wheel
-	python -m pip install --upgrade --upgrade-strategy eager --editable .[actions]
+	python -m pip install --upgrade --upgrade-strategy eager .[actions]
 
 # Install dependencies for the integration test utility script in workflow to
 # test the docker image.
@@ -211,7 +211,7 @@ setup-github-actions:
 setup-integration-test-utility-for-docker:
 	python -m pip install --upgrade pip
 	python -m pip install --upgrade wheel
-	python -m pip install --upgrade --upgrade-strategy eager --editable .[test-docker]
+	python -m pip install --upgrade --upgrade-strategy eager .[test-docker]
 
 # Generate a Software Bill of Materials (SBOM).
 .PHONY: sbom

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ upgrade: .venv/upgraded-on
 .venv/upgraded-on: pyproject.toml
 	python -m pip install --upgrade pip
 	python -m pip install --upgrade wheel
-	python -m pip install --upgrade --upgrade-strategy eager --editable .[actions,dev,docs,hooks,test]
+	python -m pip install --upgrade --upgrade-strategy eager --editable .[actions,dev,docs,hooks,test,test-docker]
 	$(MAKE) upgrade-quiet
 force-upgrade:
 	rm -f .venv/upgraded-on
@@ -209,7 +209,9 @@ setup-github-actions:
 # test the docker image.
 .PHONY: setup-integration-test-utility-for-docker
 setup-integration-test-utility-for-docker:
-	python -m pip install ruamel.yaml cfgv
+	python -m pip install --upgrade pip
+	python -m pip install --upgrade wheel
+	python -m pip install --upgrade --upgrade-strategy eager --editable .[test-docker]
 
 # Generate a Software Bill of Materials (SBOM).
 .PHONY: sbom

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ test = [
     "syrupy >=4.0.0,<5.0.0",
 ]
 
+test-docker = [
+    "cfgv >=3.4.0,<4.0.0",
+    "ruamel.yaml >=0.18.6,<1.0.0",
+]
+
 [project.urls]
 Homepage = "https://my.project/"
 Changelog = "https://my.project/CHANGELOG"


### PR DESCRIPTION
`cfgv` and `ruamel.yaml`, which are needed for Docker integration tests were missing from the `pyproject.toml`. because the GitHub Action job that runs the docker tests only needs these deps and not the rest, to improve CI runtime I have added a new `test-docker` set of optional dependencies which will by default be installed by the `setup` target in the `Makefile`.