### PR TITLE
docs: exclude hyphenated attributes in sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,11 +61,29 @@ html_theme_options = {
 }
 html_static_path = ["_static"]
 
+# These objects must be excluded due to their use of hyphens.
+# E.g. invalid signature for autoattribute ('macaron.parsers.github_workflow_model::Step5.working-directory')
+hyphenated_exclusion_list = [
+    "<class 'macaron.parsers.github_workflow_model.Strategy'>",
+    "<class 'macaron.parsers.github_workflow_model.Concurrency'>",
+    "<class 'macaron.parsers.github_workflow_model.Run'>",
+    "<class 'macaron.parsers.github_workflow_model.PermissionsEvent'>",
+    "<class 'macaron.parsers.github_workflow_model.Ref1'>",
+    "<class 'macaron.parsers.github_workflow_model.Step3'>",
+    "<class 'macaron.parsers.github_workflow_model.Step4'>",
+    "<class 'macaron.parsers.github_workflow_model.Step5'>",
+    "<class 'macaron.parsers.github_workflow_model.NormalJob'>",
+    "<class 'macaron.parsers.github_workflow_model.Workflow'>",
+]
+
 
 # We add the docstrings for class constructors in the `__init__` methods.
 def skip(app, what, name, obj, would_skip, options):
     if name == "__init__":
         return False
+    obj_str = str(obj)
+    if obj_str in hyphenated_exclusion_list:
+        return True
     return would_skip
 
 

--- a/docs/source/pages/developers_guide/apidoc/macaron.parsers.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.parsers.rst
@@ -32,3 +32,11 @@ macaron.parsers.bashparser module
    :members:
    :undoc-members:
    :show-inheritance:
+
+macaron.parsers.github\_workflow\_model module
+----------------------------------------------
+
+.. automodule:: macaron.parsers.github_workflow_model
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.checks.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.checks.rst
@@ -105,6 +105,14 @@ macaron.slsa\_analyzer.checks.provenance\_repo\_check module
    :undoc-members:
    :show-inheritance:
 
+macaron.slsa\_analyzer.checks.provenance\_verified\_check module
+----------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.checks.provenance_verified_check
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.slsa\_analyzer.checks.provenance\_witness\_l1\_check module
 -------------------------------------------------------------------
 


### PR DESCRIPTION
This excludes hyphenated attributes for the `make docs` command preventing Sphinx errors relating to them.
E.g.

> invalid signature for autoattribute ('macaron.parsers.github_workflow_model::Step5.working-directory')

These attributes are valid, only not accepted by Sphinx.