### PR TITLE
chore: disable too-many-positional-arguments check in Pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ disable = [
     "too-many-return-statements",
     "too-many-statements",
     "too-many-function-args",
+    "too-many-positional-arguments",
     "duplicate-code",
 ]
 


### PR DESCRIPTION
The [recent version of Pylint](https://github.com/pylint-dev/pylint/releases/tag/v3.3.0) has added a new check `too-many-positional-arguments`, which is causing our linter checks to fail. This PR disables this check similar to other opinionated `too-many-*` checks.