### PR TITLE
feat: obtain Java and Python artifacts from .m2 or Python virtual environment from input

### DIFF
--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -24,6 +24,7 @@ Usage
         [-d DIGEST] [-pe PROVENANCE_EXPECTATION]
         [--skip-deps] [--deps-depth DEPS_DEPTH] [-g TEMPLATE_PATH]
         [--python-venv PYTHON_VENV]
+        [--local-maven-repo LOCAL_MAVEN_REPO]
 
 -------
 Options
@@ -78,6 +79,10 @@ Options
 .. option::  --python-venv PYTHON_VENV
 
     The path to the Python virtual environment of the target software component.
+
+.. option:: --local-maven-repo LOCAL_MAVEN_REPO
+
+    The path to the local .m2 directory. If this option is not used, Macaron will use the default location at $HOME/.m2
 
 -----------
 Environment

--- a/scripts/release_scripts/run_macaron.sh
+++ b/scripts/release_scripts/run_macaron.sh
@@ -328,6 +328,10 @@ if [[ $command == "analyze" ]]; then
                 python_venv_path="$2"
                 shift
                 ;;
+            --local-maven-repo)
+                local_maven_repo="$2"
+                shift
+                ;;
             *)
                 rest_command+=("$1")
                 ;;
@@ -453,6 +457,32 @@ if [[ -n "${python_venv_path:-}" ]]; then
     argv_command+=("--python-venv" "${MACARON_WORKSPACE}/analyze_python_venv_editable")
 
     mount_dir_ro "--python-venv" "$python_venv_path" "$python_venv_in_container"
+fi
+
+# Mount the local Maven repo into ${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly.
+if [[ -n "${local_maven_repo:-}" ]]; then
+    local_maven_repo_in_container="${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly"
+    argv_command+=("--local-maven-repo" "${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly")
+
+    mount_dir_ro "--local-maven-repo" "$local_maven_repo" "$local_maven_repo_in_container"
+else
+    # If the user doesn't provide local maven repo, we mount $HOME/.m2 into ${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly ONLY IF $HOME/.m2 directory exists.
+    # If $HOME/.m2 doesn't exist, we create and mount an empty directory ${output}/analyze_local_maven_repo_readonly into ${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly instead.
+    # This is because we don't want Macaron running within
+    # the container to use `$HOME/.m2` within the container as it is being used
+    # by the cyclonedx plugins for dependency resolution.
+    if [[ -d "$HOME/.m2" ]]; then
+        local_maven_repo_in_container="${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly"
+        argv_command+=("--local-maven-repo" "${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly")
+
+        mount_dir_ro "--local-maven-repo" "$HOME/.m2" "$local_maven_repo_in_container"
+    else
+        local_maven_repo_in_container="${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly"
+        output_local_maven_repo="${output}/analyze_local_maven_repo_readonly"
+        mkdir -p "$output_local_maven_repo"
+
+        mount_dir_ro "--local-maven-repo" "$output_local_maven_repo" "$local_maven_repo_in_container"
+    fi
 fi
 
 # MACARON entrypoint - verify-policy command argvs

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -91,7 +91,7 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
         global_config.local_maven_repo = local_maven_repo
     else:
         user_provided_local_maven_repo = analyzer_single_args.local_maven_repo
-        if not os.path.exists(user_provided_local_maven_repo) or not os.path.isdir(user_provided_local_maven_repo):
+        if not os.path.isdir(user_provided_local_maven_repo):
             logger.error("The user provided local Maven repo at %s is not valid.", user_provided_local_maven_repo)
             sys.exit(os.EX_USAGE)
 

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -74,7 +74,7 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
             sys.exit(os.EX_OSFILE)
         global_config.load_python_venv(analyzer_single_args.python_venv)
 
-    # Set Python virtual environment path.
+    # Set local maven repo path.
     if analyzer_single_args.local_maven_repo is None:
         # Load the default user local .m2 directory.
         # Exit on error if $HOME is not set or empty.

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -74,6 +74,29 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
             sys.exit(os.EX_OSFILE)
         global_config.load_python_venv(analyzer_single_args.python_venv)
 
+    # Set Python virtual environment path.
+    if analyzer_single_args.local_maven_repo is None:
+        # Load the default user local .m2 directory.
+        # Exit on error if $HOME is not set or empty.
+        home_dir = os.getenv("HOME")
+        if not home_dir:
+            logger.critical("Environment variable HOME is not set.")
+            sys.exit(os.EX_USAGE)
+
+        local_maven_repo = os.path.join(home_dir, ".m2")
+        if not os.path.isdir(local_maven_repo):
+            logger.debug("The default local Maven repo at %s does not exist. Ignore ...")
+            global_config.local_maven_repo = None
+
+        global_config.local_maven_repo = local_maven_repo
+    else:
+        user_provided_local_maven_repo = analyzer_single_args.local_maven_repo
+        if not os.path.exists(user_provided_local_maven_repo) or not os.path.isdir(user_provided_local_maven_repo):
+            logger.error("The user provided local Maven repo at %s is not valid.", user_provided_local_maven_repo)
+            sys.exit(os.EX_USAGE)
+
+        global_config.local_maven_repo = user_provided_local_maven_repo
+
     analyzer = Analyzer(global_config.output_path, global_config.build_log_path)
 
     # Initiate reporters.
@@ -450,6 +473,14 @@ def main(argv: list[str] | None = None) -> None:
         help=(
             "The path to the Python virtual environment of the target software component. "
             + "If this is set, dependency resolution must be enabled with '--deps-depth'."
+        ),
+    )
+
+    single_analyze_parser.add_argument(
+        "--local-maven-repo",
+        required=False,
+        help=(
+            "The path to the local .m2 directory. If this option is not used, Macaron will use the default location at $HOME/.m2"
         ),
     )
 

--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -13,8 +13,8 @@ from macaron.artifact.maven import construct_maven_repository_path
 from macaron.errors import LocalArtifactFinderError
 
 
-def construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl: PackageURL) -> list[str] | None:
-    """Return a list of glob pattern(s) representing maven artifacts in a local maven repository.
+def construct_local_artifact_dirs_glob_pattern_maven_purl(maven_purl: PackageURL) -> list[str] | None:
+    """Return a list of glob pattern(s) representing the directory that contains the local maven artifacts for ``maven_purl``.
 
     The glob pattern(s) can be used to search in `<...>/.m2/repository` directory.
 
@@ -48,8 +48,8 @@ def construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl: PackageUR
     return [construct_maven_repository_path(group, artifact, version)]
 
 
-def construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl: PackageURL) -> list[str] | None:
-    """Return a list of glob pattern(s) representing python artifacts in a virtual environment.
+def construct_local_artifact_dirs_glob_pattern_pypi_purl(pypi_purl: PackageURL) -> list[str] | None:
+    """Return a list of glob pattern(s) representing directories that contains the artifacts in a Python virtual environment.
 
     The glob pattern(s) can be used to search in `<...>/<python_venv>/lib/python3.x/site-packages`
     directory.
@@ -194,12 +194,16 @@ def get_local_artifact_paths(
     purl: PackageURL,
     local_artifact_repo_path: str,
 ) -> list[str]:
-    """Return the path to local artifacts for a PackageURL.
+    """Return the paths to directories that store local artifacts for a PackageURL.
 
-    We look for local artifacts of this PURL in ``local_artifact_repo_path``.
+    We look for local artifacts of ``purl`` in ``local_artifact_repo_path``.
 
     This function returns a list of paths (as strings), each has the format
-        ``local_artifact_repo_path``/path/to/artifact``
+        ``local_artifact_repo_path``/path/to/artifact_dir``
+
+    This will mean that no path to an artifact is returned. Therefore, it's the responsibility
+    of this function caller to inspect the artifact directory to obtain the required
+    artifact.
 
     We assume that ``local_artifact_repo_path`` exists.
 
