### PR TITLE
chore: improve the indentation consistency of souffle Makefile goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,10 @@ souffle:
 	        echo "Unable to install Souffle. Please install it manually." && exit 0; \
 	      fi;; \
 	    *) \
-	        echo "Unsupported OS distribution: $(OS_DISTRO)"; exit 0;; \
+	      echo "Unsupported OS distribution: $(OS_DISTRO)"; exit 0;; \
 	  esac; \
 	fi && \
-	command -v souffle || true
+	command -v souffle
 
 # Install gnu-sed on mac using homebrew
 .PHONY: gnu-sed

--- a/Makefile
+++ b/Makefile
@@ -143,32 +143,33 @@ else
     OS_DISTRO := "$(shell grep '^NAME=' /etc/os-release | sed 's/^NAME=//' | sed 's/"//g')"
   endif
 endif
+# If Souffle cannot be installed, we advise the user to install it manually
+# and return status code 0, which is not considered a failure.
 .PHONY: souffle
 souffle:
 	if ! command -v souffle; then \
-		echo "Installing system dependency: souffle" && \
-	    case $(OS_DISTRO) in \
-	        "Oracle Linux") \
-                sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-oraclelinux-8-souffle-2.4-Linux.rpm \
-                ;; \
-	        "Fedora Linux") \
-                sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-fedora-34-souffle-2.4-Linux.rpm \
-                ;; \
-            "Ubuntu") \
-                sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg; \
-                echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list; \
-                sudo apt update; \
-                sudo apt install souffle; \
-                ;; \
-            "Darwin") \
-                if command -v brew; then \
-                    brew install --HEAD souffle-lang/souffle/souffle; \
-                else \
-                    echo "Unable to install Souffle. Please install it manually." && exit 0; \
-                fi ;; \
-	esac;                                                                                                                                                  \
+	  echo "Installing system dependency: souffle" && \
+	  case $(OS_DISTRO) in \
+	    "Oracle Linux") \
+	      sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-oraclelinux-8-souffle-2.4-Linux.rpm;; \
+	    "Fedora Linux") \
+	      sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-fedora-34-souffle-2.4-Linux.rpm;; \
+	    "Ubuntu") \
+	      sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg; \
+	      echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list; \
+	      sudo apt update; \
+	      sudo apt install souffle;; \
+	    "Darwin") \
+	      if command -v brew; then \
+	        brew install --HEAD souffle-lang/souffle/souffle; \
+	      else \
+	        echo "Unable to install Souffle. Please install it manually." && exit 0; \
+	      fi;; \
+	    *) \
+	        echo "Unsupported OS distribution: $(OS_DISTRO)"; exit 0;; \
+	  esac; \
 	fi && \
-    command -v souffle || true
+	command -v souffle || true
 
 # Install gnu-sed on mac using homebrew
 .PHONY: gnu-sed


### PR DESCRIPTION
This PR makes the following improvements to the `souffle` goal of the `Makefile`:

- A new comment that explains the behavior when Souffle cannot be installed automatically.
- Ensured consistent indentation and spacing for readability based on recommendations in https://github.com/oracle/macaron/pull/877
- Prints a useful message when the OS distribution is not supported.

cc @jenstroeger 

