### PR TITLE
chore: fix Makefile goal `gnu-sed` to handle brew, port, and GNU sed on macOS gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,8 +174,16 @@ souffle:
 .PHONY: gnu-sed
 gnu-sed:
 	if [ "$(OS_DISTRO)" == "Darwin" ]; then \
-		brew install gnu-sed; \
-	fi
+	  if ! command -v gsed; then \
+	    if command -v brew; then \
+	      brew install gnu-sed; \
+	    elif command -v port; then \
+	      sudo port install gsed; \
+	    else \
+	      echo "Unable to install GNU sed on macOS. Please install it manually." && exit 1; \
+	    fi; \
+	  fi; \
+	fi;
 
 # Install or upgrade an existing virtual environment based on the
 # package dependencies declared in pyproject.toml.


### PR DESCRIPTION
Fix to PR https://github.com/oracle/macaron/pull/853 (tagging @mabdollahpour-ol)

The Makefile goal assumed [Brew](https://brew.sh/) only, so I added support for [Ports](https://www.macports.org/) and a check for `gsed` to avoid installing it twice. Also note that at least Ports aliases `gsed` as `sed` such that 

https://github.com/oracle/macaron/blob/edfe06eb3f9337f86215b253f40f53ca1a0105c9/scripts/dev_scripts/copyright-checker.sh#L55-L59

becomes irrelevant. I don’t know how Brew manages overriding macOS CLI tools with GNU tools.

Furthermore, I cleaned up indentation to be consistent with most (not all!) of the Makefile: every line of a rule indents by a single tab, then two spaces within scripts. That way it is easier to tell the difference between tab-indent (four or eight, depending on the editor) and space-indent (always two), and it makes managing block-indents easier & consistent.

Lastly, I think this line https://github.com/oracle/macaron/blob/edfe06eb3f9337f86215b253f40f53ca1a0105c9/Makefile#L167 should contain an `exit 1` to communicate the failure correctly to the running shell.