### PR TITLE
feat!: allow specifying the dependency depth resolution through CLI and make dependency resolution off by default

### DIFF
--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -35,7 +35,7 @@ Options
 
 .. option:: -sbom SBOM_PATH, --sbom-path SBOM_PATH
 
-    The path to the SBOM of the analysis target. If this is set, dependency resolution must be enabled with '--deps-depth'.
+    The path to the SBOM of the analysis target.
 
 .. option:: -purl PACKAGE_URL, --package-url PACKAGE_URL
 
@@ -77,7 +77,7 @@ Options
 
 .. option::  --python-venv PYTHON_VENV
 
-    The path to the Python virtual environment of the target software component. If this is set, dependency resolution must be enabled with '--deps-depth'.
+    The path to the Python virtual environment of the target software component.
 
 -----------
 Environment

--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -22,7 +22,8 @@ Usage
     usage: ./run_macaron.sh analyze
         [-h] [-sbom SBOM_PATH] [-purl PURL] [-rp REPO_PATH] [-b BRANCH]
         [-d DIGEST] [-pe PROVENANCE_EXPECTATION]
-        [--skip-deps] [-g TEMPLATE_PATH]
+        [--skip-deps] [--deps-depth DEPS_DEPTH] [-g TEMPLATE_PATH]
+        [--python-venv PYTHON_VENV]
 
 -------
 Options
@@ -34,7 +35,7 @@ Options
 
 .. option:: -sbom SBOM_PATH, --sbom-path SBOM_PATH
 
-    The path to the SBOM of the analysis target.
+    The path to the SBOM of the analysis target. If this is set, dependency resolution must be enabled with '--deps-depth'.
 
 .. option:: -purl PACKAGE_URL, --package-url PACKAGE_URL
 
@@ -64,11 +65,19 @@ Options
 
 .. option:: --skip-deps
 
-    Skip automatic dependency analysis.
+    DEPRECATED. Dependency resolution is off by default. This flag does nothing and will be removed in the next release.
+
+.. option:: --deps-depth DEPS_DEPTH
+
+    The depth of the dependency resolution. 0: disable, 1: direct dependencies, inf: all transitive dependencies. (Default: 0)
 
 .. option:: -g TEMPLATE_PATH, --template-path TEMPLATE_PATH
 
     The path to the Jinja2 html template (please make sure to use .html or .j2 extensions).
+
+.. option::  --python-venv PYTHON_VENV
+
+    The path to the Python virtual environment of the target software component.If this is set, dependency resolution must be enabled with '--deps-depth'.
 
 -----------
 Environment

--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -77,7 +77,7 @@ Options
 
 .. option::  --python-venv PYTHON_VENV
 
-    The path to the Python virtual environment of the target software component.If this is set, dependency resolution must be enabled with '--deps-depth'.
+    The path to the Python virtual environment of the target software component. If this is set, dependency resolution must be enabled with '--deps-depth'.
 
 -----------
 Environment

--- a/docs/source/pages/supported_technologies/index.rst
+++ b/docs/source/pages/supported_technologies/index.rst
@@ -107,6 +107,17 @@ Provenances
        * The provenance should be published on JFrog Artifactory
      - :doc:`page </pages/supported_technologies/jfrog>`
 
+.. _supported_automatic_deps_resolution:
+
+-------------------------------
+Automatic dependency resolution
+-------------------------------
+
+Currently, we support the following type of project for automatic dependency resolution.
+
+* Java Maven
+* Java gradle
+
 --------
 See also
 --------

--- a/docs/source/pages/supported_technologies/index.rst
+++ b/docs/source/pages/supported_technologies/index.rst
@@ -116,7 +116,7 @@ Automatic dependency resolution
 Currently, we support the following type of project for automatic dependency resolution.
 
 * Java Maven
-* Java gradle
+* Java Gradle
 
 --------
 See also

--- a/docs/source/pages/supported_technologies/index.rst
+++ b/docs/source/pages/supported_technologies/index.rst
@@ -117,6 +117,7 @@ Currently, we support the following type of project for automatic dependency res
 
 * Java Maven
 * Java Gradle
+* Python (with a Python virtual environment created and packages installed using Python3.11, see :ref:`providing Python virtual environment <python-venv-deps>`.)
 
 --------
 See also

--- a/docs/source/pages/tutorials/commit_finder.rst
+++ b/docs/source/pages/tutorials/commit_finder.rst
@@ -50,7 +50,7 @@ To perform an analysis on Arrow, Macaron can be run with the following command:
 
 .. code-block:: shell
 
-    ./run_macaron.sh analyze -rp https://github.com/arrow-py/arrow --skip-deps
+    ./run_macaron.sh analyze -rp https://github.com/arrow-py/arrow
 
 However, this will return results based only on the current state of the repository, which as described above, is not what we want to achieve in this tutorial. To perform analyses on other repository states, we need to provide Macaron with the target artifact versions in the form of `PURLs <https://github.com/package-url/purl-spec>`_, or Package URLs, which is a convenient way to encode packages from different ecosystems into the same format.
 
@@ -67,7 +67,7 @@ We will start by running the analysis on the latest version, ``1.3.0``, with the
 
 .. code-block:: shell
 
-    ./run_macaron.sh analyze -purl pkg:pypi/arrow@1.3.0 --skip-deps
+    ./run_macaron.sh analyze -purl pkg:pypi/arrow@1.3.0
 
 The analysis involves Macaron downloading the contents of the target repository to the configured, or default, ``output`` folder. Results from the analysis, including checks, are stored in the database found at ``output/macaron.db``  (See :ref:`Output Files Guide <output_files_guide>`). Once the analysis is complete, Macaron will also produce a report in the form of a HTML file.
 
@@ -101,7 +101,7 @@ Now we should run the next analysis, and then open the new report.
 
 .. code-block:: shell
 
-    ./run_macaron.sh analyze -purl pkg:pypi/arrow@0.15.0 --skip-deps
+    ./run_macaron.sh analyze -purl pkg:pypi/arrow@0.15.0
     open output/reports/pypi/arrow/arrow.html
 
 .. _fig_arrow_0.15.0_top:

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -172,27 +172,17 @@ Let's assume ``/tmp/.django_venv`` is the virtual environment where ``django@5.0
 
 .. note:: If you want Macaron to analyze the virtual environment directly to identify the dependencies, we require Python 3.11 to be used to install the package. Alternatively, you can generate the SBOM as instructed :ref:`here <python-sbom>` and pass it to Macaron as input.
 
-Run Macaron as follows to analyze ``django`` and its dependencies.
+Run Macaron as follows to analyze ``django`` and its direct dependencies.
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv"
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --deps-depth=1
 
-
-By default Macaron only checks the direct dependencies. To turn on recursive dependency analysis, add the following to the ``configurations.ini`` file:
-
-.. code-block:: ini
-
-  [dependency.resolver]
-  recursive = True
-
-And pass that to the ``analyze`` command:
+Or alternatively, run Macaron as follows to analyze ``django`` and all its transitive dependencies.
 
 .. code-block:: shell
 
-  ./run_macaron.sh --defaults-path configurations.ini analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv"
-
-To learn more about changing configurations see :ref:`here <change-config>`.
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --deps-depth=inf
 
 Now we can enforce the policy below to ensure that the ``mcn_detect_malicious_metadata_1`` check always passes on ``django`` and its dependencies, indicating that none of the dependencies have malicious behavior.
 

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -65,7 +65,7 @@ First, we need to run the ``analyze`` command of Macaron to run a number of :ref
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --skip-deps
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6
 
 .. note:: By default, Macaron clones the repositories and creates output files under the ``output`` directory. To understand the structure of this directory please see :ref:`Output Files Guide <output_files_guide>`.
 

--- a/docs/source/pages/tutorials/exclude_include_checks.rst
+++ b/docs/source/pages/tutorials/exclude_include_checks.rst
@@ -37,7 +37,7 @@ Normally, this is how you would run Macaron:
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze --package-url pkg:maven/io.micronaut/micronaut-core@4.3.10 --skip-deps
+  ./run_macaron.sh analyze --package-url pkg:maven/io.micronaut/micronaut-core@4.3.10
 
 However, there can be checks in Macaron that are not relevant for the ``io.micronaut/micronaut-core`` artifact.
 For example, the ``mcn_provenance_witness_level_one_1`` check (defined in :class:`ProvenanceWitnessL1Check <macaron.slsa_analyzer.checks.provenance_witness_l1_check.ProvenanceWitnessL1Check>`) is not relevant because ``micronaut-projects/micronaut-core`` generates and publishes :term:`SLSA` provenances and no :term:`Witness` provenances. Therefore, we could exclude this check from running by performing the following steps.
@@ -61,7 +61,7 @@ With these two configuration options, all checks except for the excluded ``mcn_p
 
 .. code-block:: shell
 
-  ./run_macaron.sh --defaults-path ./defaults.ini analyze --package-url pkg:maven/io.micronaut/micronaut-core@4.3.10 --skip-deps
+  ./run_macaron.sh --defaults-path ./defaults.ini analyze --package-url pkg:maven/io.micronaut/micronaut-core@4.3.10
 
 This time, the check ``mcn_provenance_witness_level_one_1`` doesn't run. After the ``analyze`` command finishes, we can view the data that Macaron has gathered about the ``micronaut-projects/micronaut-core`` repository at ``v4.3.10`` in an HTML report. Note that the result of the excluded check is not recorded in the Macaron HTML reports, JSON reports, or the database).
 

--- a/docs/source/pages/tutorials/generate_verification_summary_attestation.rst
+++ b/docs/source/pages/tutorials/generate_verification_summary_attestation.rst
@@ -47,8 +47,7 @@ In order to verify the artifact with Macaron, you can follow the following steps
   ./run_macaron.sh analyze \
         --package-url pkg:maven/io.micronaut.openapi/micronaut-openapi@6.8.0?type=jar \
         --provenance-file multiple.intoto.jsonl \
-        --provenance-expectation expectation.cue \
-        --skip-deps
+        --provenance-expectation expectation.cue
 
 .. note::
 

--- a/docs/source/pages/tutorials/npm_provenance.rst
+++ b/docs/source/pages/tutorials/npm_provenance.rst
@@ -42,7 +42,7 @@ To perform an analysis on the latest version of semver (when this tutorial was w
 
 .. code-block:: shell
 
-    ./run_macaron.sh analyze -purl pkg:npm/semver@7.6.2 --skip-deps
+    ./run_macaron.sh analyze -purl pkg:npm/semver@7.6.2
 
 The analysis involves Macaron downloading the contents of the target repository to the configured, or default, ``output`` folder. Results from the analysis, including checks, are stored in the database found at ``output/macaron.db``  (See :ref:`Output Files Guide <output_files_guide>`). Once the analysis is complete, Macaron will also produce a report in the form of a HTML file.
 

--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -303,7 +303,7 @@ To run the analysis against that SBOM, run this command:
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:maven/org.apache.maven/maven@3.9.7?type=pom -sbom <path_to_sbom> --deps-depth=1
+  ./run_macaron.sh analyze -purl pkg:maven/org.apache.maven/maven@3.9.7?type=pom -sbom <path_to_sbom> --deps-depth=inf
 
 Where ``path_to_sbom`` is the path to the SBOM you want to use.
 
@@ -327,7 +327,7 @@ Then run Macaron and pass the SBOM file as input:
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 -sbom <path_to_django_sbom.json> --deps-depth=1
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 -sbom <path_to_django_sbom.json> --deps-depth=inf
 
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 Analyzing dependencies in the SBOM without the main software component
@@ -342,7 +342,7 @@ Then the analysis can be run as follows:
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:maven/private.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom -sbom <path_to_sbom> --deps-depth=1
+  ./run_macaron.sh analyze -purl pkg:maven/private.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom -sbom <path_to_sbom> --deps-depth=inf
 
 Where ``path_to_sbom`` is the path to the SBOM you want to use.
 

--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -236,7 +236,7 @@ workflows.
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -pe micronaut-core.cue -rp https://github.com/micronaut-projects/micronaut-core -b 4.0.x -d 82d115b4901d10226552ac67b0a10978cd5bc603 --skip-deps
+  ./run_macaron.sh analyze -pe micronaut-core.cue -rp https://github.com/micronaut-projects/micronaut-core -b 4.0.x -d 82d115b4901d10226552ac67b0a10978cd5bc603
 
 where ``micronaut-core.cue`` file can contain:
 
@@ -420,7 +420,7 @@ We can run Macaron against the local repository at ``target`` by using this comm
 
   ./run_macaron.sh --local-repos-path ./boo/foo --defaults-path ./defaults.ini analyze --repo-path target <rest_of_args>
 
-With ``rest_of_args`` being the arguments to the ``analyze`` command (e.g. ``--branch/-b``, ``--digest/-d`` or ``--skip-deps`` similar to two previous examples).
+With ``rest_of_args`` being the arguments to the ``analyze`` command (e.g. ``--branch/-b``, ``--digest/-d`` similar to two previous examples).
 
 The ``--local-repos-path/-lr`` flag tells Macaron to look into ``./boo/foo`` for local repositories. For more information, please see :ref:`Command Line Usage <cli-usage>`.
 
@@ -446,7 +446,7 @@ We can run Macaron against the local repository at ``target`` by using this comm
 
   ./run_macaron.sh --local-repos-path ./boo/foo analyze --repo-path target <rest_of_args>
 
-With ``rest_of_args`` being the arguments to the ``analyze`` command (e.g. ``--branch/-b``, ``--digest/-d`` or ``--skip-deps`` similar to two previous examples).
+With ``rest_of_args`` being the arguments to the ``analyze`` command (e.g. ``--branch/-b``, ``--digest/-d`` similar to two previous examples).
 
 The ``--local-repos-path/-lr`` flag tells Macaron to look into ``./boo/foo`` for local repositories. For more information, please see :ref:`Command Line Usage <cli-usage>`.
 

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -45,14 +45,6 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
         logger.error("Please provide '1', '0' or 'inf' to `--deps-depth`")
         sys.exit(os.EX_USAGE)
 
-    if analyzer_single_args.sbom_path and deps_depth == 0:
-        logger.error("Please enable dependency resolution with '--deps-depth' when providing an SBOM.")
-        sys.exit(os.EX_USAGE)
-
-    if analyzer_single_args.python_venv and deps_depth == 0:
-        logger.error("Please enable dependency resolution with '--deps-depth' when providing a Python environment.")
-        sys.exit(os.EX_USAGE)
-
     if not (analyzer_single_args.repo_path or analyzer_single_args.package_url):
         # We don't mention --config-path as a possible option in this log message as it going to be move soon.
         # See: https://github.com/oracle/macaron/issues/417

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -155,7 +155,7 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
     if analyzer_single_args.skip_deps:
         logger.warning(
             "The --skip-deps flag has been deprecated and WILL NOT do anything. "
-            + "Dependency resolution is off by default. This flag will be removed soon."
+            + "Dependency resolution is off by default. This flag does nothing and will be removed in the next release."
         )
 
     status_code = analyzer.run(

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -31,7 +31,31 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None:
     """Run the SLSA checks against a single target repository."""
+    deps_depth = None
+    if analyzer_single_args.deps_depth == "inf":
+        deps_depth = -1
+    else:
+        try:
+            deps_depth = int(analyzer_single_args.deps_depth)
+        except ValueError:
+            logger.error("Please provide '1', '0' or 'inf' to `--deps-depth`")
+            sys.exit(os.EX_USAGE)
+
+    if deps_depth not in [-1, 0, 1]:
+        logger.error("Please provide '1', '0' or 'inf' to `--deps-depth`")
+        sys.exit(os.EX_USAGE)
+
+    if analyzer_single_args.sbom_path and deps_depth == 0:
+        logger.error("Please enable dependency resolution with '--deps-depth' when providing an SBOM.")
+        sys.exit(os.EX_USAGE)
+
+    if analyzer_single_args.python_venv and deps_depth == 0:
+        logger.error("Please enable dependency resolution with '--deps-depth' when providing a Python environment.")
+        sys.exit(os.EX_USAGE)
+
     if not (analyzer_single_args.repo_path or analyzer_single_args.package_url):
+        # We don't mention --config-path as a possible option in this log message as it going to be move soon.
+        # See: https://github.com/oracle/macaron/issues/417
         logger.error(
             """Analysis target missing. Please provide a package url (PURL) and/or repo path.
             Examples of a PURL can be seen at https://github.com/package-url/purl-spec:
@@ -128,10 +152,16 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
             logger.error("Error while loading the input provenance file: %s", error)
             sys.exit(os.EX_DATAERR)
 
+    if analyzer_single_args.skip_deps:
+        logger.warning(
+            "The --skip-deps flag has been deprecated and WILL NOT do anything. "
+            + "Dependency resolution is off by default. This flag will be removed soon."
+        )
+
     status_code = analyzer.run(
         run_config,
         analyzer_single_args.sbom_path,
-        analyzer_single_args.skip_deps,
+        deps_depth,
         provenance_payload=prov_payload,
     )
     sys.exit(status_code)
@@ -312,7 +342,10 @@ def main(argv: list[str] | None = None) -> None:
         required=False,
         type=str,
         default="",
-        help=("The path to the SBOM of the analysis target."),
+        help=(
+            "The path to the SBOM of the analysis target. If this is set, "
+            + "dependency resolution must be enabled with '--deps-depth'."
+        ),
     )
 
     single_analyze_parser.add_argument(
@@ -375,7 +408,19 @@ def main(argv: list[str] | None = None) -> None:
         required=False,
         action="store_true",
         default=False,
-        help=("Skip automatic dependency analysis."),
+        help=(
+            "DEPRECATED. Dependency resolution is off by default. This flag does nothing and will be removed in the next release."
+        ),
+    )
+
+    single_analyze_parser.add_argument(
+        "--deps-depth",
+        required=False,
+        default="0",
+        help=(
+            "The depth of the dependency resolution. 0: disable, 1: direct dependencies, "
+            + "inf: all transitive dependencies. (Default: 0)"
+        ),
     )
 
     single_analyze_parser.add_argument(
@@ -390,7 +435,10 @@ def main(argv: list[str] | None = None) -> None:
     single_analyze_parser.add_argument(
         "--python-venv",
         required=False,
-        help=("The path to the Python virtual environment of the target software component."),
+        help=(
+            "The path to the Python virtual environment of the target software component. "
+            + "If this is set, dependency resolution must be enabled with '--deps-depth'."
+        ),
     )
 
     # Dump the default values.

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -39,7 +39,6 @@ dep_tool_maven = cyclonedx-maven:2.6.2
 dep_tool_gradle = cyclonedx-gradle:1.7.4
 # This is the timeout (in seconds) to run the dependency resolver.
 timeout = 2400
-recursive = False
 # Determines whether the CycloneDX BOM file should be validated or not.
 validate = True
 # The CycloneDX schema version used for validation.

--- a/src/macaron/dependency_analyzer/cyclonedx.py
+++ b/src/macaron/dependency_analyzer/cyclonedx.py
@@ -568,7 +568,7 @@ class DependencyAnalyzer(ABC):
         child_bom_paths: list[Path] | None
             The list of paths to sub-project bom.json files.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Yields
         ------
@@ -724,7 +724,7 @@ class DependencyAnalyzer(ABC):
         target_component: Component
             The analyzed target software component.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------

--- a/src/macaron/dependency_analyzer/cyclonedx.py
+++ b/src/macaron/dependency_analyzer/cyclonedx.py
@@ -149,7 +149,7 @@ class DependencyAnalyzer(ABC):
         target_component: Component
             The analyzed target software component.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------
@@ -339,10 +339,10 @@ class DependencyAnalyzer(ABC):
         ----------
         main_ctx : Any (AnalyzeContext)
             The context of object of the target repository.
-        recursive : bool
-            If True, perform transitive dependency resolution. Default: False.
         sbom_path : str
             The path to the SBOM.
+        recursive : bool
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------
@@ -758,7 +758,7 @@ class NoneDependencyAnalyzer(DependencyAnalyzer):
         target_component: Component
             The analyzed target software component.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------

--- a/src/macaron/dependency_analyzer/cyclonedx_gradle.py
+++ b/src/macaron/dependency_analyzer/cyclonedx_gradle.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from cyclonedx.model.component import Component as CDXComponent
 from packageurl import PackageURL
 
-from macaron.config.defaults import defaults
 from macaron.database.table_definitions import Component
 from macaron.dependency_analyzer.cyclonedx import DependencyAnalyzer, DependencyInfo
 
@@ -47,7 +46,12 @@ class CycloneDxGradle(DependencyAnalyzer):
             "cyclonedxBom",
         ]
 
-    def collect_dependencies(self, dir_path: str, target_component: Component) -> dict[str, DependencyInfo]:
+    def collect_dependencies(
+        self,
+        dir_path: str,
+        target_component: Component,
+        recursive: bool = False,
+    ) -> dict[str, DependencyInfo]:
         """Process the dependency JSON files and collect direct dependencies.
 
         Parameters
@@ -56,6 +60,8 @@ class CycloneDxGradle(DependencyAnalyzer):
             Local path to the target repo.
         target_component: Component
             The analyzed target software component.
+        recursive: bool
+            Set to False to get the direct dependencies only (default).
 
         Returns
         -------
@@ -82,11 +88,7 @@ class CycloneDxGradle(DependencyAnalyzer):
             target_component,
             top_path,
             child_paths,
-            recursive=defaults.getboolean(
-                "dependency.resolver",
-                "recursive",
-                fallback=False,
-            ),
+            recursive=recursive,
         )
         return self.convert_components_to_artifacts(components, root_component)
 

--- a/src/macaron/dependency_analyzer/cyclonedx_gradle.py
+++ b/src/macaron/dependency_analyzer/cyclonedx_gradle.py
@@ -61,7 +61,7 @@ class CycloneDxGradle(DependencyAnalyzer):
         target_component: Component
             The analyzed target software component.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------

--- a/src/macaron/dependency_analyzer/cyclonedx_mvn.py
+++ b/src/macaron/dependency_analyzer/cyclonedx_mvn.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from cyclonedx.model.component import Component as CDXComponent
 from packageurl import PackageURL
 
-from macaron.config.defaults import defaults
 from macaron.database.table_definitions import Component
 from macaron.dependency_analyzer.cyclonedx import DependencyAnalyzer, DependencyInfo
 
@@ -47,7 +46,12 @@ class CycloneDxMaven(DependencyAnalyzer):
             "includeTestScope=true",
         ]
 
-    def collect_dependencies(self, dir_path: str, target_component: Component) -> dict[str, DependencyInfo]:
+    def collect_dependencies(
+        self,
+        dir_path: str,
+        target_component: Component,
+        recursive: bool = False,
+    ) -> dict[str, DependencyInfo]:
         """Process the dependency JSON files and collect direct dependencies.
 
         We allow the dependency JSON files to be accepted as long as there is only one JSON file in the target
@@ -63,6 +67,8 @@ class CycloneDxMaven(DependencyAnalyzer):
             Local path to the target repo.
         target_component: Component
             The analyzed target software component.
+        recursive: bool
+            Set to False to get the direct dependencies only (default).
 
         Returns
         -------
@@ -111,11 +117,7 @@ class CycloneDxMaven(DependencyAnalyzer):
             target_component,
             top_path,
             child_paths,
-            recursive=defaults.getboolean(
-                "dependency.resolver",
-                "recursive",
-                fallback=False,
-            ),
+            recursive=recursive,
         )
         return self.convert_components_to_artifacts(components, root_component)
 

--- a/src/macaron/dependency_analyzer/cyclonedx_mvn.py
+++ b/src/macaron/dependency_analyzer/cyclonedx_mvn.py
@@ -68,7 +68,7 @@ class CycloneDxMaven(DependencyAnalyzer):
         target_component: Component
             The analyzed target software component.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------

--- a/src/macaron/dependency_analyzer/cyclonedx_python.py
+++ b/src/macaron/dependency_analyzer/cyclonedx_python.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from cyclonedx.model.component import Component as CDXComponent
 from packageurl import PackageURL
 
-from macaron.config.defaults import defaults
 from macaron.config.global_config import global_config
 from macaron.database.table_definitions import Component
 from macaron.dependency_analyzer.cyclonedx import DependencyAnalyzer, DependencyInfo
@@ -50,7 +49,12 @@ class CycloneDxPython(DependencyAnalyzer):
             os.path.join(global_config.output_path, self.file_name),
         ]
 
-    def collect_dependencies(self, dir_path: str, target_component: Component) -> dict[str, DependencyInfo]:
+    def collect_dependencies(
+        self,
+        dir_path: str,
+        target_component: Component,
+        recursive: bool = False,
+    ) -> dict[str, DependencyInfo]:
         """Process the dependency JSON files and collect dependencies.
 
         Parameters
@@ -59,6 +63,8 @@ class CycloneDxPython(DependencyAnalyzer):
             Local path to the target repo.
         target_component: Component
             The analyzed target software component.
+        recursive: bool
+            Set to False to get the direct dependencies only (default).
 
         Returns
         -------
@@ -69,11 +75,7 @@ class CycloneDxPython(DependencyAnalyzer):
             self.get_dep_components(
                 target_component=target_component,
                 root_bom_path=Path(global_config.output_path, self.file_name),
-                recursive=defaults.getboolean(
-                    "dependency.resolver",
-                    "recursive",
-                    fallback=False,
-                ),
+                recursive=recursive,
             )
         )
 

