### PR TITLE
chore: correct typo in npm provenance tutorial

### DIFF
--- a/docs/source/pages/tutorials/npm_provenance.rst
+++ b/docs/source/pages/tutorials/npm_provenance.rst
@@ -91,7 +91,7 @@ After including some helper rules, the above policy is defined as requiring all 
 
 .. code-block:: shell
 
-    ./run_macaron.sh -d output/macaron.db -f verified.dl
+    ./run_macaron.sh verify-policy -d output/macaron.db -f verified.dl
 
 The result of this command should show that the policy we have written succeeds on the ``semver`` library. As follows:
 


### PR DESCRIPTION
Issue #845 