@@ -223,7 +227,7 @@ def get_local_artifact_paths(
     purl_type = purl.type
 
     if purl_type == "maven":
-        maven_artifact_patterns = construct_local_artifact_paths_glob_pattern_maven_purl(purl)
+        maven_artifact_patterns = construct_local_artifact_dirs_glob_pattern_maven_purl(purl)
         if not maven_artifact_patterns:
             raise LocalArtifactFinderError(f"Cannot generate maven artifact patterns for {purl}")
 
@@ -233,7 +237,7 @@ def get_local_artifact_paths(
         )
 
     if purl_type == "pypi":
-        pypi_artifact_patterns = construct_local_artifact_paths_glob_pattern_pypi_purl(purl)
+        pypi_artifact_patterns = construct_local_artifact_dirs_glob_pattern_pypi_purl(purl)
         if not pypi_artifact_patterns:
             raise LocalArtifactFinderError(f"Cannot generate Python package patterns for {purl}")
 

--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module declares types and utilities for handling local artifacts."""
+
+import os
+from collections.abc import Mapping
+
+from packageurl import PackageURL
+
+from macaron.artifact.maven import construct_maven_repository_path
+from macaron.config.global_config import global_config
+
+
+def get_local_artifact_repo_mapper() -> Mapping[str, str]:
+    """Get A."""
+    local_artifact_mapper: dict[str, str] = {}
+
+    if global_config.local_maven_repo:
+        local_artifact_mapper["maven"] = global_config.local_maven_repo
+
+    if global_config.python_venv_path:
+        local_artifact_mapper["pypi"] = global_config.python_venv_path
+
+    return local_artifact_mapper
+
+
+def construct_local_artifact_path_from_purl(
+    build_purl_type: str,
+    component_purl: PackageURL,
+    local_artifact_repo_mapper: Mapping[str, str],
+) -> str | None:
+    """Get B."""
+    local_artifact_repo = local_artifact_repo_mapper.get(build_purl_type)
+    if local_artifact_repo is None:
+        return None
+
+    artifact_path = None
+    match build_purl_type:
+        case "maven":
+            group = component_purl.namespace
+            artifact = component_purl.name
+            version = component_purl.version
+
+            if group is None or version is None:
+                return None
+
+            artifact_path = os.path.join(
+                local_artifact_repo,
+                "repository",
+                construct_maven_repository_path(group, artifact, version),
+            )
+        case "pypi":
+            # TODO: implement this.
+            pass
+        case _:
+            return None
+
+    return artifact_path
+
+
+def get_local_artifact_paths(
+    purl: PackageURL,
+    build_tool_purl_types: list[str],
+    local_artifact_repo_mapper: Mapping[str, str],
+) -> dict[str, str]:
+    """Get C."""
+    result = {}
+
+    for build_purl_type in build_tool_purl_types:
+        local_artfiact_path = construct_local_artifact_path_from_purl(
+            build_purl_type=build_purl_type,
+            component_purl=purl,
+            local_artifact_repo_mapper=local_artifact_repo_mapper,
+        )
+
+        if local_artfiact_path and os.path.isdir(local_artfiact_path):
+            result[build_purl_type] = local_artfiact_path
+
+    return result

--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -56,7 +56,7 @@ def construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl: PackageURL)
 
     Parameters
     ----------
-    maven_purl : PackageURL
+    pypi_purl : PackageURL
         A pypi type PackageURL instance.
 
     Returns

--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -35,7 +35,7 @@ def construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl: PackageUR
     >>> construct_local_artifact_paths_glob_pattern_maven_purl(purl)
     ['com/oracle/macaron/macaron/0.13.0']
     """
-    if not maven_purl.type == "maven":
+    if maven_purl.type != "maven":
         return None
 
     group = maven_purl.namespace
@@ -71,7 +71,7 @@ def construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl: PackageURL)
     >>> construct_local_artifact_paths_glob_pattern_pypi_purl(purl)
     ['django', 'django-1.11.1.dist-info', 'django-1.11.1.data']
     """
-    if not pypi_purl.type == "pypi":
+    if pypi_purl.type != "pypi":
         return None
 
     name = pypi_purl.name

--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -32,7 +32,7 @@ def construct_local_artifact_dirs_glob_pattern_maven_purl(maven_purl: PackageURL
     --------
     >>> from packageurl import PackageURL
     >>> purl = PackageURL.from_string("pkg:maven/com.oracle.macaron/macaron@0.13.0")
-    >>> construct_local_artifact_paths_glob_pattern_maven_purl(purl)
+    >>> construct_local_artifact_dirs_glob_pattern_maven_purl(purl)
     ['com/oracle/macaron/macaron/0.13.0']
     """
     if maven_purl.type != "maven":
@@ -68,7 +68,7 @@ def construct_local_artifact_dirs_glob_pattern_pypi_purl(pypi_purl: PackageURL) 
     --------
     >>> from packageurl import PackageURL
     >>> purl = PackageURL.from_string("pkg:pypi/django@1.11.1")