--- a/src/macaron/dependency_analyzer/cyclonedx_python.py
+++ b/src/macaron/dependency_analyzer/cyclonedx_python.py
@@ -64,7 +64,7 @@ class CycloneDxPython(DependencyAnalyzer):
         target_component: Component
             The analyzed target software component.
         recursive: bool
-            Set to False to get the direct dependencies only (default).
+            Whether to get all transitive dependencies, otherwise only the direct dependencies will be returned (default: False).
 
         Returns
         -------

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -61,7 +61,6 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 - name: Compare analysis report
   kind: compare
   options:

--- a/tests/integration/cases/all_checks_excluded/test.yaml
+++ b/tests/integration/cases/all_checks_excluded/test.yaml
@@ -15,5 +15,4 @@ steps:
     command_args:
     - -rp
     - https://github.com/apache/maven
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/apache_maven_analyzing_a_clone_from_another_local_repo/test.yaml
+++ b/tests/integration/cases/apache_maven_analyzing_a_clone_from_another_local_repo/test.yaml
@@ -34,7 +34,6 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 # We don't compare the report content because the remote_path fields in the reports are nondeterministic when running
 # this test locally and running it in the GitHub Actions runner. We only check if the reports are generated as
 # expected without the issue described in https://github.com/oracle/macaron/issues/116.

--- a/tests/integration/cases/apache_maven_cyclonedx_sbom_tutorial/test.yaml
+++ b/tests/integration/cases/apache_maven_cyclonedx_sbom_tutorial/test.yaml
@@ -15,6 +15,7 @@ steps:
     command_args:
     - -purl
     - pkg:maven/org.apache.maven/maven@3.9.7?type=pom
+    - --deps-depth=1
     sbom: sbom.json
 - name: Compare dependencies report.
   kind: compare

--- a/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/test.yaml
+++ b/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/test.yaml
@@ -27,6 +27,7 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
+    - --deps-depth=1
 - name: Compare deps report
   kind: compare
   options:

--- a/tests/integration/cases/apache_maven_local_paths_without_dep_resolution/test.yaml
+++ b/tests/integration/cases/apache_maven_local_paths_without_dep_resolution/test.yaml
@@ -31,7 +31,6 @@ steps:
     - apache/maven
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 - name: Run macaron analyze on google/guava
   kind: analyze
   options:
@@ -43,7 +42,6 @@ steps:
     - google/guava
     - -d
     - d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4
-    - --skip-deps
 - name: Run macaron analyze on mockito/mockito
   kind: analyze
   options:
@@ -55,7 +53,6 @@ steps:
     - mockito/mockito
     - -d
     - 512ee3949484e4765038a0410cd7a7f1b73cc655
-    - --skip-deps
 - name: Run verify-policy for apache/maven
   kind: verify
   options:

--- a/tests/integration/cases/apache_maven_local_repo/test.yaml
+++ b/tests/integration/cases/apache_maven_local_repo/test.yaml
@@ -30,7 +30,6 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/apache_maven_purl_repo_path/test.yaml
+++ b/tests/integration/cases/apache_maven_purl_repo_path/test.yaml
@@ -20,7 +20,6 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 # This to check if run_macaron.sh cleans up the token file after the test case runs for the docker image.
 - name: Check the token file doesn't exist.
   kind: shell

--- a/tests/integration/cases/apache_maven_repo_path_branch_digest_with_deps_cyclonedx_maven/test.yaml
+++ b/tests/integration/cases/apache_maven_repo_path_branch_digest_with_deps_cyclonedx_maven/test.yaml
@@ -20,6 +20,7 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
+    - --deps-depth=1
 - name: Compare deps report
   kind: compare
   options:

--- a/tests/integration/cases/apache_maven_sbom/test.yaml
+++ b/tests/integration/cases/apache_maven_sbom/test.yaml
@@ -21,6 +21,7 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
+    - --deps-depth=1
     sbom: sbom.json
 - name: Compare dependency report
   kind: compare

--- a/tests/integration/cases/apache_maven_sbom_no_repo_tutorial/test.yaml
+++ b/tests/integration/cases/apache_maven_sbom_no_repo_tutorial/test.yaml
@@ -15,6 +15,7 @@ steps:
     command_args:
     - -purl
     - pkg:maven/private.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom
+    - --deps-depth=1
     sbom: sbom.json
 - name: Compare dependencies report.
   kind: compare

