### PR TITLE
test: disable mcn_infer_artifact_pipeline_1 for guava

### DIFF
--- a/tests/integration/cases/google_guava/policy.dl
+++ b/tests/integration/cases/google_guava/policy.dl
@@ -7,7 +7,10 @@ Policy("test_policy", component_id, "") :-
     check_passed(component_id, "mcn_build_as_code_1"),
     check_passed(component_id, "mcn_build_script_1"),
     check_passed(component_id, "mcn_build_service_1"),
-    check_passed(component_id, "mcn_infer_artifact_pipeline_1"),
+    // TODO: The GitHub API is no longer returning the required information about the workflow run
+    // steps for this version of Guava. So, we need to disable this check for now and adjust
+    // the logic in the mcn_infer_artifact_pipeline_1 check.
+    check_failed(component_id, "mcn_infer_artifact_pipeline_1"),
     check_passed(component_id, "mcn_version_control_system_1"),
     check_failed(component_id, "mcn_provenance_available_1"),
     check_failed(component_id, "mcn_provenance_derived_commit_1"),


### PR DESCRIPTION
The [GitHub API](https://api.github.com/repos/google/guava/actions/runs/5719444145/jobs) does not return the information related to the `steps` of the workflow run for `guava@32.1.2-jre`any longer. This PR disables the related integration test. I will adjust the logic of this check in the refactored version.

Closes https://github.com/oracle/macaron/issues/854