### PR TITLE
chore: improve commit finder accuracy

### DIFF
--- a/src/macaron/repo_finder/commit_finder.py
+++ b/src/macaron/repo_finder/commit_finder.py
@@ -499,6 +499,8 @@ def match_tags(tag_list: list[str], name: str, version: str) -> list[str]:
 
     # If any tag exactly matches the version, return it immediately.
     # Also allow for an optional 'v' prefix, and tags of the form: <release_prefix>/<artifact_name>-<version>.
+    # Generally version identifiers do not contain the `v` prefix, while tags often do. If a version does contain such
+    # a prefix, it is expected to be in the tag also. If not, the `v` prefix is left as optional.
     v_prefix = "(?:v)?" if not version.lower().startswith("v") else ""
     escaped_version = re.escape(version)
     almost_exact_pattern = re.compile(


### PR DESCRIPTION
This PR makes a number of improvements to the Commit Finder based on results from a much larger dataset than has been previously used for testing.

### Changes

#### Prefixes

The base prefix case pattern has been made more accepting:
 - Can start with any character instead of requiring an alphabetic character
 - Can end with one or two numbers
 
A new prefix case, "prefix_2", has been added that accepts a string of any alphabetic characters with no prefix separator.

#### Suffixes

The logic for determining when suffix parts should be made optional has been improved. Requirements are:
- Version parts that are alphanumeric
- AND do not come before parts that are purely numeric
- OR version parts that come after a change in separator

Separator pattern logic between version parts has been changed to only allow differences when a version contains more than one separator, e.g. v1.2-3 vs. v1.2.3. Specific separators also become optional in cases where a version part was split from a single part, e.g. 1.3rc5 -> [1, 3, rc5]

#### Preventing Misaligned Matches

The old prefix patterns were designed to help prevent versions from matching incorrectly within a tag, such as part way through numbers, or version parts, e.g. 11.33 should not match 1.33, or 33. To address this a negative look behind has been added for the first version part instead, as well as a new function that performs realignment when a version part has been marked as a prefix by mistake.

#### Pre-step Evaluation

As a pre-step to the full evaluation, a vastly simplified regex has been added that checks if the tag matches the version closely enough, using: `<release_prefix>/<artifact_name>-<v><version>`, with only the version part being required.

#### Sorting Function

The compute similarity function has been extended to consider more information from the tag matches.
This includes preferring shorter prefixes and prefix separators; prefixes that are a superstring of the artifact name; and prefixes and suffixes that have release keywords in them, or use separators that match the version.

### Tests

More regression cases have been added for new tags of interest. Strange unicode tags that were previously rejected despite being valid Git tags are now accepted using the pre-step evaluation. 

The hypothesis test for pattern creation and evaluation has been removed. Creating a slightly less restrictive pattern that is still mostly correct has become far more difficult as the Commit Finder has evolved, and likely not worth the extra effort.

(More unit tests to come in a future PR.)