--- a/tests/integration/cases/apache_maven_sbom_with_no_deps_resolution/sbom.json
+++ b/tests/integration/cases/apache_maven_sbom_with_no_deps_resolution/sbom.json
@@ -1,0 +1,5170 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "serialNumber": "urn:uuid:152fe56d-7c2a-496e-9ee6-0a6c9c7ea639",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-03-22T06:01:31Z",
+        "tools": [
+            {
+                "vendor": "OWASP Foundation",
+                "name": "CycloneDX Maven plugin",
+                "version": "2.6.2",
+                "hashes": [
+                    {
+                        "alg": "MD5",
+                        "content": "ff29fc50797fce0b33058a6b2b283f64"
+                    },
+                    {
+                        "alg": "SHA-1",
+                        "content": "597e59ebf21c3b8bfb1faeb622569df324eca956"
+                    },
+                    {
+                        "alg": "SHA-256",
+                        "content": "3cf9130fcac45a7beb6df2ae9c3fc9c062d1fddd0731d6a302968586f0aa586e"
+                    },
+                    {
+                        "alg": "SHA-384",
+                        "content": "8111a6788c959305af23daecbc79defd4478c1e274cba65bfe860e09b30cd9fe29822d5d3d3eea608e4926a9418f92e3"
+                    },
+                    {
+                        "alg": "SHA-512",
+                        "content": "2bea87b7bcd70897bf46a28a806b6064a6708d0a45e884e1ceddc25f97ca7bdf4ed190f30d9a28cc9416b6c66176d518c5876fd25bc06bdcb00d39367215e56e"
+                    },
+                    {
+                        "alg": "SHA3-256",
+                        "content": "f0f7b771749955e7898665c2fff8f4f2cd734d9cbe4d29883292db772f1be00e"
+                    },
+                    {
+                        "alg": "SHA3-384",
+                        "content": "a87d4c18bac4d48a46c0b8611ab92934e457fcd55bd4d39dbc9c4e5044d2736d3bda991c43d67b0987eddcf4c88510ff"
+                    },
+                    {
+                        "alg": "SHA3-512",
+                        "content": "90c38f168600787fc90b7e37e743b386b7296bceb10152190de6e30e0f251da3e01698d1b1e11ad84f207532b5a0743aac105f3c5006ff4607d21f30c9ea779f"
+                    }
+                ]
+            }
+        ],
+        "component": {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven",
+            "name": "maven",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "description": "Maven is a software build management and comprehension tool. Based on the concept of a project object model: builds, dependency management, documentation creation, site publication, and distribution publication are all controlled from the declarative file. Maven can be extended by plugins to utilise a number of other development tools for reporting or the build process.",
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://maven.apache.org/download.html"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MNG"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/apache/maven/tree/master"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom"
+        }
+    },
+    "components": [
+        {
+            "group": "org.apache.maven",
+            "name": "maven-bom",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-bom@4.0.0-alpha-1-SNAPSHOT?type=pom",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-bom@4.0.0-alpha-1-SNAPSHOT?type=pom"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-engine",
+            "version": "5.8.1",
+            "description": "Module \"junit-jupiter-engine\" of JUnit 5.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "fbb6af3cb86924d566a4aa96df6059de"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "21b86e08aae2720bbf017703669948be96d1388c"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "4689bc902255a19fe98277683ba3231c094d107c54c8d35f2b6f9c97d226418e"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "7c5ba8e05d94eb03b5877aad7b14dad3cc316165fd18e37021a4ab589844cd9598915af77a19be043b85701f0c63b150"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "e98d1b5fa352bef630c07fdb42da582633b9fc092cbe7ab273da3dd7b33c812f61c31882afcdafd8ceb917f272b136065d92a4b2f545d01bfa4396809ee3aecd"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "5d203b3bb55a8681428cee0a20589f208dab5547f55cd27f39e66b9aca20c3e8"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "fa843d9a263915176267c5e877cbfcf52eac7310118b70a3e4054b9a107ada81c263c7f6ba71b294d3379c94249299b8"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "9853519e0050fa0335925c05ecbdba472f5c1704c717ac0bf651907d80044202c62cd139b4158cd1e58818b0d561f8b1a933d1c3b2c8d2f9e56dd258d7b41d01"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "Eclipse Public License v2.0",
+                        "url": "https://www.eclipse.org/legal/epl-v20.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/junit-team/junit5"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-engine",
+            "version": "1.8.1",
+            "description": "Module \"junit-platform-engine\" of JUnit 5.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "73659fbb057bda54e14825c08661e98b"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "e6c63bf990dc88a6527b4ed617b23e47048f07e0"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "702868ed7e86b9b4672ede0f1e185e905baca9afab57746a7c650be3c7bca047"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "f1d7d11b618518b48cf74fee4a530546f3a2b1a6526ba9afdd17cb942960168eea5e2c978c34571ff44426f8b86b6a5a"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "840d67896a10a70de95eaf3e0bbd267f30d2ffed19672162bdc8c62deaf8d25731ccb8b33dae46b746e90e7e93c99f95923ba64a18ea61bfdee4abe6353d6a9a"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "91ee8b391f699515fc13443b50d7435fc3ab5e204c4714de52dc440835754606"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "f61eefa8a0e4aa32fe870a507e40afdfc491f9397629fdbf514fdaa76789f562bf65aaaf380984d784970e846e74b1b0"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "2c7f9d85a4764a46d206734a4be3bc2f962a4791a7ab3b1833c57f01d29fb322cd2e6f82158a32cf0981aca6a0a7f8e216ac2df8a6941a70d49f8e315d3999f3"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "Eclipse Public License v2.0",
+                        "url": "https://www.eclipse.org/legal/epl-v20.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/junit-team/junit5"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.1?type=jar"
+        },
+        {
+            "group": "org.opentest4j",
+            "name": "opentest4j",
+            "version": "1.2.0",
+            "description": "Open Test Alliance for the JVM",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "45c9a837c21f68e8c93e85b121e2fb90"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "28c11eb91f9b6d8e200631d46e20a7f407f2a046"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "ef25f5dd948c9ab7256e896da994871c1645b22a8d2d83f1e9ff7c6562b62acb70fcf0bb976a9580fb955a8e8b9c43dd"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "17f77797a260eb2bd1666a90e25efc79a5413afa9df1c1cb6c4cd1949d61c38b241e3bb20956396b5f54d144720303d72a2ac00bc5bf245a260a3c3099e01c74"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "874b139216e546b33623c53452aea25f36d6c5ec64446aa27be1e60c6838e5c3"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "c8ae5d803f34d54150681490afaa595a607e31c15c82765fb24eb7035f3310a4db71832d4ea1840d5281c4fb15e25a91"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "58368f990cb11d2965129b32986edd007f909b1187f8fe6842306aa5179fa74d7593bca2042776f6deb68921069719ee4f2bc54e609f87b974a885d7aa7fc05f"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/ota4j-team/opentest4j"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0?type=jar"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-commons",
+            "version": "1.8.1",
+            "description": "Module \"junit-platform-commons\" of JUnit 5.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "5706a289f8f6911257ad64f539f6ea89"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "001e362cbe6d0f225b066757865e233972557484"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "fa4fa68c8bd54dd0cb49c3fcbe9b2e42f4da6bedbe7e7ccf2a05f1a1e609b593"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "26db486d9854479a06177b49ffd8194b07116d4b7582b59d8d037f6ba93e5344e68d079053d04453b000d675368a0e48"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "bb838b278ad803de6443b7331718786b530d241d79170b3898c7d2f199aec81f5a6d4895bf15210f0060b1d5cc7958b184c8c73dd73cfc60fe988557f5d62da5"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "f29b9c3cd6c9b03bea3f29408d184d519c8bede866777a7e8140b5225957accd"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "b0e4aedff6b77e3cf428c608afe1ba9f3942d8a8cf12748aa91291561d823d98601ff7d66a8cf16f59f712df155e28bf"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "f6f61d3598393599f837f559170f79e289e500a50163d2f6d4e0315719ca23e0a12cf965c71b8f0bc8d3029634ea17bec0583bb6208438d1c6d7a166ee8c6bf1"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "Eclipse Public License v2.0",
+                        "url": "https://www.eclipse.org/legal/epl-v20.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/junit-team/junit5"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.1?type=jar"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-api",
+            "version": "5.8.1",
+            "description": "Module \"junit-jupiter-api\" of JUnit 5.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "291aacca1649daa9459049fb4c51f3bf"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "6538b88eb8bf8811bc7b6efb5246f835c15e0bfe"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "ce3374a7efba605e2d2b69a3fef90134032bab3ecc3ed8579a4871b1c2c4729c"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "c8adcbc5135cafbca8a3052542dee56b8a6dbf1bb83061280370673e6c9efcb79423a46d61a59130464201e03a081990"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "4d5248e43e5aba255875c0ca8f529a360f89c9275e58c87de30b5a7c10b569c7eeb1e31401f9be0c2c0b968adb12b2adc6b402aeb99671dc30bbf3a30b0f9924"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "64080fd79a7afb8c13395ace52dfccc3fa0f6ed1dba94764c22823139cf6f536"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "1f01d3a8fb6899d09c7af6a22f63f1777e1a09f0a6f5eff4aa9d0d23f87be9a85e06cfac857e9e74cfafba9d31be79dd"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "f0ceeabb5fc169245d5017d92f6b6b57e594b50e864f972e864ed555cafa4c1264ec1fce3c02eb2e5bf80a20c8ac8c4292cbb382cd113a26f69e6c5142dc402f"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "Eclipse Public License v2.0",
+                        "url": "https://www.eclipse.org/legal/epl-v20.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/junit-team/junit5"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.1?type=jar"
+        },
+        {
+            "group": "org.apiguardian",
+            "name": "apiguardian-api",
+            "version": "1.1.2",
+            "description": "@API Guardian",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "8c7de3f82037fa4a2e8be2a2f13092af"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "a231e0d844d2721b0fa1b238006d15c6ded6842a"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "5ae11cfedcee7da43a506a67946ddc8a7a2622284a924ba78f74541e9a22db6868a15f5d84edb91a541e38afded734ea"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "d7ccd0e7019f1a997de39d66dc0ad4efe150428fdd7f4c743c93884f1602a3e90135ad34baea96d5b6d925ad6c0c8487c8e78304f0a089a12383d4a62e2c9a61"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b4b436d7f615fc0b820204e69f83c517d1c1ccc5f6b99e459209ede4482268de"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "c146116b3dfd969200b2ce52d96b92dd02d6f5a45a86e7e85edf35600ddbc2f3c6e8a1ad7e2db4dcd2c398c09fad0927"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "7b95b7ac68a6891b8901b5507acd2c24a0c1e20effa63cd513764f513eab4eb55f8de5178edbe0a400c11f3a18d3f56243569d6d663100f06dd98288504c09c5"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/apiguardian-team/apiguardian"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2?type=jar"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest-core",
+            "version": "2.2",
+            "description": "Core Hamcrest API - deprecated, please use \"hamcrest\" instead",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "be43e37f4c7b4f6fadba382933006b15"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "3f2bd07716a31c395e2837254f37f21f0f0ab24b"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "094f5d92b4b7d9c8a2bf53cc69d356243ae89c3499457bcb4b92f7ed3bf95879"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "3d31875d5f5c398db6e29ea4e57ad18c9afb00b0926db20429435e74c1733f0e87189621c1f5edbf443b10bdcf7696c1"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "e6c3f02e25070177f8101f9ca265046f8c9569f82560051dbfb1e6a28c9937b1a7453f68e9a37bfce0eb69bacf45a743d16e78add931e98195d260b8a516557e"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "c34903e0e52796dce65958939fd536f475c7cc3733c31ec0e731ea4586daceaa"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "435d92c73b0a1d7ec1d1218953e2c382057658aae9bcd71359d2daeee48407ac4c4c539b4fe321e97147f3f568f0a40b"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "ce294d68caa56282e800a7d237a008a715c80f4f6f50240e7cba88154c429d30647150e4c53042569e791ddd24634ad7fe8711c0bc0d84c14663a1e5c1fab932"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "BSD-3-Clause",
+                        "url": "https://opensource.org/licenses/BSD-3-Clause"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/hamcrest/JavaHamcrest"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest",
+            "version": "2.2",
+            "description": "Core API and libraries of hamcrest matcher framework.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "10b47e837f271d0662f28780e60388e8"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "1820c0968dba3a11a1b30669bb1f01978a91dedc"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "89bdcfdb28da13eaa09a40f5e3fd5667c3cf789cf43e237b8581d1cd814fee392ada66a79cbe77295950e996f485f887"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "6b1141329b83224f69f074cb913dbff6921d6b8693ede8d2599acb626481255dae63de42eb123cbd5f59a261ac32faae012be64e8e90406ae9215543fbca5546"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "92d05019d2aec2c45f0464df5bf29a2e41c1af1ee3de05ec9d8ca82e0ee4f0b0"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "0d011b75ed22fe456ff683b420875636c4c05b3b837d8819f3f38fd33ec52b3ce2f854acfb7bebffc6659046af8fa204"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "4c5cbbe0dcaa9878e1dc6d3caa523c795a96280cb53843577164e5af458572cde0e82310cf5b52c1ea370c434d5631f02e06980d63126843d9b16e357a5f7483"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "BSD-3-Clause",
+                        "url": "https://opensource.org/licenses/BSD-3-Clause"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.hamcrest/hamcrest@2.2?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/hamcrest/JavaHamcrest"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-model",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-utils",
+            "version": "3.3.0",
+            "description": "A collection of various utility classes to ease working with strings, files, command lines, XML and more.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "3ae76ff0195ada460d495efe1fb50d17"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "cf43b5391de623b36fe066a21127baef82c64022"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "27742e2c82c13ffe947c6ce8750b1989491e8a5d7554cc3fa240a952c9d3a22fe006516041c66650e71972275c06565e"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "a93038005cd9793476c913beaea7c8c170d1853dddf39bf6794ad6446165eaf538c2c3c2314baa9d919d6b0bda78e5ea3cd987d5dbacf8e3b98e315bcfa7db64"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "364bfb131dab58736c995ac4484d9eab53b1e62129a99ed55e9c12ed39079dc6"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "16af5ee2b4f8710fa14bbd977ef3630466c51c4ed6bf9886ac0ea9c74bd23dedbbce60beae5217fab686777108c2e54d"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "4687c5ca8bb73d6880132d7d886733d0a5ce7a873c7b5b68d9d46066ee7e1f6c11f0510a70f313ca2563550bfcf6e81cf37a0c4ceef247bab55d6aadc49fae59"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "http://github.com/codehaus-plexus/plexus-utils/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://github.com/codehaus-plexus/plexus-utils"
+                },
+                {
+                    "type": "website",
+                    "url": "http://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-artifact",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.commons",
+            "name": "commons-lang3",
+            "version": "3.12.0",
+            "description": "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "19fe50567358922bdad277959ea69545"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "c6842c86792ff03b9f1d1fe2aab8dc23aa6c6f0e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "c34b8a0e0eba2168ad56fedeb7a1d710b6f1d3f1ce6aae99a4e0247bd120efbbadc8dcb2f731045b8a16e3efd30604dc"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "fbdbc0943cb3498b0148e86a39b773f97c8e6013740f72dbc727faeabea402073e2cc8c4d68198e5fc6b08a13b7700236292e99d4785f2c9989f2e5fac11fd81"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "18ef639b2aeeb5aedffb18dbf20c79f33e300d99fb31b131689639cc470e6e4c"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "8ad6ebe7754bf0caa8cda7e59c0e95360d76e06a7ad6aeec5637985519dbd1dd06e7eed04711039f36ec4c49de280def"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "fbea96114dcf4f31cfaaa99987be756ddda3a6c74f8c835461997df794d54b92da1f60fe5c3f1f2a43cb8c5f5db7f4048bef77c70993673c7a93f3660fffc8da"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/LANG"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://gitbox.apache.org/repos/asf?p=commons-lang.git"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://builds.apache.org/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://mail-archives.apache.org/mod_mbox/commons-user/"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-plugin-api",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-plugin-api@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-plugin-api@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "The Eclipse Foundation",
+            "group": "org.eclipse.sisu",
+            "name": "org.eclipse.sisu.plexus",
+            "version": "0.3.5",
+            "description": "Plexus-JSR330 adapter; adds Plexus support to the Sisu-Inject container",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "30c4a9fa2137698ed66c8542f1be196a"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "d71996bb2e536f966b3b70e647067fff3b73d32f"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "2e943a72f0ca201d50ba90b4cf70c3c1f7b5ffc3bbfdee45875bc2f6f2e2a3a93acbba3a2f1e7ffb32b70e041633b6de"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "38d7dbe023f9751cb5e30bf154e31696590317dc7b7f768811fe0f5940513fcea4665670cd47d0b72ded85453b10f7d129b0b7428b155a41c903c7b56c986e8d"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b879a16dd84d8d4f39c1009029b3a3a55e18049c7910f77814a32ca088b56585"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "a7b121732001b6f225b0687e7747993f48b3fc1d9a4325b4321a4c59adae36b49677193f5e31e3b1f11a6cd266e459f3"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "8f8fbebd2a3024bcf6f2e27e8206e3f3c2b2673217c1220743b1869bf60341490db7d1877d9eaf3c452500690df98ccda11a19bda996b74a6ebedc37bc9bc554"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "EPL-1.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.eclipse.org/"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://hudson.eclipse.org/sisu/job/sisu-plexus-nightly/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Sisu&component=Plexus&format=guided"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://dev.eclipse.org/mhonarc/lists/sisu-dev/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://git.eclipse.org/c/sisu/org.eclipse.sisu.plexus.git/tree/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar"
+        },
+        {
+            "publisher": "GlassFish Community",
+            "group": "javax.annotation",
+            "name": "javax.annotation-api",
+            "version": "1.3.2",
+            "description": "Common Annotations for the JavaTM Platform API",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "2ab1973eefffaa2aeec47d50b9e40b9d"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "934c04d3cfef185a8008e7bf34331b79730a9d43"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "fc0058495e54efb6e05a34e3ff422e7c8347bcc77d6d9b87e9253424968dee6ef6a215c318d7e54f8705276be81f0682"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "679cf44c3b9d635b43ed122a555d570292c3f0937c33871c40438a1a53e2058c80578694ec9466eac9e280e19bfb7a95b261594cc4c1161c85dc97df6235e553"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "ecfc9bef24ae28cf94c6775ecf6e2086d90a25d8d5476a4f6bb24001601b6cd0"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "ed6464b715de6ced0d9981a3f28140824946a4b7a02ffaff6116c833bb36e8f77a6282ce63c0d82cfe841d4fd6916891"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "f2b333527faedf504f60aa70a3d491972fa76f7e61e6351027f74613f41001157656824fe312b6e1df6dc4979704fe2a745b618d5368a97fe0bf8749739de9e2"
+                }
+            ],
+            "licenses": [],
+            "purl": "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://javaee.github.io/glassfish"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/javaee/javax.annotation/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/javaee/javax.annotation"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://maven.java.net/service/local/staging/deploy/maven2/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar"
+        },
+        {
+            "publisher": "The Eclipse Foundation",
+            "group": "org.eclipse.sisu",
+            "name": "org.eclipse.sisu.inject",
+            "version": "0.3.5",
+            "description": "JSR330-based container; supports classpath scanning, auto-binding, and dynamic auto-wiring",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "1b296b0ddd911ed3750b3df93b395cd5"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "d4265dd4f0f1d7a06d80df5a5f475d5ff9c17140"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "b76e74a0cda6d88c1c03d40e71d238fa13e2070485c026945ee8dc6da62eacb02071a65df35fa3e4d9d6b343a89fb605"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "f4790768c0d958b3429a3241abb15f9bb6e2fd7f43a5e034dde6a3a6820e6941c00f10ad084d5c38f8edc144e7acbea7ba3dc8952f01dab41e443803db2a4efc"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b998bcdf4f8b5550a543865408e94fadcf1dd37ac19ec37269ff5307220b2775"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "a2d3bae2f5e518c7d11e584f6b8b7368f3b927c3405f48e27d4225d4e2f4917fb5623c0071fc47f081200b7d754571d1"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "e9331e8a1b4281b45abec89dd9b7dd948207ebd7bed6be5978a5792d59327f7a4d4ee87c6f60392021f24f28439ab4ca4b6305ef6528e1c241c7a27c883b5931"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "EPL-1.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.5?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.eclipse.org/"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://hudson.eclipse.org/sisu/job/sisu-inject-nightly/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Sisu&component=Inject&format=guided"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://dev.eclipse.org/mhonarc/lists/sisu-dev/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://git.eclipse.org/c/sisu/org.eclipse.sisu.inject.git/tree/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.5?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-component-annotations",
+            "version": "2.1.0",
+            "description": "Plexus Component \"Java 5\" Annotations, to describe plexus components properties in java sources with standard annotations instead of javadoc annotations.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "141fd7a2ae613cb17d25ecd54b43eb3f"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "2f2147a6cc6a119a1b51a96f31d45c557f6244b9"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "dd102351fada419b7e66f38b62868db4141cf93863b8117926564dd883b4a3960d9c9682b346f7106cdaa2a4138c794f"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "cc534fda54272f074fe9edd581a6c3e1ea98127340c7f852c4b4953a44dad048ace22dfa10f30d6adcdfc15efd319dac778a03ebbe20de7779fd1df640506e88"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "2e9f44d1c5df160563d3cedaf01929682fb3e0432beca7c782d8ba0324fb32b1"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "2b335733d7683e8bae312b0608af7c17b1aa22a1b9cbc4cc11549faf6bacc51c7591f1073aac99e5d70fdea31c6253c4"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "5051e4210310ec60fae9f32284a93da3cff63bf43a7dda30eaf2715d24cfc7f2353a6c2731521f4d6ef32e7a3e2526b6a41c8a11b0889c8dbf7ffc7914812641"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "http://github.com/codehaus-plexus/plexus-containers/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/codehaus-plexus/plexus-containers"
+                },
+                {
+                    "type": "website",
+                    "url": "http://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-classworlds",
+            "version": "2.6.0",
+            "description": "A class loader framework",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "67e722b27e3a33b33c1b263b99dd7c43"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "8587e80fcb38e70b70fae8d5914b6376bfad6259"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "e839707ea5c4351f2703c6861ee4d58e08df0f7509110af13d4b3824e6ec5cfd65508fa80cc3f222baf5cf6c4ab5d5ac"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "6a58048d9db54e603b9cfd35373cf695b66dd860bec878c663b4fc53b6b3d44dd5b0c92e7603654911b1f78e63ef277cf6b272fe069a360989138550545f274d"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "3aef41be29373137c58c415693b312c95e048731dce519ab88649eae9ba0e492"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "75389fc7ed9aa3ad33ff317b0d41851fe0073b37aa8c33081722bfafb851493fb0e3b9629f924026fc32841f01399695"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "312eff142f86b9e110131dcca69527fbec80478e463fed5a34e2bd628673bce7be9ddb6fe0cda7fab2a119d1f310629413740019e686e9162194984ab6e06bf4"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "http://github.com/codehaus-plexus/plexus-classworlds/issues"
+                },
+                {
+                    "type": "website",
+                    "url": "http://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-builder-support",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-model-transform",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-model-transform@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-model-transform@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-params",
+            "version": "5.8.1",
+            "description": "Module \"junit-jupiter-params\" of JUnit 5.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "8a3fede18c1937e9f1432c152c28cb44"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "13afdb5d414cbe991fce3ef6b864de77c9644dae"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "389b8d13a8d8872fcbd4f0eba7b2c46afc628419f9a1b2a3a9f93241a06a7218"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "a3b747ce90bf449db52a18616c4ca94a649592874181797816cc97d0c53c306dcccfdbdcb481eb1eea28f57f5128aa27"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "7829e36b9bbe910274e46a1424f0e99fb15c584320de1264d26793b1cd857de3d5125da08880fca9a20492adeed6feaa343e40c65607ab4f448395f5835d7b75"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "826649111da8d9a5307483df92e662c5378d1851bbc7e1a7f195156205ea2d35"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "7726d962995a1aa356a3da9982d0de14277b4da4f40f25bebc53d6d54efd028faf09203958e12012f7ec2d299cafc5c1"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "79338659a8a7ad389acecbcd227576765bd6c76f6a8c2d599db331ba56635ba9a9360031947d311216f256662596cfd84747793adfd3b050def21df2deec49e5"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "Eclipse Public License v2.0",
+                        "url": "https://www.eclipse.org/legal/epl-v20.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/junit-team/junit5"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.1?type=jar"
+        },
+        {
+            "publisher": "XMLUnit",
+            "group": "org.xmlunit",
+            "name": "xmlunit-assertj",
+            "version": "2.6.4",
+            "description": "XMLUnit with AssertJ fluent API",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "28696f09ce73fdb59ecfd2119582ff46"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "ff4ed7548b076e232a167f4a00b2ea1de5d96dba"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "628b1d826596e25de78cf43775015183be4c464463d35e4e5274487f156e4e81"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "96431f2e2ae7aa2f3f9eaf95f0ec08d7856e4929c3a73990046e8baef6d936e8cf0f75d24947adb7e19985397454a630"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "dd79d50393e445d4352ac262099e6ef68e62df842496363d701c547d55eb1c63ce6f4fb6eca46f15cd529c19518145c4c3332e809b0c3ffb43b49508c5702434"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "0d4b9a851460216ee7b73710de46f140753f409d8af8220a0c22754f8b9de875"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "4712243cc5cce6c0e53861f50fbe73b3113cafb5798b84ac579965acd57533cda9db95605725f84df09450372db9fc3f"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "29dc9694ab123384596b5d83516f1bc2ef312ceb2233b19ad653fa97c6279f293c4107833f54461cc28ea9e2e27528ccf1eeaa63d5a7ef65b5f6bf9066b58041"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.xmlunit/xmlunit-assertj@2.6.4?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://www.xmlunit.org/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/xmlunit/xmlunit/issues"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://sourceforge.net/p/xmlunit/mailman/xmlunit-general/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-assertj@2.6.4?type=jar"
+        },
+        {
+            "publisher": "XMLUnit",
+            "group": "org.xmlunit",
+            "name": "xmlunit-core",
+            "version": "2.6.4",
+            "description": "XMLUnit for Java",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "a92f752128427bcc58d7228d799871f9"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "a916da161cd6c5ac85ac613c0fe0d28a8b7a3dbd"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "d90085333acc207787432667e5b35c14c9ef17193870d0ac650cbc2b77e8bca0"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "2c70462d7fec49bae8cbff24e645b197aa9e554e3d5f960eea25c6c444773d4615012b900410c1d53540531309bb69d3"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "095716477609d9943625b2c1603dd5828c6566688dab7cb7f7a6eb221fcd270550bf83f5d58f852ca105d0e35b0872a0bb11681a7af2e946e4ad6e05b40777fa"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "010b31e13080eff8d5e269ccdaa6b39226630bb50eaa9df641d5304c17b82f21"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "5a1e672b6bb9201a41185648f8c64549266002121424ca02bd2fafb108c4eb7c1ab19374b9f3746d7ee09a3ef15576bf"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "733ac457a7be3835372212d34b11aaa5d4e8c7e50fded067efa86fea5f4da4226a7f29a85020ee42d5c5460de414b3262c17f81edf317b0274d6e878decebe89"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.xmlunit/xmlunit-core@2.6.4?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://www.xmlunit.org/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/xmlunit/xmlunit/issues"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://sourceforge.net/p/xmlunit/mailman/xmlunit-general/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.6.4?type=jar"
+        },
+        {
+            "publisher": "Oracle Corporation",
+            "group": "javax.xml.bind",
+            "name": "jaxb-api",
+            "version": "2.3.0",
+            "description": "JAXB (JSR 222) API",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "ffa4ea6fada02493779bcd7f04f11ea3"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "99f802e0cb3e953ba3d6e698795c4aeb98d37c48"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "883007989d373d19f352ba9792b25dec21dc7d0e205a710a93a3815101bb3d03"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "9c1ac98f02cd0e1fe91d1742004b6e87520a84a0de18d51ba1a6f615cb92fb7d9d0640157547f18d5b2e2c81b4b1c4d0"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "0c5bfc2c9f655bf5e6d596e0c196dcb9344d6dc78bf774207c8f8b6be59f69addf2b3121e81491983eff648dfbd55002b9878132de190825dad3ef3a1265b367"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "2c25c47696ceca5f029101bc2d8be639f050348933ed9d6484b768ac276eb014"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "f6c3e158f69264ddc7b942fbb662ac0e99b79838b082cdc2a61a897c2ee9bc04ea9da5aaed2b1c46180a148093bc5ba6"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "42ff1bded0beb5c6822c061bb7511b6783bf7804083c0f34644caae768ed1e32872541ee70f2e34c637dc708617fc3e3a97f6cb4b37bd08957b1da22c221c8af"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "CDDL-1.1"
+                    }
+                },
+                {
+                    "license": {
+                        "id": "GPL-2.0-with-classpath-exception"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/javax.xml.bind/jaxb-api@2.3.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.oracle.com/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/javaee/jaxb-spec/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/javaee/jaxb-spec.git"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://maven.java.net/service/local/staging/deploy/maven2/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/javax.xml.bind/jaxb-api@2.3.0?type=jar"
+        },
+        {
+            "publisher": "AssertJ",
+            "group": "org.assertj",
+            "name": "assertj-core",
+            "version": "2.9.0",
+            "description": "Rich and fluent assertions for testing",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "dcb3015cd28447644c810af352832c19"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "5c5ae45b58f12023817abe492447cdc7912c1a2c"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "5e88ea3ecbe3c48aa1346fec76c84979fa9c8d22499f11479011691230e8babf"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "666f6dd2a1ebb2c272a27318312d45c4ca857c8a422ad37e6e86cff51552d90a6fade446a2c37d51dd0f9f506531263e"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "ef8120cb77c564e0cab404c469589bc51ba2c4136131381e674bb92f359b5a7aeb915547edd7ee98b68338230cc456b9681375f0bf7f8c49c9da94a8fb9ff9c9"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "15c3307c77e67d9b8b95dec101f1a1d8fd127bc85f4db00379d97be730b27df3"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "9c5a6b43856a76ec2fef6cf2adc81fbd2d982d28ad18cc993702a27dba5d3de03bd1b1b50cb2925b75221c97185e8e43"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "5997630b9b6435973a85e58a2afc2a138015304fb0e1c8a75e5cba3bfa1f52e3d859cfb8c54c23b692c7837f7b1efd0f1d6d11751ef9804ae375f7b04f3d8b8d"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.assertj/assertj-core@2.9.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/joel-costigliola/assertj-core/issues"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://groups.google.com/group/assertj"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://assertj.ci.cloudbees.com/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/joel-costigliola/assertj-maven-parent-pom"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.assertj/assertj-core@2.9.0?type=jar"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-core",
+            "version": "3.2.0",
+            "description": "Mockito mock objects library core API and implementation",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "b5f238f4732000775022a332acdea838"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "38157d5fab1b47814827773ca3dff01c60e31425"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "3ab21ace35374897fb760b8917fa70c255e665582e3d1583e83991d750873f2b"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "bca547ed4c9adaaf1847f6cd6d268e043d7c06af45baef2dc25fecfce5db6ffc704b4b611112e07617f0f32bdefcfc27"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "f8eb487572f9b9da0f727eabb2e35e2434ecc0bd7b8e360b2a59b97b3e16039165ed445de329d501929eabb320575b290128385c66165f7501803965c1955a03"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "bb2f26cd3e2cae6a748695934cf2e02b8d655f8e718ac7f03f9b9ec0bedb1baf"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "9b0015b6f7be63b5554c27843a2275012c26077a0d2bc8c2ff53011477ff7d97e5a3c2de652d9ce0793b0b6b780324b9"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "bb4e096ff372e96855bf8e087af0d01eec5f24b6f1e93225d86c8f4f6a29475619bd422140bbe2967e4d3578758a78edc88b79a61561ec76d87db41f0f53be40"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "MIT"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://travis-ci.org/mockito/mockito"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/mockito/mockito/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/mockito/mockito.git"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy",
+            "version": "1.10.3",
+            "description": "Byte Buddy is a Java library for creating Java classes at run time. This artifact is a build of Byte Buddy with all ASM dependencies repackaged into its own name space.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "7c7cec8d8c9f325d973a9479de7427fa"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "0db4e5b256de8945691b863e1b2150a6834e187e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "09dd9122bd4f5dfb3dac82226db5510cc80b5dfc3ba5b78eb053e16412028fcb"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "0160865201f69e0127ae5ed380cdf3d121536d492bfc0877f37df2dbead3e38acaec205f605c4d1824efe0a064dc2c60"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "bb459a4453a6828bb713ac520249bf090fd762cd2154c6a87f23b4497279af2a7004b99eed698414061ecde8365104300ec25e0cfb0d999d95b052046adc8213"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "a46f5614ac41237b3b35a7371dea2f380776dd7ed4b942fcb1a28e5674dcde96"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "4e716254aeed96d123f05c5eaf0e440363f42cdf933157579833317ff71621bd12e00171a2a9fd6b552aeb8e88bd13a3"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "0301ea4afcc09b340957e988e0092fee41dce65a999130c1f3d66a9ebbf5c33d774fd767febd64aac9c71eeafc7f7be9dcbfc87ee30365d165ff36d0676524af"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy@1.10.3?type=jar",
+            "externalReferences": [
+                {
+                    "type": "distribution",
+                    "url": "https://api.bintray.com/maven/raphw/maven/ByteBuddy"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/raphw/byte-buddy/issues"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.3?type=jar"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy-agent",
+            "version": "1.10.3",
+            "description": "The Byte Buddy agent offers convenience for attaching an agent to the local or a remote VM.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "841d9518c8d141aee26fc4245813b1e2"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "0d7a2b692adb0f4e204fc52fc7da998b60d8483d"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "03ee728cc228066a2b2693b40b50b2ddb201987e39ea85679ed46a73ce57da01"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "62e4110d9b196863a711095f321a07ac186209da258ba7acc9f67a198903e46f40a83abbf6e43343e0ca0f93976a92d4"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "bfb7c2e8bc2d1a0c63342e4326f1b0aadb8e3610204bb71f508b4bc9b5c6a65d32331819fbcddba8616f68265057cdc36bbd9b26dcdb382bb8e6368c1480bf87"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "6f21d79126ef4444fc2cec94c5c627a15b6cb8bed66cc65da997e41e259d853f"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "b90680d0fd33871fbb33a31a9a4326f74f21f05a47f8da9e3df1c796ef8d5b32ea41bb36020a418274e5bde7710e349f"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "314ab25bf294a9c103de04cd74940fb03c12eec949d8d452d5ea2329417ad1091d0c9ff242162534070ebfa07bfa82c375171bf95d61b541623f13a6ec4956ce"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.3?type=jar",
+            "externalReferences": [
+                {
+                    "type": "distribution",
+                    "url": "https://api.bintray.com/maven/raphw/maven/ByteBuddy"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/raphw/byte-buddy/issues"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.3?type=jar"
+        },
+        {
+            "publisher": "Joe Walnes, Henri Tremblay, Leonardo Mesquita",
+            "group": "org.objenesis",
+            "name": "objenesis",
+            "version": "2.6",
+            "description": "A library for instantiating Java objects",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "5ffac3f51405ca9b2915970a224b3e8f"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "639033469776fd37c08358c6b92a4761feb2af4b"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "5e168368fbc250af3c79aa5fef0c3467a2d64e5a7bd74005f25d8399aeb0708d"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "502057722913adcad184e16a4be7a65dea54b53c5d035d53ee182226b19c90ce024f5bf78d0d5458eb1e0f2710976405"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "23a593bded8cb43236faad2018b008da47bf4e29cc60c2e98fd4f2ed578fe2baddd3a98547dc14273017c82cb19ce8eaaab71d49273411856a2ba1a5d51015fc"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "1fce020475bd27d7eac3a3693e9c6992032739ef6db205c7751c92f8aba4d67a"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "b3ebb3e83ff1711359b118f17ee8ef1c06674f0385b278a1f843a79904490f496039ae54a3d498c436bad54566d3bc8b"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "ec2154e3bb9fa0b74079d4f21af3aa0ae17444da63aa1061d87aac646c070b3733673a4d0880ca58f974dc3358d7b1c6161bf030260474b36b4bae677b777b08"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.objenesis/objenesis@2.6?type=jar",
+            "externalReferences": [
+                {
+                    "type": "distribution",
+                    "url": "https://api.bintray.com/maven/easymock/maven/objenesis/;publish=1"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/easymock/objenesis"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.objenesis/objenesis@2.6?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-model-builder",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-interpolation",
+            "version": "1.26",
+            "description": "The Plexus project provides a full software stack for creating and executing software projects.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "1049ae9f5cd8cf618abf5bc5805e6b94"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "25b919c664b79795ccde0ede5cee0fd68b544197"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "93dcdffb567f4b7d24eecf9fb0733243ebfe1fd80c92fe69532fed9d1727a58ffa5ce7da4ab26b5c6aa8a6a59beb3844"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "6c3b40442adf721d325ee9cbf935d758223a04b3bd8e0f3b60fdb652175c1ca65a6010f7ea8288617ffa73cb1f19d2737c79c403d343b285e0f9afb1729caa60"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "62145ec219beb405063de848cb54e0d63efc8c255322998858d7df74f8d1ae18"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "7489d45be45f74f7639db3b18ae6075d32d84adfaa9c4568f3fe2b2fc35c7de73ffce6f42e494466a8c81e78747b0f17"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "12fba4d2ffab1f89003e375bf74df3fc5d0f831906f9716f2ab2fc5a4ca7084c8a61500b24c5fa0ded27d1cef14b030df70b34c148c138136070e27f7cc41536"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/codehaus-plexus/plexus-interpolation/issues"
+                },
+                {
+                    "type": "website",
+                    "url": "http://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar"
+        },
+        {
+            "group": "javax.inject",
+            "name": "javax.inject",
+            "version": "1",
+            "description": "The javax.inject API",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "289075e48b909e9e74e6c915b3631d2e"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "6975da39a7040257bd51d21a231b76c915872d38"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "ac04c9f03ccbe35a25deb8b50280a0ca01dbe6aff0dd795d55af6112bfe3cd5817eb82f32fb18378d86cd64b07597190"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "e126b7ccf3e42fd1984a0beef1004a7269a337c202e59e04e8e2af714280d2f2d8d2ba5e6f59481b8dcd34aaf35c966a688d0b48ec7e96f102c274dc0d3b381e"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "5b0054e39e522de0e0ffc4034d12f72270291fb24d94d5ffc9c4d69c25035fc6"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "fca090ecb1edeacb9fe865dc515cd1d109b323cd742d4a9733ff199a96ee96e0db4f924079520b9c189ef750f255475d"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "fb290f5a70b1efc1dff12f40a0b2d7b94019f66da42e78010c0b8e61f222c4f267b67e356a9e9c346eb801e5515e36243888f280c5cb95c2dd69016a30cadeb9"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/javax.inject/javax.inject@1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "http://code.google.com/p/atinject/source/checkout"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/javax.inject/javax.inject@1?type=jar"
+        },
+        {
+            "group": "com.google.inject",
+            "name": "guice",
+            "version": "4.2.3",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "5c78a92ffee82adc2ed698ba0b8b29ae"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "e07180332a35a6c52762302fc415f27d258debd6"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "5168f5e7383f978c1b4154ac777b78edd8ac214bb9f9afdb92921c8d156483d3"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "3b3a3950de637a14ab774605b5890b5169fb3b91f4823fa6fc08ce9fc31d7492bf959bd65b768164285e61e46f8de1da"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "e819e09cc869f2641541ee47cb82e01565b89794bc4b2328853e6fb138d9da484ad423054c998723f1c475a2d7d0d9325f1f09c69ecdb4fcb8f8b2ea666d70f0"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "3489e145db1eb15cfa0f101253dc9867301829c3cf20b689ab713a527ad0079c"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "c87f3800fa31e13c48f9c928a4cb082b13a2f1a77159a30f03bdfec7303af3aca4408d6801c0fc75c5dd6ec0b2c6c790"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "940989abf4b3b021cff24ea95d862f1acbce461441a6e5894fcb9a5b9d27746fb632b8ba4f2a0f3235db9def6da6287f3482ba02417635e5b1ce064e29a18d91"
+                }
+            ],
+            "purl": "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar"
+        },
+        {
+            "group": "aopalliance",
+            "name": "aopalliance",
+            "version": "1.0",
+            "description": "AOP Alliance",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "04177054e180d09e3998808efa0401c7"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "0235ba8b489512805ac13a8f9ea77a1ca5ebe3e8"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "4dddf44338b5aff9580da2532b81c0ac3e1d09e1f28c6db871a55cad442b705dd7791eb07f9d4577d49d0be3673ba783"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "3f44a932d8c00cfeee2eb057bcd7c301a2d029063e0a916e1e20b3aec4877d19d67a2fd8aaf58fa2d5a00133d1602128a7f50912ffb6cabc7b0fdc7fbda3f8a1"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "d4a726b2bf8aa58197021a7d8fca674b4b2790d4c48de43a92f728866a91c2f0"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "2bd64cbaf769c6e4e85e34f7a6119d89e16fbf55af3fc5d6cbd52eb214c367dec1ac7b9062ee0fb35a2e0acfc7c477e1"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "830bc3f8328be76897990e9b9fc42eef02623115e456af96ad09b20900ad615519c8c8de60155ac04fb332eaa9510110d52edd13911af76271c71d91cbd789cc"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "Public Domain"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/aopalliance/aopalliance@1.0?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/aopalliance/aopalliance@1.0?type=jar"
+        },
+        {
+            "group": "com.google.guava",
+            "name": "guava",
+            "version": "30.1-jre",
+            "description": "Guava is a suite of core and expanded libraries that include utility classes, Google's collections, I/O classes, and much more.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "2f8966f27f06101a08083bfa9f9277e7"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "00d0c3ce2311c9e36e73228da25a6e99b2ab826f"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "e6dd072f9d3fe02a4600688380bd422bdac184caf6fe2418cfdd0934f09432aa"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "12f54fff188f49a7d7284836768f198a6b002a1773ab80311c69449cec0544744938b8818b70cd1811cad830efb6a76d"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "e7a8098c0af7746c8a97a8cc8245166c14ee9213f67943d9d1962c94699f58d789c1e103de9cd407c4f20cd4be4e89814643560e5dae0b3f629312f2b1a2a8e2"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "6e498cb0c02bd5e60cf8feb9523b81056422df54be0e1f8d1da65b7aa454c8d9"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "2671b086b98b63915f471cc76f8ec281c12e94e14129bc35e0695f73f28e2cc1292abfcb18626ee9ee8691e587c674d3"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "a9d4cf2ff036032a0beef6249fa471c5d7d6a26e25b99995825c37555eac3fc53ca78e5c6f207476b258fe178f9ca7bf0551442632b7565279ad6c20f099b82b"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/com.google.guava/guava@30.1-jre?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://travis-ci.org/google/guava"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/google/guava/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/google/guava"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/com.google.guava/guava@30.1-jre?type=jar"
+        },
+        {
+            "group": "com.google.guava",
+            "name": "failureaccess",
+            "version": "1.0.1",
+            "description": "Contains com.google.common.util.concurrent.internal.InternalFutureFailureAccess and InternalFutures. Most users will never need to use this artifact. Its classes is conceptually a part of Guava, but they're in this separate artifact so that Android libraries can use them without pulling in all of Guava (just as they can use ListenableFuture by depending on the listenablefuture artifact).",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "091883993ef5bfa91da01dcc8fc52236"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "67659dbd9647ec303d7f15128dc9dba19b98fd8d74758ee3b602451e32c855e236ccaafe08edf4bbfa245f981268440f"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "f8d59b808d6ba617252305b66d5590937da9b2b843d492d06b8d0b1b1f397e39f360d5817707797b979a5bf20bf21987b35333e7a15c44ed7401fea2d2119cae"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "ea86406e75fcd93eafe3cde1b3135ba485f1bb9b75fed98894a0bf1f0aee04f0"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "1460875f0331c5fa3791772a6a322a7db180261bc2adacf7271df1fbf3b088a587a755a604c039982cb593c5cfc1f101"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "52ac0f487ab5dd27c9f2e54fd1d84c7a620cae9d49be4072aa2b11501787bf4391ddaa13d02eccdf19e8eea46aecbea5f6064b26777c1b836108a280652e04ac"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://travis-ci.org/google/guava"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/google/guava/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/google/guava"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar"
+        },
+        {
+            "publisher": "XMLUnit",
+            "group": "org.xmlunit",
+            "name": "xmlunit-matchers",
+            "version": "2.6.4",
+            "description": "XMLUnit for Java Hamcrest Matchers",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "d491a34102f5de94f1e72b191c061d90"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "83a589863b233d52dc94df1a6c2a59db14d6b6cf"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "6eae9f3e2b18c4bd29e7ba39d9c18bad4c12b35bd505f1871b9b53a39138267a"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "d048910cfad4d1b538866e2b051d69c192323a49b20775f5f8fa7d3b2be0f6697ac1589de2b91c41eabc4afb62c79b84"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "1804ea194d80d4b4e5fc4d4a722a2e95861ed80542764a8dd49c7523e784fd46d1b7ddf7c50b23de9937013083cc99454286be56e5b15d5dd02f9c5b1323dc4e"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "0ac72c7e3606770af4af56c20271b9c68eb05ae4455aa043d8bb692c72f69018"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "8808c0732c096942cb4e1d557ee9f9b65ce967e51f4eb7ee69971f048ada949c66b502ecd8b570aa5cc1ebadc52157f1"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "7e16f8a5f6d4b09cd35d73589c811529d42642995a3a67ff9d19c9fa1c3a1fbefd03b889c1f94c9c64a103467fd2f62d8b27d853068e447ada3ffdedf69391a6"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.xmlunit/xmlunit-matchers@2.6.4?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://www.xmlunit.org/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/xmlunit/xmlunit/issues"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://sourceforge.net/p/xmlunit/mailman/xmlunit-general/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-matchers@2.6.4?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-settings",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-settings-builder",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-sec-dispatcher",
+            "version": "2.0",
+            "description": "The Plexus project provides a full software stack for creating and executing software projects.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "e68635a721630177ac70173e441336b6"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "f89c5080614ffd0764e49861895dbedde1b47237"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "4af3426b6409cce7d5fcda4e2af407fc2dbae9873e06d98332bcd032c0039d9080a291e42223ea2bbef9825d3d63493f"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "ad4e814c8baff780a4eee064903e52b09ae00420a59fb075ef72dbb8d64d12d3d5009b03d56c15f93587d931c3a7f06cad6351ab2dc9415ccc6eeab0daebeb07"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "50fa723aefb551a3fd5888375d01f1d776c534cdf833baea392818e9bfa8166e"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "41720858dd5804f9cb26a8878c16dbdf0372a90e99c037809fe76c3de2c5517ba252af8f8cdf534c1a09900702e6a917"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "a43f823d31b377c0c7ec8d36ace69e5dbcdaf4dc4ebb45ff0561fea9e12d74c06090ee24b29b06769d4031693faf5d7e3146583d3a64bfaef6b7c79773a8831f"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-sec-dispatcher@2.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/codehaus-plexus/plexus-sec-dispatcher/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/codehaus-plexus/plexus-sec-dispatcher.git"
+                },
+                {
+                    "type": "website",
+                    "url": "https://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-sec-dispatcher@2.0?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-cipher",
+            "version": "2.0",
+            "description": "The Plexus project provides a full software stack for creating and executing software projects.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "55d612839faf248cbe3e273969c002c2"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "425ea8e534716b4bff1ea90f39bd76be951d651b"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "6973eefe06a8992aa8db1775c0f43a84cbef54eeea9122a5a30c362af3e4fb13b6cbd6fba229142e2a4495f97d71f409"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "8f187b07867a7c29d77454aae4b76479300238d9c4e777c1afa2aebe33b88dab916e29111dd55acac1341849f4579fe91a5470fdd45ccba0e05709c2ce3a1d65"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "e2e51d5350ffdce341464ddcdf9ae60108bff40bf5174dc6be43e33ffcd84af9"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "ea780d218f96e61005c5582bf3785ddbb33b53ccb4efbffd76ab58166cf261d3c256d52fea28759380684b7e9b0db8eb"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "f3e17ea31bdefc8094ba3495b8231ec7f90c7175839b009d9fd230110b66ac4c68c912fda1a6e644d93dbce639d738e2535f1ade5841e072a604f5f8ac536729"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-cipher@2.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/codehaus-plexus/plexus-cipher/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://github.com/codehaus-plexus/plexus-cipher"
+                },
+                {
+                    "type": "website",
+                    "url": "https://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-cipher@2.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-toolchain-model",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-toolchain-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-toolchain-model@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-toolchain-builder",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-toolchain-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-toolchain-builder@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-repository-metadata",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-api",
+            "version": "1.8.0",
+            "description": "The application programming interface for the repository system.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "59e0afbc71d682c726d0ba95464f3760"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "3ddb6abc5b55d5fc800a4e3ce0cd28ac75fcce47"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "5c9df7e7f6122172d5d27ce3efb2bc58fc7f423c2fb7468bf75315d742ebb181"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "5b087b309ac449e215a086e70afead79468484d881cd18294256c03def75ede308ea4735e000a4bbe624bc6edba0566d"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "1acbe75e6aca58fc62c8a29169011a13f7fb5e63baae7910a7a74b550500b30d91f545e6ce006898c9393ac7bb320bafb2e57cc4c7d07e00318928da0a559e9c"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "80e2cc55b2d9087b9cd909344872fa62e582f2588d4c6bf14ad2242c1259b644"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "05af8f0cf832045638348ad7f1a36a9190457dbfaf28bcf1bf921ea146c86c087f1632757047ea7bc381d06b5c1f4a26"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "af61f65b491a1e183e7640d789f7a931771d9857ba5218698bb5c7097764fdb8d9bdc080d9eaeae5a4fb3621bcac0345ee7299a4cb83fa9e71dd2e77935532ce"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-resolver-provider",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-resolver-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-resolver-provider@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-spi",
+            "version": "1.8.0",
+            "description": "The service provider interface for repository system implementations and repository connectors.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "f70852c4c6e52fd1a8f66b67ffa0501e"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "17dd47d032611857b1231f54de1812510827bc5b"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "7d3e1e0d65a3b1f99939cf8e475d57e7b9373846ee929e0ca1a92dab7bb0093c"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "b72fa5fc9568b6714b98f176a4e4275e3ae4a71dd7535028354bf1d87f5abd6c1d116dbb0908a8d928b6bccf76ebaeef"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "60c8dffde6369004f2f9d1e891644cfc702b8b820e9bdee60c26b3e203874fd3dc4eebb2f4eced425fb711bb3c464de2c2c112389f0d9cc6fd2fd21e3218430d"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "839d81a9a91530a57c3c53a943c967da98b7c28c9ec626b5fc944c60b49a8933"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "d480485def49a79f0b946c8488f225f199f89268381006b62f9f9c34773ad721ae6f1db3729ae454e04c0ba09db410b9"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "1488bac0efa5613ae4df73a45c37d7d1fe6d9799139c1ff6e7e319497fc748a877dda8d51a333814810cce48fc2d46259991f2c7b6e246c39b21f2df72fb9ec6"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.8.0?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-util",
+            "version": "1.8.0",
+            "description": "A collection of utility classes to ease usage of the repository system.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "ffdf20c6bd6478a0c15405856b7c8ab1"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "c9594c7fb9874039cf2584d384f9eaf7369af315"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "3468ec7ca9ee97878e61f26905546cdd709de778b8884777516a1af2d4a32e4e"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "f0dcaa116d6aaea3976f7925ac46e1b0b774bcee7a84fb0decf7cc1ebd2e7dc5800e79fd5a49e4af7203a9ac3287dea2"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "06c885acbe93dedc0442b1b8f8a48771a87462936e761c0eab78d1da7af867bc74980c335fb1fe1d1a97663faf94b3fee99242f87f2a12d92072f090beff60b4"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b1c739041c783ad17bb336acb065647d904074183e180eb19796e80ced3c6a46"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "63ff033ba281d197faae996bd7081c68a7852f34d7aedfe4275f3f08d0ea19704e4282dde4e2d6097cc552fa28c4bf3f"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "f3149cecd21aad92d5eaf10378f4b721858fc595a9aa881e9ddda1e03e87a83957c9cdc35cac34379c12a91453a21dcd8f9b5cc6edc4e879a05d1825a4726218"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-impl",
+            "version": "1.8.0",
+            "description": "An implementation of the repository system.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "9878c99da6895e14ea72521392f8b568"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "94e0d062ba92cdecdd2e9a4f0e4a6aa87042a690"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "b20883afb7c112c20e4139d79893a297718cf94813ebd2fb8aba621a62b9f872"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "376d3b531a032b7ea8f21bdcb1253cb21e60ab62609406d97092a0ba7cc55c70266e1e181b17aa9e3d9f9282d04420a0"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "9be7a477a78fc7165df18d1932ad311220fc55c316153b4f4393654528bfeb2b75938122d3f1d5c1d31654a4376dde39d542708f6da9f8e4fa39a655fcd362d7"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "632641a225357e1e5fef1c4db62ba6accff96c305c199943e8776c9e64b16b90"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "5d1f27aff1dba2da37548d65fb0596178f6952e7862bebbb2b81096a6a750005fac0a8be2bb978ad02af95e549a10b90"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "2788294dfe526471d0f7a4c76d18fa136618fb40b45f35c20063890c1bf87e90d124c7dd65908cde7d55871f87b34b99e91555682fb90ced1d45fbeb1c76099c"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.8.0?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-named-locks",
+            "version": "1.8.0",
+            "description": "A synchronization utility implementation using Named locks.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "c79baf6f53c3401436b1547a426555e8"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "5b6b88eb7851f78ea4fc4d6b9e081be3169d6a2e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "ca6ff94745a518633dddfd2f68d50a0b896cea07f5338f55ea25079d9d1a1f62"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "dd6a5716249c9b42fa97ea593c1a1a11330f01ce15349019d09c821ab6877117e0bf7fbfe274c553ea91c9bc9a82d909"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "c9fb2a74333789709f2453c7461f5e34cb2275631aa5013acc98a03c1e6be5b0ebb1567b48c0916515da2ae2b8fb94b353a9a13abdae0197e7f1853f85826ab6"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "6bcdff2b1a6baf7dddead6942b59f1f3cbe43fd79e5acc892bb8bd027ee23f15"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "629f869cdec3cb8cde62107cf8f9ac891583c673e7472d7c322edd9a9441ea9e6c615c333138296084a102175da0c6a0"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "e3dd923c218d2ab7b53e6bfec354beaf83d5356c03266f09e56bf3d7464b27483bddebf7a85ca73fd7352786ede4cd874d725921f4f32de665f5a0b459f1f9bd"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-named-locks@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-named-locks@1.8.0?type=jar"
+        },
+        {
+            "publisher": "Codehaus Plexus",
+            "group": "org.codehaus.plexus",
+            "name": "plexus-testing",
+            "version": "1.0.0",
+            "description": "The Plexus project provides a full software stack for creating and executing software projects.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "77fe2a982f5c40b041e91d609e77483d"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "45659f0fd8dda910bda63139dd990beeb4301beb"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "1720c14dc835edde808a1f9f066c9032857acb26e5c1135c208fdc5f0281ea88"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "98a28e82a72ce74204e19abad991f3d40036cf0ae4a64eb94004ec5497ddd609d18cf85ce936592c881046f298d0ef05"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "b0354d18e20e16abd28813f9e1e0027385aeab221fc982b977880fc1bf0773e604efa50a72e9af2fd37a27b6f0bfae4e0bc7dca8444cce9569593310d45bc540"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b6c7c8694cb8b28395f6d9a6ef51dca804480f73ce413a65f7c18a10f1483ce9"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "da1eea443e868c3e15dca5d9a4267e4c8b124b0c9a1165e85ac61b19bc7c1728c9ccf92f6c5d79f72288a75cfc35b8f5"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "cd52ac525bf38b8db04d86e7abd317e45200bd06114a851f52627ece0601daab559090a07e7c1244412ce5ec9e92b495d46beb4d4dadbee031fc7a287e39974c"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.codehaus.plexus/plexus-testing@1.0.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/codehaus-plexus/plexus-testing/issues"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://github.com/codehaus-plexus/plexus-testing"
+                },
+                {
+                    "type": "website",
+                    "url": "https://codehaus-plexus.github.io/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://archive.plexus.codehaus.org/user"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.codehaus.plexus/plexus-testing@1.0.0?type=jar"
+        },
+        {
+            "publisher": "Google, Inc.",
+            "group": "com.google.inject",
+            "name": "guice",
+            "version": "4.2.3",
+            "description": "Guice is a lightweight dependency injection framework for Java 6 and above",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "4209f9e543a157db0f194688760409c9"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "2ea992d6d7bdcac7a43111a95d182a4c42eb5ff7"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "a21e50ffbb67e7adc5b46cf7b9e1a480f1e0f04fd4201ddb1c65da91290601af"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "7e5decbfc09816e1c3d3f5fadce2fd9df9999cad9c30a8af1eb133dd9d1fee15a6153783d18704efc7f538ba4dc48dc3"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "1e811c276d3d953d7e2e6cc2bd33af16645f87e864713db0d70fc2dc7110483c8f40525f2f0f403344e5653bb8375ccdec9fda0c0ba6c42114ac482cba50960d"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "73c2a852e4a353b30877e77b4514f0c21c1eecb484558c60783e4c566c9b128e"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "df25f6a1e14c9fedff262d4f867a3489e592f8216334630d600e7598034448242e7f4ff75c8fcef2c08f287918697cf5"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "84fabf13bbd424d2c65ed9d211e45be224788c1fee5c461c0fe40c8a25989f503238094bc14b8e453583bf6b4d3f3152ae900393304d1b9ff07efaa45afc156c"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/com.google.inject/guice@4.2.3?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.google.com"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://travis-ci.org/google/guice"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/google/guice/issues/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://groups.google.com/group/google-guice/topics"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/google/guice"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/com.google.inject/guice@4.2.3?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-connector-basic",
+            "version": "1.8.0",
+            "description": "A repository connector implementation for repositories using URI-based layouts.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "a8e3d39f1bb42663510ee2ab596616bf"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "b4ee562cc407f849fab0a584e86d1d8f5a87f899"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "6bff434abd3d723f458db497107ea8cb1c6c833715443eb5daedeb984a36c5ec"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "73acae61a37b3b5e7c58dd9dff83b55f089d42128ef0de29d69474a57f8fb1ba0d119d901382b10358524c400d5a4a35"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "9044dd91ab1a292effbee5aaaebf9aa132c4d24a95307b2df0623868bcac0fa48ca038cb44cc444a7b4caadab58fd8f4a868bc62abd5c7029af1ad49241109d0"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "2db710efce6e002042e9ed5c04053a6d3d3f46a331df8c805b5b8dcc35608d6e"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "398d3c8d6ba1af033524710386faca4f42ab30bf28ddfbfefff9afb689699f74403cdbf1a9261d3e9578049092bc399a"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "013dec0ff3d15bbd52333406993b10fbeaffd3f35489995bc448c39f7f7606efca5e4caca5e7a3225774c6afa1f5064831c96daf1a4097c3fb02c5697657dd26"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.8.0?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-transport-file",
+            "version": "1.8.0",
+            "description": "A transport implementation for repositories using file:// URLs.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "d1d302db9752b493fae796eb1a8d81d7"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "826a85fc74f4a096768784898f61335aa5427b30"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "31b70268e4137e64e8b9542769f4e2a3ad63237b615f0963410f1b2c84e0a663"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "8032fe73ad726b575f41ee0b556fac4ca9d5e879718ff0df4a5c1f7d22be47503d084022b9de75489ad5c4becfb955c5"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "4a598e217aea50f0415525aed0133ee62b1fb0014da14db2accb7a1c633349da22d3ac2292cc4dff411447fe7a49a77c5dfd993defa6d9f7707209ca46963cca"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b16d881f9e8891bd9196ca0e6ba30108d12e1459d95cf5148239ba472d6550d9"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "2ffd6cf4dba4825f2f3194b51e73921779bcc18665d6df935f6d881d4dae914943b0ce0ce5d212712b0203fa04c32c95"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "adb96b7cce92e3661f42f5d6feac1dcb466ec8d95c6937b547203d823973b24f6df7151fd68fe63f4781cde3020619b66c82cfe1f067f153550acbdb010b86c9"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-file@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-file@1.8.0?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-transport-http",
+            "version": "1.8.0",
+            "description": "A transport implementation for repositories using http:// and https:// URLs.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "a209cee4b3f43a017bd71977a1354bcb"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "e288630407c733e4718b0af512245dffca0b718e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "046efa89d5e17b3df4d1aa8dde5a2373fcb4e3129e7da3bf42780e853b8b281f"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "68c097b3d9864d536e8732fd30b67ee2599df95e83b4e46da36b80aed1ff357ca7c702ff7cdf933ed5319327b3ad0bb7"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "4bfeba860ab54c812ef2c074f7ebaf09d6f749e28c9b3f928036969edd0970707902d0764458665c100029d02a0500e233afece87fead47e76a8465694145613"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "74d50d8bed8123ad249ae30669741fbd41366ec96fa82e5f0c9c6822bdc0b8c2"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "d5fd22aa25186ac65970f190a5c7cd9c0ccf0eddd80f6c21112839819828f9307f8085810c2ca8861d5cabbb46ce623e"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "fe98ad182727e6f9aae5b4a2a39486fbf4671006a9c0cd42b37f8e614104fdd7b454e930bab4c7022dc36d12aec1abbda90b8cb0f7fb61a680a0f96bcb29190b"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-http@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-http@1.8.0?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.httpcomponents",
+            "name": "httpclient",
+            "version": "4.5.13",
+            "description": "Apache HttpComponents Client",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "40d6b9075fbd28fa10292a45a0db9457"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "e5f6cae5ca7ecaac1ec2827a9e2d65ae2869cada"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "093ac3e2dde58e34aa70309c7305eb3c9b5be2509a9293f1672494da55479a86bd112e83326746dc7a32855472952b99"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "3567739186e551f84cad3e4b6b270c5b8b19aba297675a96bcdff3663ff7d20d188611d21f675fe5ff1bfd7d8ca31362070910d7b92ab1b699872a120aa6f089"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "710b1d8d7dae0b8e4270756694ca9c83d64965f42d3b4170c609b14d47c2762c"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "cd6882e7868624164e460f2f3ea01466f863c0dcb902b031c656b57356f563be83b29530df41d88d634ed3d01fc9964d"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "276fa6a6599dc89382d658115695cf4da6b0d39b34e9c349c17a5dbd64122eaee553bb9ed75c0378ec4a83be157c8aa39370662de3c9b8fd55ebc1dd608383e6"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.apache.org/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "http://issues.apache.org/jira/browse/HTTPCLIENT"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "commons-codec",
+            "name": "commons-codec",
+            "version": "1.11",
+            "description": "The Apache Commons Codec package contains simple encoder and decoders for various formats such as Base64 and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "567159b1ae257a43e1391a8f59d24cfe"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "3acb4705652e16236558f0f4f2192cc33c3bd189"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "9ae3d8fd4c38f3af52c76c5f98039109901cb0f70700e6d9999b27cc4b30b188e2688aa4adcf6b846376bc3ca125907a"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "d9586162b257386b5871e7e9ae255a38014a9efaeef5148de5e40a3b0200364dad8516bddd554352aa2e5337bec2cc11df88c76c4fdde96a40f3421aa60650d7"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "90ec34f9701a8b212c65e6167c505ea6417289f910deedcac8517075b8349728"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "bd272e22540371e7d834cd897bce9be657293ba9c5584e0d47a4073711dacb524cc59e294e942ffc01613d17ac7d6ac1"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "101bc04efae2bd16d7923e61bca922c4a006b0e4b34909e0f8865196cb4df4f4f6269737c17880b4dfd0309cb487b806e88d09c6e1a7dc70237563b3f4312f7f"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/commons-codec/commons-codec@1.11?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "http://issues.apache.org/jira/browse/CODEC"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://svn.apache.org/viewvc/commons/proper/codec/trunk"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://builds.apache.org/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/commons-user/"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-codec/commons-codec@1.11?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.httpcomponents",
+            "name": "httpcore",
+            "version": "4.4.15",
+            "description": "Apache HttpComponents Core (blocking I/O)",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "be7c67929df007fcac6c8eff5322d3a0"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "7f2e0c573eaa7a74bac2e89b359e1f73d92a0a1d"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "3cbaed088c499a10f96dde58f39dc0e7985171abd88138ca1655a872011bb142"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "fffa9cd7434271990e20230ef9c3754f4b198958437573cdec2d4e7063147a765cb0cdf0b79a9688e81ff85dc704c25b"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "f0605e4d521c6e9c7e645905687c519239fa9e2128403a515e6118b0406b503b0865a8ead197f8532186b0c9aaa4189ff5bb301d5b0cf84bd54fa2258d17551d"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "3290e3547fd3ea688f30ba6a554c779c784bb209642ec4d48b284ca8374191b3"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "0b72d65d0c3a7d74d1baf1a2fc4e9510e64bd34f7b23f52d436621d2043d81b5395c9b05803e7471537964ac42e2fe94"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "230b7196270183aaaf5e89e8d7598a3c65ac6bbede816e222e6d457fe5fca50fbe8ca2cb30ecf161bf4ddf34a08ee3a95d2f559e0aa513e9e730eeb5624b296b"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.15?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.apache.org/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "http://issues.apache.org/jira/browse/HTTPCORE"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.15?type=jar"
+        },
+        {
+            "publisher": "QOS.ch",
+            "group": "org.slf4j",
+            "name": "jcl-over-slf4j",
+            "version": "1.7.36",
+            "description": "JCL 1.2 implemented over SLF4J",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "8065610cde33ed9fd5d34367912c1938"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "d877e195a05aca4a2f1ad2ff14bfec1393af4b5e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "ab57ca8fd223772c17365d121f59e94ecbf0ae59d08c03a3cb5b81071c019195"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "618704032ab3f8f87091ac797e2c9319a4b7f36a53e060695d56173b67ce9bc9e16c74cba228e758ac90e279df75428a"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "ac231ab44521bb5478742af13624db5c14aea809c3a2c13b989fba30186ba6db840f2d1b4aea54f9c1f779547b975fd042dd353f54025592774d40192bd71148"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "7aef3380fdeae9b7a4adfa6ad69c2c92f246fcdbd4fcd3d1056ee846d8ef92fb"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "95a189173932d8080d91de8b71b9d1bca49a330db7cad9c41d51fe9514a9f6299b24e31441f06681b3dcc188807dcf40"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "da7d1b8e5a150300e1051dda5755df64275e5822256ef624fd8a37c582cc2774aadce97f8732de52e54b1c74e28ba601d3bfc3482abb4a24f7e9f779e7e8dd64"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.36?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.qos.ch"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/qos-ch/slf4j"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.36?type=jar"
+        },
+        {
+            "publisher": "QOS.ch",
+            "group": "org.slf4j",
+            "name": "slf4j-api",
+            "version": "1.7.32",
+            "description": "The slf4j API",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "fbcf58513bc25b80f075d812aad3e3cf"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "cdcff33940d9f2de763bc41ea05a0be5941176c3"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "3624f8474c1af46d75f98bc097d7864a323c81b3808aa43689a6e1c601c027be"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "c95aa5a652533b3b54e721b7f20c4ef19a022ac6c8cd353b032bfd65f636b1adc3eb2e5ca0b409f19456e265cbfd3cb0"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "4ca4045775a879c3ce3021908db7b4778235a322fd8e2567da960156f24b9da86e6812a4956c8dc19920cd83e4c61141168c580829f43f10bbac925d465c3fd1"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "f6a3b253b2c5a06a9559fd9f21e36d04198e660d4e9437ddeb78245969f03fe4"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "b08f2d668d9233a3380c37c028486014db65000e918aa1c59e2db35fb5661b3a40183e51677b73a5d96a308f9c2346c0"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "0a45c046c106cf88a510bde208b1ac92d7b3dc547b2516583afdbb829219ec31b0bba9fc4b7fd240d2ef859abb722ce307f9572d87409d261887130a5df6827d"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "MIT",
+                        "url": "https://opensource.org/licenses/MIT"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.qos.ch"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/qos-ch/slf4j"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar"
+        },
+        {
+            "publisher": "QOS.ch",
+            "group": "org.slf4j",
+            "name": "slf4j-simple",
+            "version": "1.7.32",
+            "description": "SLF4J Simple binding",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "2a97fb2dbc6d061009dcccb8481dd9b1"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "321ffafb5123a91a71737dbff38ebe273e771e5b"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "d2fdd7b73ca2019a2062d145a0d86179a58f98c8c3e35ca7c735a27b3b5621c3"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "c747140ea8d18e4e59b939f9956f61dd916a33db5cadfe1ad0cf54b1a718a9ee530d779e39daaf434a1516c53ca53847"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "4fd5226c071f6ed7884264008b383dc012d46e8025a4e80d03c9e3ba548f75d3c39775f19219c37d0320fc14a2a4d502d0f1755a828ded4fd64e639077042db6"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "8df78b5ebc0ba037c95422ba5e0c40fe92e6ad0b40bf0e53d363da8fee03b00a"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "606b1b85624f90713a52c697b81dfb33617b01d460e95b40f447a5c25435075b8468664d289db9ad53e062e627ce5668"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "7bf2f430572f6c5627846dea316def4d8300807d5b46761729c471ba2c1151ade8af34bd982416bd8f6a9d04fcdc5271474a851c07607af9dddcde0da9febe31"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "MIT",
+                        "url": "https://opensource.org/licenses/MIT"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.slf4j/slf4j-simple@1.7.32?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.qos.ch"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/qos-ch/slf4j"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/slf4j-simple@1.7.32?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-core",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.shared",
+            "name": "maven-shared-utils",
+            "version": "3.3.4",
+            "description": "Shared utilities for use by Maven core and plugins",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "908f2a0107ff330ac9b856356a0acaef"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "f87a61adb1e12a00dcc6cc6005a51e693aa7c4ac"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "bc5b42831ff598f42dda54738be004a619d60201a009b04cb3aaa0dc343d0e4fbc423b19739391eb7c33efcac3c08dd5"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "c6693f8a061de74ac59c61d185f5b130cb574405cfc37febb8e73806ea64eea822a4a75c24098fb49b7871373091543a6f4c526c0842589e528cacad40e5554a"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "888fde30d4f9a9e1b7c4c5e4d61f9cf0499192e5bc1212538e2e3320688e44da"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "385bebb35d7ea13d92ae6a5afa9257b184a1fcf40cba077a103c7a91d39a4d3e0180a475febdba73ac75949968e77186"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "40b55bb907452777443b8162d456bf1d48e02bfd9124062faed9c9bf51e0f522d40b02f4c24eb39f760469ad226570876f0de6afecd74903112ec794f0aa9a78"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-shared-utils/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/issues/?jql=project%20%3D%20MSHARED%20AND%20component%20%3D%20maven-shared-utils"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "commons-io",
+            "name": "commons-io",
+            "version": "2.6",
+            "description": "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "467c2a1f64319c99b5faf03fc78572af"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "815893df5f31da2ece4040fe0a12fd44b577afaf"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "1efcb8c663fff4cf7f2bc86e1a367b5f88819a6a2f80341fd5d41ad82eb0adda9f34a05c20115f461bee64d1ab487e3c"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "4de22e2a50711f756a5542474395d8619dca0a8be0407b722605005a1167f8c306bc5eef7f0b8252f5508c817c1ceb759171e4e18d4eb9697dfdd809ac39673f"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "12e088d6b2f63a97e29d4cf1a81dbe311a0110e784677698a2eaa0b63785dc6e"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "47f8067345da2e60493ced8f5852b5a9ee5fd1ee141c03177f132f97fa4beccd3c3f649276cbcb06a3fa2d0b39e20369"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "82e8aa5fb7b8801b94c83f912dc863ff1b569a281081d33ca7e512a694202aebb60101b54bc9ba0a3b6a769221667a3d222b67102377d554603678798ca22d07"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/commons-io/commons-io@2.6?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "http://issues.apache.org/jira/browse/IO"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://git-wip-us.apache.org/repos/asf?p=commons-io.git"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://builds.apache.org/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/commons-user/"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-io/commons-io@2.6?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "commons-jxpath",
+            "name": "commons-jxpath",
+            "version": "1.3",
+            "description": "A Java-based implementation of XPath 1.0 that, in addition to XML processing, can inspect/modify Java object graphs (the library's explicit purpose) and even mixed Java/XML structures.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "61a9aa8ff43ba10853571d57f724bf88"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "c22d7d0f0f40eb7059a23cfa61773a416768b137"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "fcbc0ad917d9d6a73c6df21fac322e00d213ef19cd94815a007c407a8a3ff449"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "327139dac9f672ffa772480a754ec6c3125a3057faf7911188a34cc52d088770efe8464bb303e2347be7f55303d24493"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "351c5f6af0711a955e5d839551833015956812765e9dc35e78bfd7c99656f1ecec5cf6587469229688340f00c2b5d07917993ccb0809561e0dd35b4ffb074d93"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "3bbafe102ece8be037419a214a524f0c52fa0c3455322d3c2633f1c075e9efbc"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "b2913b137433bfc2fe78ed57dc44de5737410947e809c0b8bb1d6a83ad333069e41fd97167c20e9fd3a052c2a7dfa9b8"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "e050591ecd10746ffee670e1e95a53afa8b43b01164c3ae581bce9ee0a5410eece3f71d05175486eb4d186de88d5defeebef52730939611951ca1cd50ec978a7"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "http://issues.apache.org/jira/browse/JXPATH"
+                },
+                {
+                    "type": "vcs",
+                    "url": "http://svn.apache.org/repos/asf/commons/proper/jxpath/trunk"
+                },
+                {
+                    "type": "build-system",
+                    "url": "http://vmbuild.apache.org/continuum/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/commons-user/"
+                },
+                {
+                    "type": "website",
+                    "url": "http://www.apache.org/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest-library",
+            "version": "2.2",
+            "description": "A library of Hamcrest matchers - deprecated, please use \"hamcrest\" instead",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "e55927fb7e4a3c7a4ecd325677ea8cb3"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "cf530c8a0bc993487c64e940ae639bb4a6104dc6"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "3851523a201a0d4825c25a61a6edc50712825a39bd3d03391b98c48ca3cb396c"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "8340f2168dc13e4b55f080d05a3db191c00dc55dc9ae750a6c6b21891fd416fa26fd772ea06bc215423037572121a62c"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "00cad2b303f3203b9c11e869f5afb085f348a3c9767cd636809dbd8842cbb62cf5dd60d7c3bbb9b3cc986202fc5b2c18f1066e3a9b778ef06776cf63ef78dddd"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "624ed20d38b8fc2abbf0f8a0363790e7b13ed6661bc15b95eb0664ba0352bea0"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "f3922b80af857e40ce57ee8414cc2d3fb2474a2a6fd6db7c1259d10c9e668c92578f2a72a547526b57f76ae9118f06e4"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "4daed173e054b212bda87a1651aec8c63ee176f3b14bd46b732fe667a61c31e8f987cea53e8bef6823172ec49763782a1b974db0fe2a48a479ef40bb48d72a15"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "BSD-3-Clause",
+                        "url": "https://opensource.org/licenses/BSD-3-Clause"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.hamcrest/hamcrest-library@2.2?type=jar",
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/hamcrest/JavaHamcrest"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest-library@2.2?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-slf4j-wrapper",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-slf4j-wrapper@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-slf4j-wrapper@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-slf4j-provider",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-slf4j-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-slf4j-provider@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-embedder",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-embedder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-embedder@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "QOS.ch",
+            "group": "ch.qos.logback",
+            "name": "logback-classic",
+            "version": "1.2.11",
+            "description": "logback-classic module",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "e13679004cc76ad5792f275f04884fab"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "4741689214e9d1e8408b206506cbe76d1c6a7d60"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "4d8e899621a3006c2f66e19feab002b11e6cfc5cb1854fc41f01532c00deb2aa"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "d480881d1a0d58c94aba0b719d56cd492147bc6481b67370dc7426ea7a81326af5b19f32d6a95fee714f37b90a5eed76"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "6df8b42396c5d3257f11fb19c280533aa28d66e647115816d4ebfd6a58c9b5adf0e098504772261b29435df75b86cb2b9a47f846ed45d770179c9d10f39941de"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "60c1dbe51066ffb3885673255a279e8894c89fe26f079180fa992478c1d9b03e"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "070647c93da744f04cc13ab3f1958c61a8b1e219fe221ed0bf251e4cc97563c64be323bfb3a9e2fd4839e33ded424b21"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "ce16fae69767bca975bec0d7dd0ceeb40c15cf034a4a949721c828a0f2c25cb9d619c4db3f986f6d9805d5b76d27b8926c55be5579522cd5ab3fa5e69bb68aeb"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "EPL-1.0"
+                    }
+                },
+                {
+                    "license": {
+                        "name": "GNU Lesser General Public License",
+                        "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.qos.ch"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/ceki/logback"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar"
+        },
+        {
+            "publisher": "QOS.ch",
+            "group": "ch.qos.logback",
+            "name": "logback-core",
+            "version": "1.2.11",
+            "description": "logback-core module",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "115da115b5e66ef64e774ec35af1fb1a"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "a01230df5ca5c34540cdaa3ad5efb012f1f1f792"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "6ce1e9397be8298a2e99029f55f955c6fa3cef255171c554d0b9c201cffd0159"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "2afd896ebe6333d99e5baa553d80b7851d8ff51c06c725267e061df81bc9a878b74a65394699ae853f9738a08963aa0a"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "86b12a74c2a822a12ba2e9a7b0db5013803f18784a3cb1201c95d5f7872a6aa8cf06d5861a5c35777a7decc7ea26df7b4388fab3b3b71aab7274527d9b339318"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "c23af1733b972e958369a2e14372fd2b306d4f552d7ae5ff6b9dfad3c14611c6"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "43d39acc5608b60d671c000bf6114f4623d3057399142abca01b0fc2381f2191479a2f0dd74f812223b66f57fa48fd9c"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "c7f6357d32a3b9fd82dfbd162c3a6cbe4b4909ef530e956bcd18649b2d3624eb51c5a71fee54533a9786e87cf1ccdc693f563ef6e3c6fbff7beedbd1d670f9bb"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "EPL-1.0"
+                    }
+                },
+                {
+                    "license": {
+                        "name": "GNU Lesser General Public License",
+                        "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.qos.ch"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/ceki/logback"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "commons-cli",
+            "name": "commons-cli",
+            "version": "1.5.0",
+            "description": "Apache Commons CLI provides a simple API for presenting, processing and validating a Command Line Interface.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "6c3b2052160144196118b1f019504388"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "dc98be5d5390230684a092589d70ea76a147925c"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "bc8bb01fc0fad250385706e20f927ddcff6173f6339b387dc879237752567ac6"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "a7a2daa807c4007c506b5100f0a9b526c0052c4e1f6b699904ef9d2aba8195b6003dc4d47ca133b15e2f3e830bdbe6c4"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "b78ac2b418e9e9e7d0bc866664577199d320408a6f03151b3789bac365c986dd526df853599e633d7e50fe136cbf3eb9ce50c9cfa0ad38c3cc8d8ee416f61c40"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "a0a47001d3a293f129ffc21f17f575a9d23ce5b88b440e651e4cd01edd0cc421"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "44ca97514a2e34b5bf3de9b5d45c8e871f6eee517db7f3c4b4476eb3e8dfe9a9d8760f3181114708288c373727b42475"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "483dae23d6827a105d17847c8c813527f19042b65c4d09635dfc4bfd25990fe3ba2a997540460fd5b1d72ca3add9a38ca8b32004680764db972a9bb62f7f68d8"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/CLI"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://gitbox.apache.org/repos/asf?p=commons-cli.git"
+                },
+                {
+                    "type": "build-system",
+                    "url": "https://builds.apache.org/"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://mail-archives.apache.org/mod_mbox/commons-user/"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar"
+        },
+        {
+            "publisher": "FuseSource, Corp.",
+            "group": "org.fusesource.jansi",
+            "name": "jansi",
+            "version": "2.4.0",
+            "description": "Jansi is a java library for generating and interpreting ANSI escape sequences.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "bb0f7e4e04a71518dfe5b4ec102aa61f"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "321c614f85f1dea6bb08c1817c60d53b7f3552fd"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "6cd91991323dd7b2fb28ca93d7ac12af5a86a2f53279e2b35827b30313fd0b9f"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "766087de6a3e179c3596bef5730adb933a6cd93b88c8d4ffef728aa39c4fb9a008597aeef75b7484b8982908be258fc9"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "7a6a8952b07302cd2ae1beec3241c36cdaa24215b23671ea4a47eb70b3430e99398e3b9a52c6fdaa017e464b5ee5ef5473da250df06c301c5331f7b4535ce4e7"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "38cff35fadbf292a584a8bd8cbe5ba9dca6cd5ad0ad2aafb68c3e1cddbba962c"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "5648c2fae00d502517d51edd769126aa71a1c43b899b3c5046016e1536e3dbac406b82115cc5281cc8097210bff3b9bf"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "c13b48dce288ea096546d84696d565c6161ee12360cf7832a7d562ccfd6e289c053e2bde1fa447401bfeb688648decd0c0d596c773d6191aed32d8ecf60e7c72"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.fusesource.jansi/jansi@2.4.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/fusesource/jansi/issues"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://groups.google.com/group/jansi"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/fusesource/jansi"
+                },
+                {
+                    "type": "website",
+                    "url": "http://fusesource.com/"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.fusesource.jansi/jansi@2.4.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "maven-compat",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/maven-compat@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/maven-compat@4.0.0-alpha-1-SNAPSHOT?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.wagon",
+            "name": "wagon-provider-api",
+            "version": "3.5.1",
+            "description": "Maven Wagon API that defines the contract between different Wagon implementations",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "1c9c31b230017042a508cf7ebbbf79ea"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "118e63f22d05b14535451933ae207be47ec45d91"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "b215d27bfcec3ff8d00d3f6cdc8807f271b8cc270fcebf4f06a67fb90a2aa227"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "d1990ae9771494a1af5d2b68dd56bcd6c1e0e83d0d3a09ade0d0d94b3b94f6a5af1d8d63c970038a2772ce9a99e8796c"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "6a9e95dd6a2d4c040f3564fd76ae2c290eb3787bdb0a84e2c9caaa1d252eae9bcd3cf6768da652e1790ca8ca54a857213336d5ef606ed61c24b3aef96aadfa3f"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "189da5aa97a16efd60a6dc830c6d777eeda0a6e338a653b40595f48efa5985a2"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "4dd570bc91539f0bf9745efd1b96af43ecc8f7da30e4d50179ede9b898c55803b7c109399067ec47643fbefc63ffcb4e"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "49bc7f7df90907b11c27f4d88e085a1d2709e091a5da20355f67f44e7f6cae32e9447a6d65608e53a552cb79c1283c9c63b4123477eb9ddf20ff93e9aeec80c7"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.5.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-wagon/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/WAGON"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/maven-dev"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.5.1?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.wagon",
+            "name": "wagon-file",
+            "version": "3.5.1",
+            "description": "Wagon provider that gets and puts artifacts using file system protocol",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "25a3cd8e3af6021662b7d65955547165"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "292e503e558e6758fc3a6d26a80b46017d4fedea"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "48f0b78df175140ac331819aa288eb1d9899a6ff39ffae0d82a7839687a30ddc"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "1077d5f1f06b058bb6eac18e442f58e921d91742595b2cc063785a27f61abbec5339a22c8dd1f980b6d22628d571e4e8"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "9ff32a1a7478b4e0a6f034d6ef847b26e858ba04f99809c868e4cf070ae369fd754e6476a64e150c194ce44700a56c3ac3c1cb941483805c2187b4be9c16cfd1"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "6481f00c12cf4366530d493aea3019a659dbefb9439ea93886c666e453fe40da"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "f9b8d6f241b3d2a30f30b478ff3e705b87edbf976f1ddf517feb90ec38b9746eb1831fed03e0339724d14439da3395b1"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "c582d783508588da805ef67c64b0152543c8f9dc1688211617f19fffb5c9beed975e3d4cf7a8cb68775f82286675f2aa88f94a262f31b78a4949faf247b207ac"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.wagon/wagon-file@3.5.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-wagon/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/WAGON"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/maven-dev"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-file@3.5.1?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.resolver",
+            "name": "maven-resolver-transport-wagon",
+            "version": "1.8.0",
+            "description": "A transport implementation based on Maven Wagon.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "69a037f14a01fd5503992ef9835fa042"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "81485e75fadc807ce20426d1a1936261de2b9c03"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "95a3e1c7df7493b25d1aea5a115ce5f37a1c90a56954dbb4aaa5dd46beaecb0d"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "07f078f55de2ca88d49a7f2263918b634015192101395b063fca66bf7cc7e77f63f878492e61fa5a55f22191552a751e"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "e4fa47055705206c0fbe3cb8f325ba8d9c6aefde7f0bacab4c9478bec7e5bf3ca689a3bde8ef159f4c2413775a9070ccd61916008c510e3977c9fa1c83b8c7fa"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "b78e514c410255e94949bdf32696026ad6fd29766c9aeee0ae4e5474edc9ab78"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "02d036edff39e1acc39916df7010c67b15d17d9d2051867e49d45bc4726c2ff0b027a88e81c87ae5cfdf732e6b00fdbc"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "c21ebe9b83693685cd73e110fe557063ba2a05aa04313600019df23dc5d068eff6d816310bb87383c498eb454315e011fd49879d18e3b08acb131e15f47441b8"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.8.0?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/MRESOLVER"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "https://lists.apache.org/list.html?users@maven.apache.org"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.8.0?type=jar"
+        },
+        {
+            "group": "org.apache.maven",
+            "name": "apache-maven",
+            "version": "4.0.0-alpha-1-SNAPSHOT",
+            "purl": "pkg:maven/org.apache.maven/apache-maven@4.0.0-alpha-1-SNAPSHOT?type=pom",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven/apache-maven@4.0.0-alpha-1-SNAPSHOT?type=pom"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.wagon",
+            "name": "wagon-http",
+            "version": "3.5.1",
+            "description": "Wagon provider that gets and puts artifacts through HTTP(S) using Apache HttpClient-4.x.",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "51740fea71f662c81fdab3ae13739d61"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "06f1cf071afb2d3b1190d7ef047e24f7c3edff11"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "4056e8185ee53213192694135cc4e06e31129e1f8e8bfa8a6d5fb6a2d54bbc89"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "4456281c0ddca089e2d1dd0d8274bf9bd5d02a13c5e4ca525ace9da1d5912a67d9b9f2bd630be38fed8ed7d1f7b65d05"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "305f12677ccfc18d9291e6c08c782cfce804f907954c66b27674c944442147a8db42b22edbfa2fa526ce94f4134960de316cde2092b6630718b43fff6c89282c"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "c79f99067e437f7cf00525ab47b936e370d7461ea64f908f769221d6d9f2090b"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "eb07287d0053ab829f52fbafa454a5272248c0be08f9979860cc97e8d2501b2d81520a55033693bf29b166dfe9d8f339"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "7d80eff54dbac30d1bfb69e6dbd4413a9ca281f978c37bea69ab93fba78a038eb5575c1a98a2f1a59ebcfe70ef3dc99eab394434b704c84085a9eea11bd449b6"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.wagon/wagon-http@3.5.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-wagon/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/WAGON"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/maven-dev"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http@3.5.1?type=jar"
+        },
+        {
+            "publisher": "The Apache Software Foundation",
+            "group": "org.apache.maven.wagon",
+            "name": "wagon-http-shared",
+            "version": "3.5.1",
+            "description": "Shared Library for wagon providers supporting HTTP.",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "500f50a3f0780c05510308ed5ec393e0"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "5f7371f8f061d386e4c1af530c34263371d8f583"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "9e7d6c7a1671a98e43f0a22c303c23a686b65002e25f014481882556f41ce627"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "e5a3b00dd8611d1a803db7417088f03bcd7802983f276da2bdd0b76f636567da6890a27a2e88942c26902d2feb8987e5"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "d5dc1c2b7124eab9608d4ff0e3564d8e923539d5092bf4df8ba49b6cb95f7326c971e6d1ccad3ce7b46f4304e3bd1e2ed39f1cf81edfff83bbe77bfed96f2fd9"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "4e46e7f34f36f99d7845b3fef72fdf2de6be0ab122d3c9fb7161c0e68cb8ee63"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "d0dd51e2c66c1453196c6579fc5b5049a4c5d93da6fe1f1a4c91626529dfcd88cc33eb9dab7513c2586b38fd63b52d46"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "34325d8574bc853545d0fa293dd4fecb851dc3082067724eba03ff668360f2d88cee58853d94570a6bbcbb0c34e94dcd38b2705b379b910319b8d16837be5f50"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.5.1?type=jar",
+            "externalReferences": [
+                {
+                    "type": "build-system",
+                    "url": "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-wagon/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://issues.apache.org/jira/browse/WAGON"
+                },
+                {
+                    "type": "mailing-list",
+                    "url": "http://mail-archives.apache.org/mod_mbox/maven-dev"
+                },
+                {
+                    "type": "website",
+                    "url": "https://www.apache.org/"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://repository.apache.org/service/local/staging/deploy/maven2"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.5.1?type=jar"
+        },
+        {
+            "publisher": "QOS.ch",
+            "group": "org.slf4j",
+            "name": "jcl-over-slf4j",
+            "version": "1.7.32",
+            "description": "JCL 1.2 implemented over SLF4J",
+            "scope": "optional",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "8788169f5d5be6550efc75d3bfffc82c"
+                },
+                {
+                    "alg": "SHA-1",
+                    "content": "32c060250bcc5282cdbc1fd7008c12eb4ebad00e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "60f3bda5922e3912889cca1311d1b227753610bf60cb4e5e914e8b2eaa0326b4"
+                },
+                {
+                    "alg": "SHA-384",
+                    "content": "f1b69471e3c75cd1c13f6557666ebc4b01c676cce3bd2cb19720471dcca98333b9573b468cfe308abd7cf297cee59133"
+                },
+                {
+                    "alg": "SHA-512",
+                    "content": "55b0678cbe5359d7fabcec55f305997170b0d45264b5cc0577cc9137ac2388a459b86c5438b5850d6e7247d3a00486f83f4b7e305b0eb756a52d3e5c5466ddbd"
+                },
+                {
+                    "alg": "SHA3-256",
+                    "content": "f515d8b3b683bd709ce241190b40b6f8266b392da6e69b0e637377f488e6d38f"
+                },
+                {
+                    "alg": "SHA3-384",
+                    "content": "2df2a1639c379ed6962a039804e7613ba9cde8ec612c94062d9375d1071b2870edb58f3b9d407650a13dce61bcb69d29"
+                },
+                {
+                    "alg": "SHA3-512",
+                    "content": "dd2156b7589ce3989471e856cb65ebb50af00a23aef1a2b80ca7ee5f8a4c4573a7887f54559784e710fa8a089ea57ff04c0a80f804710e956cbaebac11c647b2"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "purl": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32?type=jar",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "http://www.qos.ch"
+                },
+                {
+                    "type": "distribution",
+                    "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/qos-ch/slf4j"
+                }
+            ],
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32?type=jar"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-bom@4.0.0-alpha-1-SNAPSHOT?type=pom",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar",
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-plugin-api@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-transform@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-toolchain-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-toolchain-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-resolver-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-slf4j-wrapper@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-slf4j-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-embedder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-compat@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/apache-maven@4.0.0-alpha-1-SNAPSHOT?type=pom"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.junit.platform/junit-platform-engine@1.8.1?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.1?type=jar",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.1?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0?type=jar",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.8.1?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.hamcrest/hamcrest@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest@2.2?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-plugin-api@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+            "dependsOn": [
+                "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.5?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.5?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-model-transform@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.1?type=jar",
+                "pkg:maven/org.xmlunit/xmlunit-assertj@2.6.4?type=jar",
+                "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.1?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.1?type=jar",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-assertj@2.6.4?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.xmlunit/xmlunit-core@2.6.4?type=jar",
+                "pkg:maven/org.assertj/assertj-core@2.9.0?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-core@2.6.4?type=jar",
+            "dependsOn": [
+                "pkg:maven/javax.xml.bind/jaxb-api@2.3.0?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/javax.xml.bind/jaxb-api@2.3.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.assertj/assertj-core@2.9.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+            "dependsOn": [
+                "pkg:maven/net.bytebuddy/byte-buddy@1.10.3?type=jar",
+                "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.3?type=jar",
+                "pkg:maven/org.objenesis/objenesis@2.6?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.3?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.3?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.objenesis/objenesis@2.6?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-transform@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.5?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar",
+                "pkg:maven/com.google.guava/guava@30.1-jre?type=jar",
+                "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+                "pkg:maven/org.xmlunit/xmlunit-core@2.6.4?type=jar",
+                "pkg:maven/org.xmlunit/xmlunit-matchers@2.6.4?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/javax.inject/javax.inject@1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar",
+            "dependsOn": [
+                "pkg:maven/aopalliance/aopalliance@1.0?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/aopalliance/aopalliance@1.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.google.guava/guava@30.1-jre?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-matchers@2.6.4?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-sec-dispatcher@2.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-sec-dispatcher@2.0?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-cipher@2.0?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-cipher@2.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-toolchain-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-toolchain-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-toolchain-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+                "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-resolver-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.8.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar",
+                "pkg:maven/com.google.guava/guava@30.1-jre?type=jar",
+                "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-testing@1.0.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-file@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-http@1.8.0?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+                "pkg:maven/org.slf4j/slf4j-simple@1.7.32?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.8.0?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-named-locks@1.8.0?type=jar",
+                "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-named-locks@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.codehaus.plexus/plexus-testing@1.0.0?type=jar",
+            "dependsOn": [
+                "pkg:maven/com.google.inject/guice@4.2.3?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.1?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.google.inject/guice@4.2.3?type=jar",
+            "dependsOn": [
+                "pkg:maven/aopalliance/aopalliance@1.0?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-file@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-http@1.8.0?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+                "pkg:maven/org.apache.httpcomponents/httpcore@4.4.15?type=jar",
+                "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.36?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+            "dependsOn": [
+                "pkg:maven/commons-codec/commons-codec@1.11?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/commons-codec/commons-codec@1.11?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.15?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.36?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/slf4j-simple@1.7.32?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-toolchain-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-toolchain-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-plugin-api@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-transform@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-resolver-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-spi@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.inject@0.3.5?type=jar",
+                "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar",
+                "pkg:maven/com.google.guava/guava@30.1-jre?type=jar",
+                "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+                "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+                "pkg:maven/org.slf4j/slf4j-simple@1.7.32?type=jar",
+                "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar",
+                "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-library@2.2?type=jar",
+                "pkg:maven/org.xmlunit/xmlunit-assertj@2.6.4?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-testing@1.0.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+            "dependsOn": [
+                "pkg:maven/commons-io/commons-io@2.6?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/commons-io/commons-io@2.6?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest-library@2.2?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-slf4j-wrapper@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-library@2.2?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-slf4j-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+                "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+                "pkg:maven/org.apache.maven/maven-slf4j-wrapper@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-embedder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-plugin-api@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-builder-support@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.shared/maven-shared-utils@3.3.4?type=jar",
+                "pkg:maven/org.apache.maven/maven-slf4j-wrapper@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/com.google.inject/guice@4.2.3?classifier=no_aop&type=jar",
+                "pkg:maven/com.google.guava/guava@30.1-jre?type=jar",
+                "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-classworlds@2.6.0?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-sec-dispatcher@2.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-cipher@2.0?type=jar",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.32?type=jar",
+                "pkg:maven/org.slf4j/slf4j-simple@1.7.32?type=jar",
+                "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+                "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+                "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar",
+                "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+                "pkg:maven/org.fusesource.jansi/jansi@2.4.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.fusesource.jansi/jansi@2.4.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/maven-compat@4.0.0-alpha-1-SNAPSHOT?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-model@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-model-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-settings-builder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-artifact@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-resolver-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-repository-metadata@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-api@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-util@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-impl@1.8.0?type=jar",
+                "pkg:maven/javax.inject/javax.inject@1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-utils@3.3.0?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-interpolation@1.26?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-component-annotations@2.1.0?type=jar",
+                "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.5.1?type=jar",
+                "pkg:maven/org.codehaus.plexus/plexus-testing@1.0.0?type=jar",
+                "pkg:maven/org.mockito/mockito-core@3.2.0?type=jar",
+                "pkg:maven/org.apache.maven.wagon/wagon-file@3.5.1?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.8.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.wagon/wagon-provider-api@3.5.1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.wagon/wagon-file@3.5.1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.8.0?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven/apache-maven@4.0.0-alpha-1-SNAPSHOT?type=pom",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven/maven-embedder@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-core@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.apache.maven/maven-compat@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.eclipse.sisu/org.eclipse.sisu.plexus@0.3.5?type=jar",
+                "pkg:maven/commons-cli/commons-cli@1.5.0?type=jar",
+                "pkg:maven/org.apache.maven.wagon/wagon-http@3.5.1?type=jar",
+                "pkg:maven/org.apache.maven.wagon/wagon-file@3.5.1?type=jar",
+                "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-connector-basic@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-file@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-http@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven.resolver/maven-resolver-transport-wagon@1.8.0?type=jar",
+                "pkg:maven/org.apache.maven/maven-slf4j-provider@4.0.0-alpha-1-SNAPSHOT?type=jar",
+                "pkg:maven/org.fusesource.jansi/jansi@2.4.0?type=jar",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.1?type=jar",
+                "pkg:maven/org.hamcrest/hamcrest-core@2.2?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.wagon/wagon-http@3.5.1?type=jar",
+            "dependsOn": [
+                "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.5.1?type=jar",
+                "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+                "pkg:maven/org.apache.httpcomponents/httpcore@4.4.15?type=jar"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.maven.wagon/wagon-http-shared@3.5.1?type=jar",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.32?type=jar",
+            "dependsOn": []
+        }
+    ]
+}

--- a/tests/integration/cases/apache_maven_sbom_with_no_deps_resolution/test.yaml
+++ b/tests/integration/cases/apache_maven_sbom_with_no_deps_resolution/test.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing using a CycloneDx SBOM but --deps-depth is not set or set to 0. Macaron should exit on error.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze using an SBOM but --deps-depth is not set
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/org.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom
+    - -rp
+    - https://github.com/apache/maven
+    - -b
+    - master
+    - -d
+    - 3fc399318edef0d5ba593723a24fff64291d6f9b
+    sbom: sbom.json
+  expect_fail: true
+- name: Run macaron analyze using an SBOM but --deps-depth is set to 0
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/org.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom
+    - -rp
+    - https://github.com/apache/maven
+    - -b
+    - master
+    - -d
+    - 3fc399318edef0d5ba593723a24fff64291d6f9b
+    - --deps-depth=0
+    sbom: sbom.json
+  expect_fail: true

--- a/tests/integration/cases/apache_maven_sbom_with_no_deps_resolution/test.yaml
+++ b/tests/integration/cases/apache_maven_sbom_with_no_deps_resolution/test.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
-  Analyzing using a CycloneDx SBOM but --deps-depth is not set or set to 0. Macaron should exit on error.
+  Analyzing using a CycloneDx SBOM. Macaron should not exit on error when --deps-depth is not set or set to 0.
 
 tags:
 - macaron-python-package
@@ -21,7 +21,6 @@ steps:
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
     sbom: sbom.json
-  expect_fail: true
 - name: Run macaron analyze using an SBOM but --deps-depth is set to 0
   kind: analyze
   options:
@@ -36,4 +35,3 @@ steps:
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
     - --deps-depth=0
     sbom: sbom.json
-  expect_fail: true

--- a/tests/integration/cases/apache_maven_using_default_template_file_as_input_template/test.yaml
+++ b/tests/integration/cases/apache_maven_using_default_template_file_as_input_template/test.yaml
@@ -20,7 +20,6 @@ steps:
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
     - -g
     - macaron.html
-    - --skip-deps
 - name: Run verify-policy
   kind: verify
   options:

--- a/tests/integration/cases/apache_maven_with_dep_resolution/test.yaml
+++ b/tests/integration/cases/apache_maven_with_dep_resolution/test.yaml
@@ -21,6 +21,7 @@ steps:
     - master
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
+    - --deps-depth=1
 - name: Compare dependency report
   kind: compare
   options:

--- a/tests/integration/cases/apache_maven_yaml_input_no_deps_and_skip_deps/test.yaml
+++ b/tests/integration/cases/apache_maven_yaml_input_no_deps_and_skip_deps/test.yaml
@@ -18,7 +18,6 @@ steps:
     - https://github.com/apache/maven
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 - name: Compare dependency report
   kind: compare
   options:

--- a/tests/integration/cases/apache_maven_yaml_input_skip_deps/test.yaml
+++ b/tests/integration/cases/apache_maven_yaml_input_skip_deps/test.yaml
@@ -18,7 +18,6 @@ steps:
     - https://github.com/apache/maven
     - -d
     - 3fc399318edef0d5ba593723a24fff64291d6f9b
-    - --skip-deps
 - name: Run macaron analyze google/guava
   kind: analyze
   options:

--- a/tests/integration/cases/apache_maven_yaml_input_skip_deps/test.yaml
+++ b/tests/integration/cases/apache_maven_yaml_input_skip_deps/test.yaml
@@ -27,7 +27,6 @@ steps:
     - https://github.com/google/guava
     - -d
     - d8633ac8539dae52c8361f79c7a0dbd9ad6dd2c4
-    - --skip-deps
 - name: Run macaron analyze mockito/mockito
   kind: analyze
   options:
@@ -36,7 +35,6 @@ steps:
     - https://github.com/mockito/mockito
     - -d
     - 512ee3949484e4765038a0410cd7a7f1b73cc655
-    - --skip-deps
 - name: Run macaron verify-policy for maven
   kind: verify
   options:

--- a/tests/integration/cases/behnazh-w_example-maven-app/test.yaml
+++ b/tests/integration/cases/behnazh-w_example-maven-app/test.yaml
@@ -24,7 +24,6 @@ steps:
     - pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0-SNAPSHOT?type=jar
     - --repo-path
     - example-maven-app
-    - --skip-deps
     expectation: witness_provenance_expectation.cue
     provenance: witness_provenance.jsonl
 - name: Run macaron analyze on the remote repository with GitHub provenance.
@@ -33,7 +32,6 @@ steps:
     command_args:
     - --package-url
     - pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar
-    - --skip-deps
     expectation: github_provenance_expectation.cue
     provenance: github_provenance.jsonl
 - name: Run macaron verify-policy
@@ -60,7 +58,6 @@ steps:
     - https://github.com/behnazh-w/example-maven-app
     - -d
     - 2deca75ed5dd365eaf1558a82347b1f11306135f
-    - --skip-deps
     provenance: github_provenance.jsonl
 - name: Run macaron analyze, validate user input of repo and commit (via purl) vs provenance
   kind: analyze
@@ -68,7 +65,6 @@ steps:
     command_args:
     - -purl
     - pkg:github/behnazh-w/example-maven-app@2deca75
-    - --skip-deps
     provenance: github_provenance.jsonl
 - name: Run macaron analyze, validate user input of repo and commit (via purl with tag) vs provenance
   kind: analyze
@@ -76,5 +72,4 @@ steps:
     command_args:
     - -purl
     - pkg:github/behnazh-w/example-maven-app@1.0
-    - --skip-deps
     provenance: github_provenance.jsonl

--- a/tests/integration/cases/deps_depth_invalid_value/test.yaml
+++ b/tests/integration/cases/deps_depth_invalid_value/test.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Setting invalid values to --deps-depth flag.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: A negative integer is not valid.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/django@5.0.6
+    - --depth=-10
+  expect_fail: true
+- name: A string value (except from `inf`) is not valid.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/django@5.0.6
+    - --depth=infinity
+  expect_fail: true
+- name: Provide un-supported depth.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/django@5.0.6
+    - --depth=10
+  expect_fail: true
+- name: Expect one argument for --deps-depth
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/django@5.0.6
+    - --depth
+  expect_fail: true

--- a/tests/integration/cases/django_virtual_path_and_sbom_with_no_deps_resolution/test.yaml
+++ b/tests/integration/cases/django_virtual_path_and_sbom_with_no_deps_resolution/test.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
-  Analyzing the dependencies with virtual env provided as input. --deps-depth is not set or set to 0. Macaron should exit on error.
+  Analyzing the dependencies with virtual env provided as input. Macaron should not exit on error when --deps-depth is not set or set to 0.
 
 tags:
 - macaron-python-package
@@ -16,7 +16,7 @@ steps:
   kind: shell
   options:
     cmd: python -m venv ./django_venv
-- name: Run macaron analyze with --deps-depth not set.
+- name: Run macaron analyze with python venv and --deps-depth not set.
   kind: analyze
   options:
     command_args:
@@ -24,8 +24,7 @@ steps:
     - pkg:pypi/django@5.0.6
     - --python-venv
     - ./django_venv
-  expect_fail: true
-- name: Run macaron analyze with --deps-depth set to 0.
+- name: Run macaron analyze with python venv and --deps-depth set to 0.
   kind: analyze
   options:
     command_args:
@@ -34,7 +33,6 @@ steps:
     - --python-venv
     - ./django_venv
     - --deps-depth=0
-  expect_fail: true
 - name: Clean up the virtual environment.
   kind: shell
   options:

--- a/tests/integration/cases/django_virtual_path_with_no_deps_resolution/test.yaml
+++ b/tests/integration/cases/django_virtual_path_with_no_deps_resolution/test.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing the dependencies with virtual env provided as input. --deps-depth is not set or set to 0. Macaron should exit on error.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Clean up the virtual environment if it exists.
+  kind: shell
+  options:
+    cmd: rm -rf ./django_venv
+- name: Create an empty virtual environment.
+  kind: shell
+  options:
+    cmd: python -m venv ./django_venv
+- name: Run macaron analyze with --deps-depth not set.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/django@5.0.6
+    - --python-venv
+    - ./django_venv
+  expect_fail: true
+- name: Run macaron analyze with --deps-depth set to 0.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/django@5.0.6
+    - --python-venv
+    - ./django_venv
+    - --deps-depth=0
+  expect_fail: true
+- name: Clean up the virtual environment.
+  kind: shell
+  options:
+    cmd: rm -rf ./django_venv

--- a/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/configurations.ini
+++ b/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/configurations.ini
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
-
-[dependency.resolver]
-recursive = True

--- a/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/test.yaml
+++ b/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/test.yaml
@@ -30,6 +30,7 @@ steps:
     - pkg:pypi/django@5.0.6
     - --python-venv
     - ./django_venv
+    - --deps-depth=1
 - name: Run macaron verify-policy to check the dependencies
   kind: verify
   options:
@@ -47,14 +48,12 @@ steps:
 - name: Run macaron analyze on deps recursively
   kind: analyze
   options:
-    main_args:
-    - --defaults-path
-    - configurations.ini
     command_args:
     - -purl
     - pkg:pypi/django@5.0.6
     - --python-venv
     - ./django_venv
+    - --deps-depth=inf
 - name: Run macaron verify-policy to check for all transitive dependencies.
   kind: verify
   options:

--- a/tests/integration/cases/example_maven_app_automatic_dep_resolution_tutorial/test.yaml
+++ b/tests/integration/cases/example_maven_app_automatic_dep_resolution_tutorial/test.yaml
@@ -17,6 +17,7 @@ steps:
     - pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar
     - -rp
     - https://github.com/behnazh-w/example-maven-app
+    - --deps-depth=1
 - name: Compare dependencies report.
   kind: compare
   options:

--- a/tests/integration/cases/facebook_yoga_yarn_classic/test.yaml
+++ b/tests/integration/cases/facebook_yoga_yarn_classic/test.yaml
@@ -19,7 +19,6 @@ steps:
     - main
     - -d
     - f8e2bc0875c145c429d0e865c9b83a40f65b3070
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/gitlab_tinyMediaManager/test.yaml
+++ b/tests/integration/cases/gitlab_tinyMediaManager/test.yaml
@@ -18,7 +18,6 @@ steps:
     - main
     - -d
     - cca6b67a335074eca42136556f0a321f75dc4f48
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/gitlab_tinyMediaManager_purl/test.yaml
+++ b/tests/integration/cases/gitlab_tinyMediaManager_purl/test.yaml
@@ -20,7 +20,6 @@ steps:
     - main
     - -d
     - cca6b67a335074eca42136556f0a321f75dc4f48
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/google_guava/test.yaml
+++ b/tests/integration/cases/google_guava/test.yaml
@@ -14,7 +14,6 @@ steps:
     command_args:
     - -purl
     - pkg:maven/com.google.guava/guava@32.1.2-jre?type=jar
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/invalid_provenance_file/test.yaml
+++ b/tests/integration/cases/invalid_provenance_file/test.yaml
@@ -15,5 +15,4 @@ steps:
     command_args:
     - -rp
     - https://github.com/apache/maven
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/invalid_purl/test.yaml
+++ b/tests/integration/cases/invalid_purl/test.yaml
@@ -17,5 +17,4 @@ steps:
     - invalid-purl
     - --repo-path
     - https://github.com/apache/maven
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/jackson_databind_deps_resolution_with_purl_cyclonedx_maven_plugin/test.yaml
+++ b/tests/integration/cases/jackson_databind_deps_resolution_with_purl_cyclonedx_maven_plugin/test.yaml
@@ -16,6 +16,7 @@ steps:
     command_args:
     - -purl
     - pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.0-rc1
+    - --deps-depth=1
 - name: Compare deps report
   kind: compare
   options:

--- a/tests/integration/cases/jackson_databind_with_purl_and_no_deps/test.yaml
+++ b/tests/integration/cases/jackson_databind_with_purl_and_no_deps/test.yaml
@@ -14,7 +14,6 @@ steps:
     command_args:
     - -purl
     - pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.0-rc1
-    - --skip-deps
 - name: Run verify-policy
   kind: verify
   options:

--- a/tests/integration/cases/jenkinsci_plotplugin/test.yaml
+++ b/tests/integration/cases/jenkinsci_plotplugin/test.yaml
@@ -18,7 +18,6 @@ steps:
     - master
     - -d
     - 55b059187e252b35ac0d6cb52268833ee1bb7380
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/micronaut-projects_micronaut-core/test.yaml
+++ b/tests/integration/cases/micronaut-projects_micronaut-core/test.yaml
@@ -16,7 +16,6 @@ steps:
     command_args:
     - -purl
     - pkg:maven/io.micronaut/micronaut-core@4.2.3
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/micronaut-projects_micronaut-test/test.yaml
+++ b/tests/integration/cases/micronaut-projects_micronaut-test/test.yaml
@@ -17,7 +17,6 @@ steps:
     - https://github.com/micronaut-projects/micronaut-test
     - -d
     - 5b81340f319a2287cb2e81ddec0154c0ea2510cf
-    - --skip-deps
 - name: Validate JSON report schema
   kind: validate_schema
   options:

--- a/tests/integration/cases/micronaut-projects_micronaut-test/test.yaml
+++ b/tests/integration/cases/micronaut-projects_micronaut-test/test.yaml
@@ -31,7 +31,6 @@ steps:
     - https://github.com/qos-ch/slf4j
     - -d
     - e9ee55cca93c2bf26f14482a9bdf961c750d2a56
-    - --skip-deps
 - name: Run macaron analyze ben-manes/caffeine
   kind: analyze
   options:
@@ -40,7 +39,6 @@ steps:
     - https://github.com/ben-manes/caffeine
     - -d
     - 05a040c2478341bab8a58a02b3dc1fe14d626d72
-    - --skip-deps
 - name: Run macaron verify-policy for micronaut-test
   kind: verify
   options:

--- a/tests/integration/cases/micronaut_test_deps_resolution_with_config_cyclonedx_gradle_plugin/test.yaml
+++ b/tests/integration/cases/micronaut_test_deps_resolution_with_config_cyclonedx_gradle_plugin/test.yaml
@@ -16,6 +16,7 @@ steps:
     command_args:
     - -c
     - config.yaml
+    - --deps-depth=1
 - name: Compare deps report
   kind: compare
   options:

--- a/tests/integration/cases/missing_template_file/test.yaml
+++ b/tests/integration/cases/missing_template_file/test.yaml
@@ -14,7 +14,6 @@ steps:
     command_args:
     - -rp
     - https://github.com/apache/maven
-    - --skip-deps
     - -g
     - does/not/exist
   expect_fail: true

--- a/tests/integration/cases/no_branch_or_commit/test.yaml
+++ b/tests/integration/cases/no_branch_or_commit/test.yaml
@@ -17,5 +17,4 @@ steps:
     - pkg:maven/apache/maven
     - --repo-path
     - https://github.com/apache/maven
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/no_github_token/test.yaml
+++ b/tests/integration/cases/no_github_token/test.yaml
@@ -14,8 +14,7 @@ steps:
   options:
     command_args:
     - --repo-path
-    - https://github.com/apache/maven --skip-deps
-    - --skip-deps
+    - https://github.com/apache/maven
   env:
     GITHUB_TOKEN:
   expect_fail: true

--- a/tests/integration/cases/onu-ui_onu-ui_pnpm/test.yaml
+++ b/tests/integration/cases/onu-ui_onu-ui_pnpm/test.yaml
@@ -19,7 +19,6 @@ steps:
     - main
     - -d
     - e3f2825c3940002a920d65476116a64684b3d95e
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/ossf_scorecard/test.yaml
+++ b/tests/integration/cases/ossf_scorecard/test.yaml
@@ -17,7 +17,6 @@ steps:
     command_args:
     - --package-url
     - pkg:github/ossf/scorecard@v4.13.1
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/purl_of_nonexistent_artifact/test.yaml
+++ b/tests/integration/cases/purl_of_nonexistent_artifact/test.yaml
@@ -14,7 +14,6 @@ steps:
     command_args:
     - -purl
     - pkg:maven/com.example/nonexistent@1.0.0
-    - --skip-deps
 - name: Run macaron verify-policy
   kind: verify
   options:

--- a/tests/integration/cases/sigstore_mock/test.yaml
+++ b/tests/integration/cases/sigstore_mock/test.yaml
@@ -21,7 +21,6 @@ steps:
     - main
     - -d
     - ebdcfdfbdfeb9c9aeee6df53674ef230613629f5
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/sigstore_sget/test.yaml
+++ b/tests/integration/cases/sigstore_sget/test.yaml
@@ -19,7 +19,6 @@ steps:
     - main
     - -d
     - 99e7b91204d391ccc76507f7079b6d2a7957489e
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/slsa-framework_slsa-verifier/test.yaml
+++ b/tests/integration/cases/slsa-framework_slsa-verifier/test.yaml
@@ -21,7 +21,6 @@ steps:
     - main
     - -d
     - e6428d7da594455a4c2b7f24907fec421a5e0e95
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/slsa-framework_slsa-verifier_explicit_provenance_provided/test.yaml
+++ b/tests/integration/cases/slsa-framework_slsa-verifier_explicit_provenance_provided/test.yaml
@@ -19,7 +19,6 @@ steps:
     - https://github.com/slsa-framework/slsa-verifier
     - -d
     - 6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:
@@ -35,7 +34,6 @@ steps:
     - https://github.com/slsa-framework/slsa-verifier
     - -d
     - 6fb4f7e2dd9c2f5d4f55fa88f6796278a7bba6d6
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/snakeyaml_unsupported_git_service/test.yaml
+++ b/tests/integration/cases/snakeyaml_unsupported_git_service/test.yaml
@@ -28,7 +28,6 @@ steps:
     - snakeyaml
     - -d
     - a34989252e6f59e36a3aaf788a903b7a37a73d33
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/test_analyzing_an_invalid_local_repo_path/test.yaml
+++ b/tests/integration/cases/test_analyzing_an_invalid_local_repo_path/test.yaml
@@ -17,5 +17,4 @@ steps:
     command_args:
     - -rp
     - path/to/invalid/repo
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/test_not_pulling_from_remote_for_a_local_repo/test.sh
+++ b/tests/integration/cases/test_not_pulling_from_remote_for_a_local_repo/test.sh
@@ -6,4 +6,4 @@
 # latest changes (i.e the second commit of SOURCE_REPO) into TARGET_REPO.
 # Therefore, this analysis is expected to fail because the commit HEAD_COMMIT_SHA does not exist in TARGET_REPO.
 HEAD_COMMIT_SHA=$(cat target_commit_sha.txt)
-macaron -lr ./output/git_repos/local_repos/ analyze -rp target -d "$HEAD_COMMIT_SHA" --skip-deps
+macaron -lr ./output/git_repos/local_repos/ analyze -rp target -d "$HEAD_COMMIT_SHA"

--- a/tests/integration/cases/test_using_a_repo_path_outside_of_local_repos_dir/test.yaml
+++ b/tests/integration/cases/test_using_a_repo_path_outside_of_local_repos_dir/test.yaml
@@ -21,5 +21,4 @@ steps:
     command_args:
     - -rp
     - ../
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/test_using_invalid_local_repos_dir/test.yaml
+++ b/tests/integration/cases/test_using_invalid_local_repos_dir/test.yaml
@@ -17,5 +17,4 @@ steps:
     command_args:
     - -rp
     - apache/maven
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/test_using_local_repo_with_no_commit/test.yaml
+++ b/tests/integration/cases/test_using_local_repo_with_no_commit/test.yaml
@@ -21,5 +21,4 @@ steps:
     command_args:
     - -rp
     - empty_repo
-    - --skip-deps
   expect_fail: true

--- a/tests/integration/cases/timyarkov_docker_test/test.yaml
+++ b/tests/integration/cases/timyarkov_docker_test/test.yaml
@@ -19,7 +19,6 @@ steps:
     - main
     - -d
     - 404a51a2f38c4470af6b32e4e00b5318c2d7c0cc
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/timyarkov_multibuild_test_gradle/test.yaml
+++ b/tests/integration/cases/timyarkov_multibuild_test_gradle/test.yaml
@@ -21,6 +21,7 @@ steps:
     - main
     - -d
     - a8b0efe24298bc81f63217aaa84776c3d48976c5
+    - --deps-depth=1
 - name: Compare dependency resolution result
   kind: compare
   options:

--- a/tests/integration/cases/timyarkov_multibuild_test_maven/test.yaml
+++ b/tests/integration/cases/timyarkov_multibuild_test_maven/test.yaml
@@ -22,6 +22,7 @@ steps:
     - main
     - -d
     - a8b0efe24298bc81f63217aaa84776c3d48976c5
+    - --deps-depth=1
 - name: Compare dependency resolution result
   kind: compare
   options:

--- a/tests/integration/cases/tutorial_npm_verify_provenance_semver/test.yaml
+++ b/tests/integration/cases/tutorial_npm_verify_provenance_semver/test.yaml
@@ -14,7 +14,6 @@ steps:
     command_args:
     - -purl
     - pkg:npm/semver@7.6.2
-    - --skip-deps
 - name: Verify checks for semver@7.6.2
   kind: verify
   options:
@@ -25,7 +24,6 @@ steps:
     command_args:
     - -purl
     - pkg:npm/semver@7.6.0
-    - --skip-deps
 - name: Verify checks for all 7.6.x semver runs
   kind: verify
   options:
@@ -36,7 +34,6 @@ steps:
     command_args:
     - -purl
     - pkg:npm/semver@1.0.0
-    - --skip-deps
 - name: Verify checks for all semver runs
   kind: verify
   options:

--- a/tests/integration/cases/uiv-lib_uiv/test.yaml
+++ b/tests/integration/cases/uiv-lib_uiv/test.yaml
@@ -19,7 +19,6 @@ steps:
     - dev
     - -d
     - 057b25b4db0913edab4cf728c306085e6fc20d49
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/urllib3_expectation_dir/test.yaml
+++ b/tests/integration/cases/urllib3_expectation_dir/test.yaml
@@ -18,7 +18,6 @@ steps:
     - pkg:pypi/urllib3@2.0.0a1
     - --provenance-expectation
     - expectation
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/urllib3_expectation_file/test.yaml
+++ b/tests/integration/cases/urllib3_expectation_file/test.yaml
@@ -17,7 +17,6 @@ steps:
     command_args:
     - -purl
     - pkg:pypi/urllib3@2.0.0a1
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/urllib3_invalid_expectation/test.yaml
+++ b/tests/integration/cases/urllib3_invalid_expectation/test.yaml
@@ -17,7 +17,6 @@ steps:
     command_args:
     - -purl
     - pkg:pypi/urllib3@2.0.0a1
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/urllib3_no_tag/test.yaml
+++ b/tests/integration/cases/urllib3_no_tag/test.yaml
@@ -18,7 +18,6 @@ steps:
     - main
     - --digest
     - 87a0ecee6e691fe5ff93cd000c0158deebef763b
-    - --skip-deps
 - name: Run macaron verify-policy to verify failed check
   kind: verify
   options:

--- a/tests/integration/cases/wojtekmaj_reactpdf_yarn_modern/test.yaml
+++ b/tests/integration/cases/wojtekmaj_reactpdf_yarn_modern/test.yaml
@@ -19,7 +19,6 @@ steps:
     - main
     - -d
     - be18436b7be827eb993b2e1e4bd9230dd835a9a3
-    - --skip-deps
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:


### PR DESCRIPTION
Closes #838 .

In this Pull Request I made the following changes:
- https://github.com/oracle/macaron/pull/840/commits/63b981d982e829a0b5a8774357c4c6e2cc833ee7 I refactor the dependency resolver base class so that it accepts whether it should analyze all transitive dependencies through a method parameter instead of the `defaults.ini` configuration. 
```ini
[dependency.resolver] 
   recursive = True
```
- https://github.com/oracle/macaron/pull/840/commits/076318a7740af4de7f386a0789eb861849effa30 I modified the Macaron's CLI to make `--skip-deps` an no-op. I also added `--deps-depth` as a new flag for setting the dependency resolution behavior (it's disabled by default).
- https://github.com/oracle/macaron/pull/840/commits/a9dbacb8bcebcd146444a92e790f2e4bab3e14d4, https://github.com/oracle/macaron/pull/840/commits/41e6399a5e2041c3883c8ed2fbea5a881dd949df, https://github.com/oracle/macaron/pull/840/commits/a85e85521ae2e9613e2496f9e55ee83eb085c35e I modified the existing test cases given the changes in Macaron's analyze command CLI.
- https://github.com/oracle/macaron/pull/840/commits/d30215be8642447ebe978e94f6eefe7bd9326812 I added new integration test cases on invalid usage of `--deps-depth`:
    - Providing invalid values to `--deps-depth`
    - Not setting `--deps-depth` when providing SBOM or Python Virtual Environment as input.
- https://github.com/oracle/macaron/pull/840/commits/f2dde1f091b23099853ed62ff322422f4a6e3f08 Update the Sphinx documentation accordingly.