-    >>> construct_local_artifact_paths_glob_pattern_pypi_purl(purl)
+    >>> construct_local_artifact_dirs_glob_pattern_pypi_purl(purl)
     ['django', 'django-1.11.1.dist-info', 'django-1.11.1.data']
     """
     if pypi_purl.type != "pypi":
@@ -91,11 +91,11 @@ def construct_local_artifact_dirs_glob_pattern_pypi_purl(pypi_purl: PackageURL) 
     return glob_patterns
 
 
-def find_artifact_paths_from_local_maven_repo(
+def find_artifact_dirs_from_local_maven_repo(
     local_maven_repo: str,
     glob_patterns: list[str],
 ) -> list[str]:
-    """Find maven artifacts within a local maven repository directory.
+    """Find directories that contains maven artifacts within a maven local repository.
 
     ``local_maven_repo`` should be in format `<...>/.m2/repository`.
 
@@ -104,13 +104,13 @@ def find_artifact_paths_from_local_maven_repo(
     local_maven_repo: str
         The path to the directory to find artifacts.
     glob_patterns: list[str]
-        The list of glob patterns that matches to artifact file names.
+        The list of glob patterns that matches to artifact directory names.
 
     Returns
     -------
     list[str]
-        The list of path to found artifacts in the form of ``local_maven_repo``/<artifact_specific_path>.
-        If no artifact is found, this list will be empty.
+        The list of paths to artifact directories in the form of ``venv_site_package_path``/path/to/artifact_dir
+        If no artifact directory is found, this list will be empty.
 
     Raises
     ------
@@ -135,11 +135,11 @@ def find_artifact_paths_from_local_maven_repo(
     return artifact_paths
 
 
-def find_artifact_paths_from_python_venv(
+def find_artifact_dirs_from_python_venv(
     venv_site_package_path: str,
     glob_patterns: list[str],
 ) -> list[str]:
-    """Find python artifacts within a python virtual environment directory.
+    """Find directories within a python virtual environment.
 
     For packages in the virtual environment, we will treat their name case-insensitively.
     https://packaging.python.org/en/latest/specifications/name-normalization/
@@ -151,13 +151,13 @@ def find_artifact_paths_from_python_venv(
     venv_path: str
         The path to the local directory to find artifacts.
     glob_patterns: list[str]
-        The list of glob patterns that matches to artifact file names.
+        The list of glob patterns that matches to artifact directory names.
 
     Returns
     -------
     list[str]
-        The list of path to found artifacts in the form of ``venv_site_package_path``/<artifact_specific_path>
-        If no artifact is found, this list will be empty.
+        The list of paths to artifact directories in the form of ``venv_site_package_path``/path/to/artifact_dir
+        If no artifact directory is found, this list will be empty.
 
     Raises
     ------
@@ -190,7 +190,7 @@ def find_artifact_paths_from_python_venv(
     return artifact_paths
 
 
-def get_local_artifact_paths(
+def get_local_artifact_dirs(
     purl: PackageURL,
     local_artifact_repo_path: str,
 ) -> list[str]:
@@ -217,7 +217,7 @@ def get_local_artifact_paths(
     Returns
     -------
     list[str]
-        The list contains the found artifact paths. It will be empty if no artifact can be found.
+        The list contains the artifact directory paths. It will be empty if no artifact can be found.
 
     Raises
     ------
@@ -231,7 +231,7 @@ def get_local_artifact_paths(
         if not maven_artifact_patterns:
             raise LocalArtifactFinderError(f"Cannot generate maven artifact patterns for {purl}")
 
-        return find_artifact_paths_from_local_maven_repo(
+        return find_artifact_dirs_from_local_maven_repo(
             local_maven_repo=local_artifact_repo_path,
             glob_patterns=maven_artifact_patterns,
         )
@@ -241,7 +241,7 @@ def get_local_artifact_paths(
         if not pypi_artifact_patterns:
             raise LocalArtifactFinderError(f"Cannot generate Python package patterns for {purl}")
 
-        return find_artifact_paths_from_python_venv(
+        return find_artifact_dirs_from_python_venv(
             venv_site_package_path=local_artifact_repo_path,
             glob_patterns=pypi_artifact_patterns,
         )

--- a/src/macaron/artifact/maven.py
+++ b/src/macaron/artifact/maven.py
@@ -158,3 +158,41 @@ def is_valid_maven_group_id(group_id: str) -> bool:
     # Should match strings like org.example.foo, org.example-2.foo.bar_1.
     pattern = r"^[a-zA-Z][a-zA-Z0-9-]*\.([a-zA-Z][a-zA-Z0-9-]*\.)*[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$"
     return re.match(pattern, group_id) is not None
+
+
+def construct_maven_repository_path(
+    group_id: str,
+    artifact_id: str | None = None,
+    version: str | None = None,
+    asset_name: str | None = None,
+) -> str:
+    """Construct a path to a folder or file on the registry, assuming Maven repository layout.
+
+    For more details regarding Maven repository layout, see the following:
+    - https://maven.apache.org/repository/layout.html
+    - https://maven.apache.org/guides/mini/guide-naming-conventions.html
+
+    Parameters
+    ----------
+    group_id : str
+        The group id of a Maven package.
+    artifact_id : str
+        The artifact id of a Maven package.
+    version : str
+        The version of a Maven package.
+    asset_name : str
+        The asset name.
+
+    Returns
+    -------
+    str
+        The path to a folder or file on the registry.
+    """
+    path = group_id.replace(".", "/")
+    if artifact_id:
+        path = "/".join([path, artifact_id])
+    if version:
+        path = "/".join([path, version])
+    if asset_name:
+        path = "/".join([path, asset_name])
+    return path

--- a/src/macaron/config/global_config.py
+++ b/src/macaron/config/global_config.py
@@ -46,6 +46,9 @@ class GlobalConfig:
     #: The path to Python virtual environment.
     python_venv_path: str = ""
 
+    #: The path to the local .m2 Maven repository. This attribute is None if there is no available .m2 directory.
+    local_maven_repo: str | None = None
+
     def load(
         self,
         macaron_path: str,

--- a/src/macaron/errors.py
+++ b/src/macaron/errors.py
@@ -90,3 +90,7 @@ class DependencyAnalyzerError(MacaronError):
 
 class HeuristicAnalyzerValueError(MacaronError):
     """Error class for BaseHeuristicAnalyzer errors when parsing data."""
+
+
+class LocalArtifactFinderError(MacaronError):
+    """Happens when there is an error looking for local artifacts."""

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -55,9 +55,8 @@ class ChecksOutputs(TypedDict):
     """The commit digest extracted from provenance, if applicable."""
     provenance_verified: bool
     """True if the provenance exists and has been verified against a signed companion provenance."""
-    local_artifact_paths: dict[str, str]
-    # TODO this doc string for this variable need more informatino, to be revise later.
-    """The mapping between build tool types and the directory that contains the corresponding artifacts."""
+    local_artifact_paths: dict[str, list[str]]
+    """The mapping between purl types and the local artifact absolute paths."""
 
 
 class AnalyzeContext:

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -55,6 +55,9 @@ class ChecksOutputs(TypedDict):
     """The commit digest extracted from provenance, if applicable."""
     provenance_verified: bool
     """True if the provenance exists and has been verified against a signed companion provenance."""
+    local_artifact_paths: dict[str, str]
+    # TODO this doc string for this variable need more informatino, to be revise later.
+    """The mapping between build tool types and the directory that contains the corresponding artifacts."""
 
 
 class AnalyzeContext:
@@ -110,6 +113,7 @@ class AnalyzeContext:
             provenance_repo_url=None,
             provenance_commit_digest=None,
             provenance_verified=False,
+            local_artifact_paths={},
         )
 
     @property

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -55,8 +55,8 @@ class ChecksOutputs(TypedDict):
     """The commit digest extracted from provenance, if applicable."""
     provenance_verified: bool
     """True if the provenance exists and has been verified against a signed companion provenance."""
-    local_artifact_paths: dict[str, list[str]]
-    """The mapping between purl types and the local artifact absolute paths."""
+    local_artifact_paths: list[str]
+    """The local artifact absolute paths."""
 
 
 class AnalyzeContext:
@@ -112,7 +112,7 @@ class AnalyzeContext:
             provenance_repo_url=None,
             provenance_commit_digest=None,
             provenance_verified=False,
-            local_artifact_paths={},
+            local_artifact_paths=[],
         )
 
     @property

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -16,6 +16,7 @@ from pydriller.git import Git
 from sqlalchemy.orm import Session
 
 from macaron import __version__
+from macaron.artifact.local_artifact import get_local_artifact_paths, get_local_artifact_repo_mapper
 from macaron.config.defaults import defaults
 from macaron.config.global_config import global_config
 from macaron.config.target_config import Configuration
@@ -472,6 +473,17 @@ class Analyzer:
             analyze_ctx.dynamic_data["provenance_verified"] = provenance_is_verified
         analyze_ctx.dynamic_data["provenance_repo_url"] = provenance_repo_url
         analyze_ctx.dynamic_data["provenance_commit_digest"] = provenance_commit_digest
+
+        discovered_build_toosl = (
+            analyze_ctx.dynamic_data["build_spec"]["tools"] + analyze_ctx.dynamic_data["build_spec"]["purl_tools"]
+        )
+        build_tools_purl_types = [build_tool.purl_type for build_tool in discovered_build_toosl]
+        analyze_ctx.dynamic_data["local_artifact_paths"] = get_local_artifact_paths(
+            # The PURL is definitely valid here.
+            PackageURL.from_string(analyze_ctx.component.purl),
+            build_tools_purl_types,
+            local_artifact_repo_mapper=get_local_artifact_repo_mapper(),
+        )
 
         analyze_ctx.check_results = registry.scan(analyze_ctx)
 

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -1012,6 +1012,11 @@ class Analyzer:
 
             if len(site_packages_dirs) == 1:
                 local_artifact_mapper["pypi"] = site_packages_dirs.pop()
+            else:
+                logger.info(
+                    "There are multiple python3.* directories in the input Python venv. "
+                    + "This venv will NOT be used for local artifact findings."
+                )
 
         return local_artifact_mapper
 

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -2,10 +2,13 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module handles the cloning and analyzing a Git repo."""
+
+import glob
 import logging
 import os
 import re
 import sys
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -16,7 +19,7 @@ from pydriller.git import Git
 from sqlalchemy.orm import Session
 
 from macaron import __version__
-from macaron.artifact.local_artifact import get_local_artifact_paths, get_local_artifact_repo_mapper
+from macaron.artifact.local_artifact import get_local_artifact_paths
 from macaron.config.defaults import defaults
 from macaron.config.global_config import global_config
 from macaron.config.target_config import Configuration
@@ -474,15 +477,14 @@ class Analyzer:
         analyze_ctx.dynamic_data["provenance_repo_url"] = provenance_repo_url
         analyze_ctx.dynamic_data["provenance_commit_digest"] = provenance_commit_digest
 
-        discovered_build_toosl = (
+        discovered_build_tools = (
             analyze_ctx.dynamic_data["build_spec"]["tools"] + analyze_ctx.dynamic_data["build_spec"]["purl_tools"]
         )
-        build_tools_purl_types = [build_tool.purl_type for build_tool in discovered_build_toosl]
+        build_tools_purl_types = [build_tool.purl_type for build_tool in discovered_build_tools]
         analyze_ctx.dynamic_data["local_artifact_paths"] = get_local_artifact_paths(
-            # The PURL is definitely valid here.
             PackageURL.from_string(analyze_ctx.component.purl),
             build_tools_purl_types,
-            local_artifact_repo_mapper=get_local_artifact_repo_mapper(),
+            local_artifact_repo_mapper=self._get_local_artifact_repo_mapper(),
         )
 
         analyze_ctx.check_results = registry.scan(analyze_ctx)
@@ -984,6 +986,30 @@ class Analyzer:
                 build_tool=build_tool,
             )
             analyze_ctx.dynamic_data["repo_verification"].append(verification_result)
+
+    @staticmethod
+    def _get_local_artifact_repo_mapper() -> Mapping[str, str]:
+        """Return the mapping between purl type and its local artifact repo path if that path exists."""
+        local_artifact_mapper: dict[str, str] = {}
+
+        if global_config.local_maven_repo:
+            m2_repository_dir = os.path.join(global_config.local_maven_repo, "repository")
+            if os.path.isdir(m2_repository_dir):
+                local_artifact_mapper["maven"] = m2_repository_dir
+
+        if global_config.python_venv_path:
+            site_packages_dir_pattern = os.path.join(
+                global_config.python_venv_path,
+                "lib",
+                "python3.*",
+                "site-packages",
+            )
+            site_packages_dirs = glob.glob(site_packages_dir_pattern)
+
+            if len(site_packages_dirs) == 1:
+                local_artifact_mapper["pypi"] = site_packages_dirs.pop()
+
+        return local_artifact_mapper
 
 
 class DuplicateCmpError(DuplicateError):

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -19,7 +19,7 @@ from pydriller.git import Git
 from sqlalchemy.orm import Session
 
 from macaron import __version__
-from macaron.artifact.local_artifact import get_local_artifact_paths
+from macaron.artifact.local_artifact import get_local_artifact_dirs
 from macaron.config.defaults import defaults
 from macaron.config.global_config import global_config
 from macaron.config.target_config import Configuration
