### PR TITLE
fix: use gnu-sed on mac instead of the built-in sed command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ setup: force-upgrade setup-go setup-binaries setup-schemastore
 setup-go:
 	go build -o $(PACKAGE_PATH)/bin/ $(REPO_PATH)/golang/cmd/...
 	go build -o $(PACKAGE_PATH)/bin/cuevalidate.so -buildmode=c-shared $(REPO_PATH)/golang/internal/cue_validator/cue_validator.go
-setup-binaries: $(PACKAGE_PATH)/bin/slsa-verifier $(PACKAGE_PATH)/resources/mvnw $(PACKAGE_PATH)/resources/gradlew souffle
+setup-binaries: $(PACKAGE_PATH)/bin/slsa-verifier $(PACKAGE_PATH)/resources/mvnw $(PACKAGE_PATH)/resources/gradlew souffle gnu-sed
 $(PACKAGE_PATH)/bin/slsa-verifier:
 	git clone --depth 1 https://github.com/slsa-framework/slsa-verifier.git -b v2.5.1
 	cd slsa-verifier/cli/slsa-verifier && go build -o $(PACKAGE_PATH)/bin/
@@ -170,6 +170,12 @@ souffle:
 	fi && \
     command -v souffle || true
 
+# Install gnu-sed on mac using homebrew
+.PHONY: gnu-sed
+gnu-sed:
+	if [ "$(OS_DISTRO)" == "Darwin" ]; then \
+		brew install gnu-sed; \
+	fi
 
 # Install or upgrade an existing virtual environment based on the
 # package dependencies declared in pyproject.toml.

--- a/scripts/dev_scripts/copyright-checker.sh
+++ b/scripts/dev_scripts/copyright-checker.sh
@@ -52,6 +52,12 @@ for f in $files; do
     fi
 done
 
+SED="sed"
+# Use gnu-sed (gsed) on mac.
+if [[ "$(uname)" == "Darwin" ]]; then
+    SED="gsed"
+fi
+
 if [ ${#missing_copyright_files[@]} -ne 0 ]; then
     for f in "${missing_copyright_files[@]}"; do
 
@@ -86,14 +92,14 @@ if [ ${#missing_copyright_files[@]} -ne 0 ]; then
             shebang_line=$(grep -m 1 -n "#!" "$f")
             if [[ -z "$shebang_line" ]];then
                 # If there is no shebang, insert at the first line.
-                sed -i "1s/^/$expected\n\n/" "$f"
+                $SED -i "1s/^/$expected\n\n/" "$f"
             else
                 # If there is a shebang, append to the end of the line.
-                sed -i "$(echo "$shebang_line" | cut -d : -f 1)""s/$/\n\n$expected/" "$f"
+                $SED -i "$(echo "$shebang_line" | cut -d : -f 1)""s/$/\n\n$expected/" "$f"
             fi
         else
             echo "Copyright header needs update for $f."
-            sed -i "$line_number""s/^.*/$expected/" "$f"
+            $SED -i "$line_number""s/^.*/$expected/" "$f"
         fi
     done
     echo "Copyright headers have been automatically added/updated. Please review and stage the changes before running git commit again."


### PR DESCRIPTION
- Install gnu-sed as part of `setup` (`setup-binaries`). 
- Use `gsed` in `copyright-checker.sh` when running on mac.

Closes #852 