### PR TITLE
fix: prevent endless loop on 403 GitHub response

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -4,6 +4,8 @@
 [requests]
 # The default timeout in seconds for 'requests' API calls.
 timeout = 10
+# The number of times to re-attempt to retrieve a resource when an error is encountered.
+error_retries = 5
 
 [downloads]
 # The default timeout in seconds for downloading assets.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -127,7 +127,7 @@ def test_get_http_partial_failure(httpserver: HTTPServer) -> None:
 
 
 def test_get_http_complete_failure(httpserver: HTTPServer) -> None:
-    """Test get http GET operations when too many errors are received and the request fails."""
+    """Test the http GET operation when too many errors are received and the request fails."""
     # Retrieve the allowed number of retries on a failed request.
     target_value = defaults.getint("requests", "error_retries", fallback=5)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -101,24 +101,37 @@ def _response_generator(target_value: int) -> Callable[[Request], Response]:
     return generator
 
 
-def test_get_http_failure(httpserver: HTTPServer) -> None:
-    """Test get http operations when a 403 error code is received."""
-    # Set up a localhost URL.
-    mocked_url = httpserver.url_for("")
-
-    # Retrieve the allowed number of retries on a failed request.
-    target_value = defaults.getint("requests", "error_retries", fallback=5)
+def _http_setup(retries: int, httpserver: HTTPServer) -> str:
+    """Set up the http server for a GET test."""
+    # Get a localhost URL.
+    mocked_url: str = httpserver.url_for("")
 
     # Create and assign the stateful handler.
-    handler = _response_generator(target_value)
+    handler = _response_generator(retries)
     httpserver.expect_request("").respond_with_handler(handler)
+    return mocked_url
 
-    # Assert the request fails and returns nothing.
-    assert send_get_http_raw(mocked_url) is None
 
-    # Test for a correct response after the expected number of retries and other requests (including this one).
-    expected_value = target_value + 2
+def test_get_http_partial_failure(httpserver: HTTPServer) -> None:
+    """Test the http GET operation when some errors are received before the request succeeds."""
+    # Retrieve the allowed number of retries on a failed request and reduce it by 1.
+    target_value = defaults.getint("requests", "error_retries", fallback=5) - 1
+
+    mocked_url = _http_setup(target_value, httpserver)
+
+    # Test for a correct response after the expected number of retries.
     response = send_get_http_raw(mocked_url)
     assert response
     assert "X-VALUE" in response.headers
-    assert response.headers["X-VALUE"] == str(expected_value)
+    assert response.headers["X-VALUE"] == str(target_value + 2)
+
+
+def test_get_http_complete_failure(httpserver: HTTPServer) -> None:
+    """Test get http GET operations when too many errors are received and the request fails."""
+    # Retrieve the allowed number of retries on a failed request.
+    target_value = defaults.getint("requests", "error_retries", fallback=5)
+
+    mocked_url = _http_setup(target_value, httpserver)
+
+    # Assert the request fails and returns nothing.
+    assert send_get_http_raw(mocked_url) is None


### PR DESCRIPTION
This PR prevents GET requests made by Macaron from looping endlessly when receiving a 403 error that is not related to GitHub's API rate limit. It also adds a configurable retry limit that applies to all request failures.

Closes #865 