@@ -482,7 +482,7 @@ class Analyzer:
         if parsed_purl and parsed_purl.type in self.local_artifact_repo_mapper:
             local_artifact_repo_path = self.local_artifact_repo_mapper[parsed_purl.type]
             analyze_ctx.dynamic_data["local_artifact_paths"].extend(
-                get_local_artifact_paths(
+                get_local_artifact_dirs(
                     purl=parsed_purl,
                     local_artifact_repo_path=local_artifact_repo_path,
                 )

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -30,6 +30,7 @@ from macaron.errors import (
     DuplicateError,
     InvalidAnalysisTargetError,
     InvalidPURLError,
+    LocalArtifactFinderError,
     ProvenanceError,
     PURLNotFoundError,
 )
@@ -481,12 +482,14 @@ class Analyzer:
 
         if parsed_purl and parsed_purl.type in self.local_artifact_repo_mapper:
             local_artifact_repo_path = self.local_artifact_repo_mapper[parsed_purl.type]
-            analyze_ctx.dynamic_data["local_artifact_paths"].extend(
-                get_local_artifact_dirs(
+            try:
+                local_artifact_dirs = get_local_artifact_dirs(
                     purl=parsed_purl,
                     local_artifact_repo_path=local_artifact_repo_path,
                 )
-            )
+                analyze_ctx.dynamic_data["local_artifact_paths"].extend(local_artifact_dirs)
+            except LocalArtifactFinderError as error:
+                logger.debug(error)
 
         analyze_ctx.check_results = registry.scan(analyze_ctx)
 

--- a/src/macaron/slsa_analyzer/package_registry/jfrog_maven_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/jfrog_maven_registry.py
@@ -13,6 +13,7 @@ from urllib.parse import SplitResult, urlunsplit
 
 import requests
 
+from macaron.artifact.maven import construct_maven_repository_path
 from macaron.config.defaults import defaults
 from macaron.errors import ConfigurationError
 from macaron.json_tools import JsonType
@@ -197,44 +198,6 @@ class JFrogMavenRegistry(PackageRegistry):
         compatible_build_tool_classes = [Maven, Gradle]
         return any(isinstance(build_tool, build_tool_class) for build_tool_class in compatible_build_tool_classes)
 
-    def construct_maven_repository_path(
-        self,
-        group_id: str,
-        artifact_id: str | None = None,
-        version: str | None = None,
-        asset_name: str | None = None,
-    ) -> str:
-        """Construct a path to a folder or file on the registry, assuming Maven repository layout.
-
-        For more details regarding Maven repository layout, see the following:
-        - https://maven.apache.org/repository/layout.html
-        - https://maven.apache.org/guides/mini/guide-naming-conventions.html
-
-        Parameters
-        ----------
-        group_id : str
-            The group id of a Maven package.
-        artifact_id : str
-            The artifact id of a Maven package.
-        version : str
-            The version of a Maven package.
-        asset_name : str
-            The asset name.
-
-        Returns
-        -------
-        str
-            The path to a folder or file on the registry.
-        """
-        path = group_id.replace(".", "/")
-        if artifact_id:
-            path = "/".join([path, artifact_id])
-        if version:
-            path = "/".join([path, version])
-        if asset_name:
-            path = "/".join([path, asset_name])
-        return path
-
     def fetch_artifact_ids(self, group_id: str) -> list[str]:
         """Get all artifact ids under a group id.
 
@@ -251,7 +214,7 @@ class JFrogMavenRegistry(PackageRegistry):
             The artifacts ids under the group.
         """
         folder_info_url = self.construct_folder_info_url(
-            folder_path=self.construct_maven_repository_path(group_id),
+            folder_path=construct_maven_repository_path(group_id),
         )
 
         try:
@@ -440,7 +403,7 @@ class JFrogMavenRegistry(PackageRegistry):
         list[str]
             The list of asset names.
         """
-        folder_path = self.construct_maven_repository_path(
+        folder_path = construct_maven_repository_path(
             group_id=group_id,
             artifact_id=artifact_id,
             version=version,
@@ -615,7 +578,7 @@ class JFrogMavenRegistry(PackageRegistry):
         JFrogMavenAssetMetadata | None
             The asset's metadata, or ``None`` if the metadata cannot be retrieved.
         """
-        file_path = self.construct_maven_repository_path(
+        file_path = construct_maven_repository_path(
             group_id=group_id,
             artifact_id=artifact_id,
             version=version,
@@ -798,7 +761,7 @@ class JFrogMavenRegistry(PackageRegistry):
         str
             The URL to the asset, which can be use for downloading the asset.
         """
-        group_path = self.construct_maven_repository_path(group_id)
+        group_path = construct_maven_repository_path(group_id)
         return urlunsplit(
             SplitResult(
                 scheme="https",

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -3,74 +3,138 @@
 
 """Test the local artifact utilities."""
 
-import tempfile
-from collections.abc import Mapping
+import os
+from pathlib import Path
 
 import pytest
 from packageurl import PackageURL
 
-from macaron.artifact.local_artifact import construct_local_artifact_paths_from_purl, get_local_artifact_paths
+from macaron.artifact.local_artifact import (
+    construct_local_artifact_paths_glob_pattern_maven_purl,
+    construct_local_artifact_paths_glob_pattern_pypi_purl,
+    find_artifact_paths_from_python_venv,
+    get_local_artifact_paths,
+)
 
 
 @pytest.mark.parametrize(
-    ("build_purl_type", "purl_str", "local_artifact_repo_mapper", "expectation"),
+    ("purl_str", "expectation"),
     [
         pytest.param(
-            "maven",
             "pkg:maven/com.google.guava/guava@33.2.1-jre",
-            {"maven": "/home/foo/.m2"},
-            ["/home/foo/.m2/repository/com/google/guava/guava/33.2.1-jre"],
-            id="A maven type PURL with available local maven repo",
+            ["com/google/guava/guava/33.2.1-jre"],
+            id="A Maven PURL with group, artifact and version",
         ),
         pytest.param(
-            "maven",
-            "pkg:maven/com.google.guava/guava@33.2.1-jre",
-            {},
-            None,
-            id="A maven type PURL without an available local maven repo",
-        ),
-        pytest.param(
-            "maven",
-            "pkg:maven/com.google.guava/guava@33.2.1-jre",
-            {"pypi": "/home/foo/.venv"},
-            None,
-            id="A maven type PURL without an available local maven repo but there is a Python venv",
-        ),
-        pytest.param(
-            "maven",
-            "pkg:maven/com.google.guava/guava",
-            {"maven": "/home/foo/.m2"},
-            None,
-            id="A maven type PURL with missing version and an available local maven repo",
-        ),
-        pytest.param(
-            "maven",
-            "pkg:maven/guava",
-            {"maven": "/home/foo/.m2"},
-            None,
-            id="A maven type PURL with missing groupd Id and an available local maven repo",
-        ),
-        pytest.param(
-            "maven",
-            "pkg:github/oracle/macaron",
-            {"maven": "/home/foo/.m2"},
-            None,
-            id="A git type PURL and an available local maven repo",
+            "pkg:maven/com.google.guava/guava@33.2.1-jre?type=jar",
+            ["com/google/guava/guava/33.2.1-jre"],
+            id="A Maven PURL with group artifact, version and type qualifier",
         ),
     ],
 )
-def test_construct_local_artifact_path_from_purl(
-    build_purl_type: str,
+def test_construct_local_artifact_paths_glob_pattern_maven_purl(
     purl_str: str,
-    local_artifact_repo_mapper: Mapping[str, str],
     expectation: list[str],
 ) -> None:
-    """Test constructing a local artifact path from a given purl."""
-    component_purl = PackageURL.from_string(purl_str)
+    """Test constructing a local artifact patterns from a given maven purl."""
+    maven_purl = PackageURL.from_string(purl_str)
+    result = construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl=maven_purl)
+    assert result is not None
+    assert sorted(result) == sorted(expectation)
+
+
+@pytest.mark.parametrize(
+    ("purl_str"),
+    [
+        pytest.param("pkg:pypi/django@5.0.6", id="The purl type is not supported."),
+        pytest.param("pkg:maven/guava@33.2.1-jre", id="Missing group id in the PURL"),
+        pytest.param("pkg:maven/guava", id="Missing version"),
+    ],
+)
+def test_construct_local_artifact_paths_glob_pattern_maven_purl_error(purl_str: str) -> None:
+    """Test constructing a local artifact patterns from a given maven purl with error."""
+    maven_purl = PackageURL.from_string(purl_str)
+    result = construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl=maven_purl)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("purl_str", "expectation"),
+    [
+        pytest.param(
+            "pkg:pypi/django@5.0.6",
+            ["django", "django-5.0.6.dist-info", "django-5.0.6.data"],
+            id="A valid pypi PURL with version",
+        )
+    ],
+)
+def test_construct_local_artifact_paths_glob_pattern_pypi_purl(
+    purl_str: str,
+    expectation: list[str],
+) -> None:
+    """Test constructing a local artifact patterns from a given pypi purl."""
+    pypi_purl = PackageURL.from_string(purl_str)
+    result = construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl=pypi_purl)
+    assert result is not None
+    assert sorted(result) == sorted(expectation)
+
+
+@pytest.mark.parametrize(
+    ("purl_str"),
+    [
+        pytest.param(
+            "pkg:pypi/django",
+            id="A pypi PURL without version",
+        ),
+        pytest.param(
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            id="The purl type is not supported.",
+        ),
+    ],
+)
+def test_construct_local_artifact_paths_glob_pattern_pypi_purl_error(purl_str: str) -> None:
+    """Test constructing a local artifact patterns from a given pypi purl with error."""
+    pypi_purl = PackageURL.from_string(purl_str)
+    result = construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl=pypi_purl)
+    assert result is None
+
+
+def test_find_artifact_paths_from_invalid_python_venv() -> None:
+    """Test find_artifact_paths_from_python_venv method with invalid venv path"""
+    assert not find_artifact_paths_from_python_venv("./does-not-exist", ["django", "django-5.0.6.dist-info"])
+
+
+@pytest.mark.parametrize(
+    ("purl_str", "build_tool_purl_types", "local_artifact_repo_mapper", "expectation"),
+    [
+        pytest.param(
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            ["maven", "pypi"],
+            {},
+            {},
+            id="A maven type PURL where multiple build tool types are discovered. But no local repository is available.",
+        ),
+        pytest.param(
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            [],
+            {},
+            {},
+            id="A maven type PURL where no build tool types are discovered and no local repository is available.",
+        ),
+    ],
+)
+def test_get_local_artifact_paths_empty(
+    purl_str: str,
+    build_tool_purl_types: list[str],
+    local_artifact_repo_mapper: dict[str, str],
+    expectation: dict[str, list[str]],
+) -> None:
+    """Test getting local artifact paths where the result is empty."""
+    purl = PackageURL.from_string(purl_str)
     assert (
-        construct_local_artifact_paths_from_purl(
-            build_purl_type=build_purl_type,
-            component_purl=component_purl,
+        get_local_artifact_paths(
+            purl=purl,
+            build_tool_purl_types=build_tool_purl_types,
             local_artifact_repo_mapper=local_artifact_repo_mapper,
         )
         == expectation
@@ -83,31 +147,108 @@ def test_construct_local_artifact_path_from_purl(
         pytest.param(
             "pkg:maven/com.google.guava/guava@33.2.1-jre",
             ["maven", "pypi"],
-            {"maven": []},
-            id="A maven type PURL where multiple build tool types are discovered. But no artifact path is available.",
+            {},
+            id="A maven type PURL where multiple build tool types are discovered",
+        ),
+        pytest.param(
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            [],
+            {},
+            id="A maven type PURL where no build tool is discovered",
+        ),
+        pytest.param(
+            "pkg:pypi/django@5.0.3",
+            [],
+            {},
+            id="A maven type PURL where no build tool is discovered",
         ),
     ],
 )
-def test_get_local_artifact_paths_non_existing(
+def test_get_local_artifact_paths_not_available(
     purl_str: str,
     build_tool_purl_types: list[str],
     expectation: dict[str, list[str]],
+    tmp_path: Path,
 ) -> None:
-    """Test getting local artifact paths of non existing artifacts.
-
-    The local artifact repos are available.
-    """
+    """Test getting local artifact paths where the artifact paths are not available."""
     purl = PackageURL.from_string(purl_str)
-    with tempfile.TemporaryDirectory() as temp_dir:
-        local_artifact_repo_mapper = {
-            "maven": temp_dir,
-            "pypi": temp_dir,
-        }
-        assert (
-            get_local_artifact_paths(
-                purl=purl,
-                build_tool_purl_types=build_tool_purl_types,
-                local_artifact_repo_mapper=local_artifact_repo_mapper,
-            )
-            == expectation
+    local_artifact_repo_mapper = {
+        "maven": str(tmp_path),
+        "pypi": str(tmp_path),
+    }
+
+    assert (
+        get_local_artifact_paths(
+            purl=purl,
+            build_tool_purl_types=build_tool_purl_types,
+            local_artifact_repo_mapper=local_artifact_repo_mapper,
         )
+        == expectation
+    )
+
+
+def test_get_local_artifact_paths_succeeded_maven(tmp_path: Path) -> None:
+    """Test getting local artifact paths succeeded with maven purl."""
+    purl = PackageURL.from_string("pkg:maven/com.oracle.macaron/macaron@0.13.0")
+    build_tool_purl_types = ["maven", "pypi"]
+
+    tmp_path_str = str(tmp_path)
+
+    local_artifact_repo_mapper = {
+        "maven": f"{tmp_path_str}/.m2/repository",
+        "pypi": f"{tmp_path_str}/.venv/lib/python3.11/site-packages",
+    }
+    maven_artifact_path = f"{local_artifact_repo_mapper['maven']}/com/oracle/macaron/macaron/0.13.0"
+    os.makedirs(local_artifact_repo_mapper["maven"])
+    os.makedirs(local_artifact_repo_mapper["pypi"])
+    os.makedirs(maven_artifact_path)
+
+    expectation = {
+        "maven": [maven_artifact_path],
+    }
+
+    result = get_local_artifact_paths(
+        purl=purl,
+        build_tool_purl_types=build_tool_purl_types,
+        local_artifact_repo_mapper=local_artifact_repo_mapper,
+    )
+
+    assert result == expectation
+
+
+def test_get_local_artifact_paths_succeeded_pypi(tmp_path: Path) -> None:
+    """Test getting local artifact paths succeeded with pypi purl."""
+    purl = PackageURL.from_string("pkg:pypi/macaron@0.13.0")
+    build_tool_purl_types = ["maven", "pypi"]
+
+    tmp_path_str = str(tmp_path)
+
+    local_artifact_repo_mapper = {
+        "maven": f"{tmp_path_str}/.m2/repository",
+        "pypi": f"{tmp_path_str}/.venv/lib/python3.11/site-packages",
+    }
+    pypi_artifact_paths = [
+        f"{local_artifact_repo_mapper['pypi']}/macaron",
+        f"{local_artifact_repo_mapper['pypi']}/macaron-0.13.0.dist-info",
+        f"{local_artifact_repo_mapper['pypi']}/Macaron-0.13.0.dist-info",
+    ]
+
+    os.makedirs(local_artifact_repo_mapper["maven"])
+    os.makedirs(local_artifact_repo_mapper["pypi"])
+
+    for artifact_path in pypi_artifact_paths:
+        os.makedirs(artifact_path)
+
+    expectation = {
+        "pypi": sorted(pypi_artifact_paths),
+    }
+
+    result = get_local_artifact_paths(
+        purl=purl,
+        build_tool_purl_types=build_tool_purl_types,
+        local_artifact_repo_mapper=local_artifact_repo_mapper,
+    )
+    for value in result.values():
+        value.sort()
+
+    assert result == expectation

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -160,7 +160,7 @@ def test_get_local_artifact_paths_empty(
             "pkg:pypi/django@5.0.3",
             [],
             {},
-            id="A maven type PURL where no build tool is discovered",
+            id="A pypi type PURL where no build tool is discovered",
         ),
     ],
 )

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -10,8 +10,8 @@ import pytest
 from packageurl import PackageURL
 
 from macaron.artifact.local_artifact import (
-    construct_local_artifact_paths_glob_pattern_maven_purl,
-    construct_local_artifact_paths_glob_pattern_pypi_purl,
+    construct_local_artifact_dirs_glob_pattern_maven_purl,
+    construct_local_artifact_dirs_glob_pattern_pypi_purl,
     find_artifact_paths_from_python_venv,
     get_local_artifact_paths,
 )
@@ -39,7 +39,7 @@ def test_construct_local_artifact_paths_glob_pattern_maven_purl(
 ) -> None:
     """Test constructing a local artifact patterns from a given maven purl."""
     maven_purl = PackageURL.from_string(purl_str)
-    result = construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl=maven_purl)
+    result = construct_local_artifact_dirs_glob_pattern_maven_purl(maven_purl=maven_purl)
     assert result is not None
     assert sorted(result) == sorted(expectation)
 
@@ -55,7 +55,7 @@ def test_construct_local_artifact_paths_glob_pattern_maven_purl(
 def test_construct_local_artifact_paths_glob_pattern_maven_purl_error(purl_str: str) -> None:
     """Test constructing a local artifact patterns from a given maven purl with error."""
     maven_purl = PackageURL.from_string(purl_str)
-    result = construct_local_artifact_paths_glob_pattern_maven_purl(maven_purl=maven_purl)
+    result = construct_local_artifact_dirs_glob_pattern_maven_purl(maven_purl=maven_purl)
     assert result is None
 
 
@@ -75,7 +75,7 @@ def test_construct_local_artifact_paths_glob_pattern_pypi_purl(
 ) -> None:
     """Test constructing a local artifact patterns from a given pypi purl."""
     pypi_purl = PackageURL.from_string(purl_str)
-    result = construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl=pypi_purl)
+    result = construct_local_artifact_dirs_glob_pattern_pypi_purl(pypi_purl=pypi_purl)
     assert result is not None
     assert sorted(result) == sorted(expectation)
 
@@ -96,7 +96,7 @@ def test_construct_local_artifact_paths_glob_pattern_pypi_purl(
 def test_construct_local_artifact_paths_glob_pattern_pypi_purl_error(purl_str: str) -> None:
     """Test constructing a local artifact patterns from a given pypi purl with error."""
     pypi_purl = PackageURL.from_string(purl_str)
-    result = construct_local_artifact_paths_glob_pattern_pypi_purl(pypi_purl=pypi_purl)
+    result = construct_local_artifact_dirs_glob_pattern_pypi_purl(pypi_purl=pypi_purl)
     assert result is None
 
 

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Test the local artifact utilities."""
+
+import tempfile
+from collections.abc import Mapping
+
+import pytest
+from packageurl import PackageURL
+
+from macaron.artifact.local_artifact import construct_local_artifact_path_from_purl, get_local_artifact_paths
+
+
+@pytest.mark.parametrize(
+    ("build_purl_type", "purl_str", "local_artifact_repo_mapper", "expectation"),
+    [
+        pytest.param(
+            "maven",
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            {"maven": "/home/foo/.m2"},
+            "/home/foo/.m2/repository/com/google/guava/guava/33.2.1-jre",
+            id="A maven type PURL with available local maven repo",
+        ),
+        pytest.param(
+            "maven",
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            {},
+            None,
+            id="A maven type PURL without an available local maven repo",
+        ),
+        pytest.param(
+            "maven",
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            {"pypi": "/home/foo/.venv"},
+            None,
+            id="A maven type PURL without an available local maven repo but there is a Python venv",
+        ),
+        pytest.param(
+            "maven",
+            "pkg:maven/com.google.guava/guava",
+            {"maven": "/home/foo/.m2"},
+            None,
+            id="A maven type PURL with missing version and an available local maven repo",
+        ),
+        pytest.param(
+            "maven",
+            "pkg:maven/guava",
+            {"maven": "/home/foo/.m2"},
+            None,
+            id="A maven type PURL with missing groupd Id and an available local maven repo",
+        ),
+        pytest.param(
+            "maven",
+            "pkg:github/oracle/macaron",
+            {"maven": "/home/foo/.m2"},
+            None,
+            id="A git type PURL and an available local maven repo",
+        ),
+    ],
+)
+def test_construct_local_artifact_path_from_purl(
+    build_purl_type: str,
+    purl_str: str,
+    local_artifact_repo_mapper: Mapping[str, str],
+    expectation: str,
+) -> None:
+    """Test constructing a local artifact path from a given purl."""
+    component_purl = PackageURL.from_string(purl_str)
+    assert (
+        construct_local_artifact_path_from_purl(
+            build_purl_type=build_purl_type,
+            component_purl=component_purl,
+            local_artifact_repo_mapper=local_artifact_repo_mapper,
+        )
+        == expectation
+    )
+
+
+@pytest.mark.parametrize(
+    ("purl_str", "build_tool_purl_types"),
+    [
+        pytest.param(
+            "pkg:maven/com.google.guava/guava@33.2.1-jre",
+            ["maven", "pypi"],
+            id="A maven type PURL where multiple build tool types are discovered",
+        ),
+    ],
+)
+def test_get_local_artifact_paths_non_existing(
+    purl_str: str,
+    build_tool_purl_types: list[str],
+) -> None:
+    """Test getting local artifact paths of non existing artifacts.
+
+    The local artifact repos are available.
+    """
+    purl = PackageURL.from_string(purl_str)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        local_artifact_repo_mapper = {
+            "maven": temp_dir,
+            "pypi": temp_dir,
+        }
+        assert not get_local_artifact_paths(
+            purl=purl,
+            build_tool_purl_types=build_tool_purl_types,
+            local_artifact_repo_mapper=local_artifact_repo_mapper,
+        )

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -12,8 +12,8 @@ from packageurl import PackageURL
 from macaron.artifact.local_artifact import (
     construct_local_artifact_dirs_glob_pattern_maven_purl,
     construct_local_artifact_dirs_glob_pattern_pypi_purl,
-    find_artifact_paths_from_python_venv,
-    get_local_artifact_paths,
+    find_artifact_dirs_from_python_venv,
+    get_local_artifact_dirs,
 )
 from macaron.errors import LocalArtifactFinderError
 
@@ -103,7 +103,7 @@ def test_construct_local_artifact_paths_glob_pattern_pypi_purl_error(purl_str: s
 def test_find_artifact_paths_from_invalid_python_venv() -> None:
     """Test find_artifact_paths_from_python_venv method with invalid venv path"""
     with pytest.raises(LocalArtifactFinderError):
-        find_artifact_paths_from_python_venv("./does-not-exist", ["django", "django-5.0.6.dist-info"])
+        find_artifact_dirs_from_python_venv("./does-not-exist", ["django", "django-5.0.6.dist-info"])
 
 
 @pytest.mark.parametrize(
@@ -130,7 +130,7 @@ def test_get_local_artifact_paths_not_available(
     purl = PackageURL.from_string(purl_str)
 
     assert (
-        get_local_artifact_paths(
+        get_local_artifact_dirs(
             purl=purl,
             local_artifact_repo_path=str(tmp_path),
         )
@@ -171,7 +171,7 @@ def test_get_local_artifact_paths_invalid_purl(
     purl = PackageURL.from_string(purl_str)
 
     with pytest.raises(LocalArtifactFinderError):
-        get_local_artifact_paths(
+        get_local_artifact_dirs(
             purl=purl,
             local_artifact_repo_path=str(tmp_path),
         )
@@ -188,7 +188,7 @@ def test_get_local_artifact_paths_succeeded_maven(tmp_path: Path) -> None:
     os.makedirs(maven_local_repo_path)
     os.makedirs(target_artifact_path)
 
-    result = get_local_artifact_paths(
+    result = get_local_artifact_dirs(
         purl=purl,
         local_artifact_repo_path=maven_local_repo_path,
     )
@@ -218,7 +218,7 @@ def test_get_local_artifact_paths_succeeded_pypi(tmp_path: Path) -> None:
     for artifact_path in pypi_artifact_paths:
         os.makedirs(artifact_path)
 
-    result = get_local_artifact_paths(
+    result = get_local_artifact_dirs(
         purl=purl,
         local_artifact_repo_path=python_venv_path,
     )

--- a/tests/artifact/test_maven.py
+++ b/tests/artifact/test_maven.py
@@ -6,7 +6,7 @@
 import pytest
 from packageurl import PackageURL
 
-from macaron.artifact.maven import MavenSubjectPURLMatcher
+from macaron.artifact.maven import MavenSubjectPURLMatcher, construct_maven_repository_path
 from macaron.slsa_analyzer.provenance.intoto import InTotoPayload, validate_intoto_payload
 
 
@@ -86,3 +86,78 @@ def test_to_maven_artifact_subject(
         )
         == provenance_payload.statement["subject"][subject_index]
     )
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_path"),
+    [
+        pytest.param(
+            {
+                "group_id": "io.micronaut",
+            },
+            "io/micronaut",
+            id="Only group_id 1",
+        ),
+        pytest.param(
+            {
+                "group_id": "com.fasterxml.jackson.core",
+            },
+            "com/fasterxml/jackson/core",
+            id="Only group_id 2",
+        ),
+        pytest.param(
+            {
+                "group_id": "com.fasterxml.jackson.core",
+                "artifact_id": "jackson-annotations",
+            },
+            "com/fasterxml/jackson/core/jackson-annotations",
+            id="group_id and artifact_id",
+        ),
+        pytest.param(
+            {
+                "group_id": "com.fasterxml.jackson.core",
+                "artifact_id": "jackson-annotations",
+                "version": "2.9.9",
+            },
+            "com/fasterxml/jackson/core/jackson-annotations/2.9.9",
+            id="group_id and artifact_id and version",
+        ),
+        pytest.param(
+            {
+                "group_id": "com.fasterxml.jackson.core",
+                "artifact_id": "jackson-annotations",
+                "version": "2.9.9",
+                "asset_name": "jackson-annotations-2.9.9.jar",
+            },
+            "com/fasterxml/jackson/core/jackson-annotations/2.9.9/jackson-annotations-2.9.9.jar",
+            id="group_id and artifact_id and version and asset_name,",
+        ),
+    ],
+)
+def test_construct_maven_repository_path(
+    args: dict,
+    expected_path: str,
+) -> None:
+    """Test the ``construct_maven_repository_path`` method."""
+    assert construct_maven_repository_path(**args) == expected_path
+
+
+@pytest.mark.parametrize(
+    ("group_id", "expected_group_path"),
+    [
+        (
+            "io.micronaut",
+            "io/micronaut",
+        ),
+        (
+            "com.fasterxml.jackson.core",
+            "com/fasterxml/jackson/core",
+        ),
+    ],
+)
+def test_to_group_folder_path(
+    group_id: str,
+    expected_group_path: str,
+) -> None:
+    """Test the ``to_gorup_folder_path`` method."""
+    assert construct_maven_repository_path(group_id) == expected_group_path

--- a/tests/integration/cases/docker_local_maven_repo_input_errors/test.yaml
+++ b/tests/integration/cases/docker_local_maven_repo_input_errors/test.yaml
@@ -27,7 +27,7 @@ steps:
     - --local-maven-repo
     - invalid_dir
   expect_fail: true
-- name: Create a test file.
+- name: Create a test file to mimick user input. Therefore, this test file will be outside of the output dir.
   kind: shell
   options:
     cmd: touch test.txt
@@ -40,7 +40,7 @@ steps:
     - --local-maven-repo
     - ./test.txt
   expect_fail: true
-- name: Clean up the test file.
+- name: Clean up the test file because it's not automatically cleaned up by the test script as it's outside of the output directory.
   kind: shell
   options:
     cmd: rm test.txt

--- a/tests/integration/cases/docker_local_maven_repo_input_errors/test.yaml
+++ b/tests/integration/cases/docker_local_maven_repo_input_errors/test.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Test invalid usecases for --local-maven-repo.
+
+tags:
+- macaron-docker-image
+- macaron-python-package
+
+steps:
+- name: HOME environment variable is not set and --local-maven-repo is not used.
+  kind: analyze
+  env:
+    HOME:
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar
+  expect_fail: true
+- name: Providing a directory that doesn't exist to --local-maven-repo.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar
+    - --local-maven-repo
+    - invalid_dir
+  expect_fail: true
+- name: Create a test file.
+  kind: shell
+  options:
+    cmd: touch test.txt
+- name: Providing a file path to --local-maven-repo.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.github.behnazh-w.demo/example-maven-app@1.0?type=jar
+    - --local-maven-repo
+    - ./test.txt
+  expect_fail: true
+- name: Clean up the test file.
+  kind: shell
+  options:
+    cmd: rm test.txt

--- a/tests/integration/cases/run_macaron_sh_script_unit_test/test_run_macaron_sh.py
+++ b/tests/integration/cases/run_macaron_sh_script_unit_test/test_run_macaron_sh.py
@@ -81,7 +81,7 @@ def test_macaron_command_help() -> int:
     return exit_code
 
 
-def test_macaron_command_no_home_m2() -> int:
+def test_macaron_command_no_home_m2_on_host() -> int:
     """Test if the ``macaron`` command in the container receives the correct arguments."""
     test_cases = [
         TestCase(
@@ -103,11 +103,11 @@ def test_macaron_command_no_home_m2() -> int:
     return exit_code
 
 
-def test_macaron_command_home_m2_available() -> int:
+def test_macaron_command_host_home_m2_available() -> int:
     """Test if the ``macaron`` command in the container receives the correct arguments."""
     test_cases = [
         TestCase(
-            name="no --local-maven-repo and host $HOME/.m2 is available",
+            name="no --local-maven-repo provided by the user and host $HOME/.m2 is available",
             script_args=["analyze"],
             expected_macaron_args=["analyze", "--local-maven-repo", "/home/macaron/analyze_local_maven_repo_readonly"],
         ),
@@ -130,7 +130,7 @@ def test_macaron_command_home_m2_available() -> int:
     return exit_code
 
 
-def test_macaron_provide_local_maven_repo() -> int:
+def test_macaron_user_provide_valid_local_maven_repo() -> int:
     """Test if the ``macaron`` command in the container receives the correct arguments."""
     with tempfile.TemporaryDirectory() as temp_dir:
         test_cases = [
@@ -159,9 +159,9 @@ def main() -> int:
     """Run all tests."""
     return (
         test_macaron_command_help()
-        | test_macaron_command_no_home_m2()
-        | test_macaron_command_home_m2_available()
-        | test_macaron_provide_local_maven_repo()
+        | test_macaron_command_no_home_m2_on_host()
+        | test_macaron_command_host_home_m2_available()
+        | test_macaron_user_provide_valid_local_maven_repo()
     )
 
 

--- a/tests/integration/cases/run_macaron_sh_script_unit_test/test_run_macaron_sh.py
+++ b/tests/integration/cases/run_macaron_sh_script_unit_test/test_run_macaron_sh.py
@@ -6,13 +6,54 @@
 import os
 import subprocess  # nosec B404
 import sys
+import tempfile
 from collections import namedtuple
 
+TestCase = namedtuple("TestCase", ["name", "script_args", "expected_macaron_args"])
 
-def test_macaron_command() -> int:
+
+def run_test_case(
+    test_case: TestCase,
+    env: dict[str, str],
+) -> int:
+    """Run a test case in an environment with variables defined by `env` and return the exit code."""
+    exit_code = 0
+
+    name, script_args, expected_macaron_args = test_case
+    print(f"test_macaron_command[{name}]:", end=" ")
+
+    result = subprocess.run(
+        [  # nosec B603
+            "./output/run_macaron.sh",
+            *script_args,
+        ],
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        exit_code = 1
+        print(f"FAILED with exit code {exit_code}")
+        print("stderr:")
+        print(result.stderr.decode("utf-8"))
+        return exit_code
+
+    resulting_macaron_args = list(result.stderr.decode("utf-8").split())
+
+    if resulting_macaron_args != expected_macaron_args:
+        print("FAILED")
+        print("  script args           : %s", str(script_args))
+        print("  expected macaron args : %s", str(expected_macaron_args))
+        print("  resulting macaron args: %s", str(resulting_macaron_args))
+        exit_code = 1
+    else:
+        print("PASSED")
+
+    return exit_code
+
+
+def test_macaron_command_help() -> int:
     """Test if the ``macaron`` command in the container receives the correct arguments."""
-    TestCase = namedtuple("TestCase", ["name", "script_args", "expected_macaron_args"])
-
     test_cases = [
         TestCase(
             name="'-h' as main argument",
@@ -20,9 +61,9 @@ def test_macaron_command() -> int:
             expected_macaron_args=["-h"],
         ),
         TestCase(
-            name="'-h' as action argument for 'analyze'",
-            script_args=["analyze", "-h"],
-            expected_macaron_args=["analyze", "-h"],
+            name="'-h' as action argument for 'dump-defaults'",
+            script_args=["dump-defaults", "-h"],
+            expected_macaron_args=["dump-defaults", "-h"],
         ),
         TestCase(
             name="'-h' as action argument for 'verify-policy'",
@@ -31,47 +72,97 @@ def test_macaron_command() -> int:
         ),
     ]
 
-    exit_code = 0
     env = dict(os.environ)
     env["MCN_DEBUG_ARGS"] = "1"
 
-    for test_case in test_cases:
-        name, script_args, expected_macaron_args = test_case
-        print(f"test_macaron_command[{name}]:", end=" ")
+    for case in test_cases:
+        exit_code = run_test_case(case, env)
 
-        result = subprocess.run(
-            [  # nosec B603
-                "./output/run_macaron.sh",
-                *script_args,
-            ],
-            capture_output=True,
-            env=env,
-            check=False,
-        )
-        if result.returncode != 0:
-            exit_code = 1
-            print(f"FAILED with exit code {exit_code}")
-            print("stderr:")
-            print(result.stderr.decode("utf-8"))
-            continue
+    return exit_code
 
-        resulting_macaron_args = list(result.stderr.decode("utf-8").split())
 
-        if resulting_macaron_args != expected_macaron_args:
-            print("FAILED")
-            print("  script args           : %s", str(script_args))
-            print("  expected macaron args : %s", str(expected_macaron_args))
-            print("  resulting macaron args: %s", str(resulting_macaron_args))
-            exit_code = 1
-        else:
-            print("PASSED")
+def test_macaron_command_no_home_m2() -> int:
+    """Test if the ``macaron`` command in the container receives the correct arguments."""
+    test_cases = [
+        TestCase(
+            name="no --local-maven-repo and host $HOME/.m2 is not available",
+            script_args=["analyze"],
+            expected_macaron_args=["analyze", "--local-maven-repo", "/home/macaron/analyze_local_maven_repo_readonly"],
+        ),
+    ]
+
+    env = dict(os.environ)
+    env["MCN_DEBUG_ARGS"] = "1"
+    # We mimick the behavior of $HOME/.m2 not available by making $HOME pointing to a directory that doesn't exist.
+    env["HOME"] = "./non_exist_dir"
+
+    exit_code = 0
+    for case in test_cases:
+        exit_code = run_test_case(case, env)
+
+    return exit_code
+
+
+def test_macaron_command_home_m2_available() -> int:
+    """Test if the ``macaron`` command in the container receives the correct arguments."""
+    test_cases = [
+        TestCase(
+            name="no --local-maven-repo and host $HOME/.m2 is available",
+            script_args=["analyze"],
+            expected_macaron_args=["analyze", "--local-maven-repo", "/home/macaron/analyze_local_maven_repo_readonly"],
+        ),
+    ]
+
+    env = dict(os.environ)
+    env["MCN_DEBUG_ARGS"] = "1"
+    exit_code = 0
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # We create a temp dir with a .m2 directory and point $HOME to it.
+        # This .m2 directory contains an empty `repository` directory.
+        os.mkdir(os.path.join(temp_dir, ".m2"))
+        os.mkdir(os.path.join(temp_dir, ".m2/repository"))
+        env["HOME"] = temp_dir
+
+        for case in test_cases:
+            exit_code = run_test_case(case, env)
+
+    return exit_code
+
+
+def test_macaron_provide_local_maven_repo() -> int:
+    """Test if the ``macaron`` command in the container receives the correct arguments."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_cases = [
+            TestCase(
+                name="with --local-maven-repo pointing to an existing directory",
+                script_args=["analyze", "--local-maven-repo", f"{temp_dir}"],
+                expected_macaron_args=[
+                    "analyze",
+                    "--local-maven-repo",
+                    "/home/macaron/analyze_local_maven_repo_readonly",
+                ],
+            ),
+        ]
+
+        env = dict(os.environ)
+        env["MCN_DEBUG_ARGS"] = "1"
+        exit_code = 0
+
+        for case in test_cases:
+            exit_code = run_test_case(case, env)
 
     return exit_code
 
 
 def main() -> int:
     """Run all tests."""
-    return test_macaron_command()
+    return (
+        test_macaron_command_help()
+        | test_macaron_command_no_home_m2()
+        | test_macaron_command_home_m2_available()
+        | test_macaron_provide_local_maven_repo()
+    )
 
 
 if __name__ == "__main__":

--- a/tests/slsa_analyzer/package_registry/test_jfrog_maven_registry.py
+++ b/tests/slsa_analyzer/package_registry/test_jfrog_maven_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for the ``JFrogMavenRegistry`` class."""
@@ -135,83 +135,6 @@ def test_is_detected(
     # (in the ini config).
     jfrog_maven.enabled = False
     assert jfrog_maven.is_detected(build_tool) is False
-
-
-@pytest.mark.parametrize(
-    ("args", "expected_path"),
-    [
-        pytest.param(
-            {
-                "group_id": "io.micronaut",
-            },
-            "io/micronaut",
-            id="Only group_id 1",
-        ),
-        pytest.param(
-            {
-                "group_id": "com.fasterxml.jackson.core",
-            },
-            "com/fasterxml/jackson/core",
-            id="Only group_id 2",
-        ),
-        pytest.param(
-            {
-                "group_id": "com.fasterxml.jackson.core",
-                "artifact_id": "jackson-annotations",
-            },
-            "com/fasterxml/jackson/core/jackson-annotations",
-            id="group_id and artifact_id",
-        ),
-        pytest.param(
-            {
-                "group_id": "com.fasterxml.jackson.core",
-                "artifact_id": "jackson-annotations",
-                "version": "2.9.9",
-            },
-            "com/fasterxml/jackson/core/jackson-annotations/2.9.9",
-            id="group_id and artifact_id and version",
-        ),
-        pytest.param(
-            {
-                "group_id": "com.fasterxml.jackson.core",
-                "artifact_id": "jackson-annotations",
-                "version": "2.9.9",
-                "asset_name": "jackson-annotations-2.9.9.jar",
-            },
-            "com/fasterxml/jackson/core/jackson-annotations/2.9.9/jackson-annotations-2.9.9.jar",
-            id="group_id and artifact_id and version and asset_name,",
-        ),
-    ],
-)
-def test_construct_maven_repository_path(
-    jfrog_maven: JFrogMavenRegistry,
-    args: dict,
-    expected_path: str,
-) -> None:
-    """Test the ``construct_maven_repository_path`` method."""
-    assert jfrog_maven.construct_maven_repository_path(**args) == expected_path
-
-
-@pytest.mark.parametrize(
-    ("group_id", "expected_group_path"),
-    [
-        (
-            "io.micronaut",
-            "io/micronaut",
-        ),
-        (
-            "com.fasterxml.jackson.core",
-            "com/fasterxml/jackson/core",
-        ),
-    ],
-)
-def test_to_group_folder_path(
-    jfrog_maven: JFrogMavenRegistry,
-    group_id: str,
-    expected_group_path: str,
-) -> None:
-    """Test the ``to_gorup_folder_path`` method."""
-    assert jfrog_maven.construct_maven_repository_path(group_id) == expected_group_path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #811 
# Description
This pull request adds the following features:
- The ability to provide Macaron with a [maven local repository](https://maven.apache.org/repositories/local.html)
- The ability to resolve the directories that contains artifacts corresponding to a PackageURL from the Maven local repository and/or the Python virtual environment.

## Providing a Maven local repository.
A new CLI parameter is added `--local-maven-repo` that takes a path to a maven local repo. This flag is optional.
If `--local-maven-repo` is not used, Macaron will load the path to the local maven repo (at `$HOME/.m2`) if that directory is available.
Macaron will treat this maven local repo as *READ-ONLY*.

### What directory to mount if Macaron is being run as a Docker container?
If `--local-maven-repo` is provided to `run_macaron.sh`, the directory provided with this flag is mount to `${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly`.

If `--local-maven-repo` is NOT provided to `run_macaron.sh`, `run_macaron.sh` default behavior is consistent with Macaron running as a package, regarding loading the default location `$HOME/.m2` of the host:
- If `$HOME/.m2/` of the host is not available, an empty directory is created within the `output` dir and mounted as read only to `${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly`. Then Macaron running within the Docker container will be provided with this empty directory as `--local-maven-repo`. We do so to avoid Macaron loading `$HOME/.m2` as maven local repo inside the container, as `$HOME/.m2` inside the container is being used by the cyclone-dx SBOM generator. 
- If `$HOME/.m2/` of the host is available, it will be mounted to `${MACARON_WORKSPACE}/analyze_local_maven_repo_readonly`.

## Providing Python virtual environment as input
This has been implemented in #748.

## Resolving artifacts from local repositories for a PackageURL

This is a high-level diagram of finding local artifacts for a PURL

```mermaid
graph LR
purl[Input - PackageURL] -->patt_gen{1 - Generating glob patterns} -->patts(artifact dir glob patterns)

lrps[Input - Local repository path]

patts -->fa{2 - Find artifact dis from local repo path}
lrps -->fa

fa -->result(Output - list of artifact directories existed within the local repo path.)
```

### Generating glob patterns
From a PackageURL, we can directly obtain the glob patterns representing the location of artifact dirs in a local repo. These glob patterns will be different between a maven PURL and a PYPI PURL.

### Glob patterns matching on the repo path corresponding to the input PURL's type.
In Macaron (the main's `Analyzer` instance), we will store mappings between a PURL type (e.g `maven`) to its corresponding local repo path (if provided by the user). Right now, we only have maximum 2 entries:
- `maven` maps to the maven local repo path
- `pypi` maps to the python virtual env path

If the user doesn't provide a local repo path, there will be no entry for it in these mappings.

Using the input PURL's type, we will find the corresponding local repo path from this mapping. 
Then we use the glob patterns obtained earlier to look for artifacts within this path. We don't raise error if we cannot find any artifact dir that matches any of the glob patterns.

## Storing the discovered artifacts paths

They will be stored in the analyze context instance's `dynamic_data` object as a list of string.

# Tasks
- [x] Add `--local-maven-repo` as CLI option.
- [x] Handle mounting .m2 depending on user provided `--local-maven-repo` into the container. 
- [x] Add integration tests for invalid usages of `--local-maven-repo`
- [x] Add unit tests for run_macaron.sh adding `--local-maven-repo` behavior
- [x] Fix and issue with `dumps-defaults` command not being handled in `run_macaron.sh`
- [x] Obtain directories and files corresponding to a Python software component from virtual environment.
    - [x] Add unit tests.
- [x] Obtain directories and files corresponding to a Java software component from the cached .m2.
    - [x] Add unit tests.
- [ ] Add tutorial - will be worked on later - https://github.com/oracle/macaron/issues/936