### PR TITLE
chore: fix pylint message use-set-for-membership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ fail-under = 10.0
 suggestion-mode = true  # Remove this setting when pylint v4 is released.
 load-plugins = [
     "pylint.extensions.for_any_all",
+    "pylint.extensions.set_membership",
 ]
 disable = [
     "fixme",

--- a/src/macaron/repo_finder/provenance_finder.py
+++ b/src/macaron/repo_finder/provenance_finder.py
@@ -69,7 +69,7 @@ class ProvenanceFinder:
             discovery_functions = [partial(find_npm_provenance, purl, self.npm_registry)]
             return self._find_provenance(discovery_functions)
 
-        if purl.type in ["gradle", "maven"]:
+        if purl.type in {"gradle", "maven"}:
             # TODO add support for Maven Central provenance.
             if not self.jfrog_registry:
                 logger.debug("Missing JFrog registry to find provenance in.")

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -62,12 +62,12 @@ def find_repo(purl: PackageURL) -> str:
     repo_finder: BaseRepoFinder
     if purl.type == "maven":
         repo_finder = JavaRepoFinder()
-    elif defaults.getboolean("repofinder", "use_open_source_insights") and purl.type in [
+    elif defaults.getboolean("repofinder", "use_open_source_insights") and purl.type in {
         "pypi",
         "nuget",
         "cargo",
         "npm",
-    ]:
+    }:
         repo_finder = DepsDevRepoFinder()
     else:
         logger.debug("No Repo Finder found for package type: %s of %s", purl.type, purl)

--- a/src/macaron/slsa_analyzer/ci_service/github_actions/analyzer.py
+++ b/src/macaron/slsa_analyzer/ci_service/github_actions/analyzer.py
@@ -319,7 +319,7 @@ def build_call_graph_from_node(node: GitHubWorkflowNode, repo_path: str) -> None
                     # Right now, the script with the default shell is passed to the parser, which will fail
                     # if the runner is Windows and Powershell is used. But there is no easy way to avoid passing
                     # the script because that means we need to accurately determine the runner's OS.
-                    if step.get("run") and ("shell" not in step or step["shell"] in ["bash", "sh"]):
+                    if step.get("run") and ("shell" not in step or step["shell"] in {"bash", "sh"}):
                         try:
                             name = "UNKNOWN"
                             node_id = None

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -637,7 +637,7 @@ def parse_remote_url(
     res_netloc = ""
 
     # e.g., https://github.com/owner/project.git
-    if parsed_url.scheme in ("http", "https", "ftp", "ftps", "git+https"):
+    if parsed_url.scheme in {"http", "https", "ftp", "ftps", "git+https"}:
         if parsed_url.netloc not in allowed_git_service_hostnames:
             return None
         path_params = parsed_url.path.strip("/").split("/")
@@ -651,7 +651,7 @@ def parse_remote_url(
     # e.g.:
     #   ssh://git@hostname:port/owner/project.git
     #   ssh://git@hostname:owner/project.git
-    elif parsed_url.scheme in ("ssh", "git+ssh"):
+    elif parsed_url.scheme in {"ssh", "git+ssh"}:
         user_host, _, port = parsed_url.netloc.partition(":")
         user, _, host = user_host.rpartition("@")
 

--- a/src/macaron/slsa_analyzer/provenance/expectations/expectation_registry.py
+++ b/src/macaron/slsa_analyzer/provenance/expectations/expectation_registry.py
@@ -33,7 +33,7 @@ class ExpectationRegistry:
 
         for expectation_path in expectation_paths:
             _, ext = os.path.splitext(expectation_path)
-            if ext in (".cue",):
+            if ext == ".cue":
                 expectation = CUEExpectation.make_expectation(expectation_path)
                 if expectation and expectation.target:
                     self.expectations[expectation.target] = expectation


### PR DESCRIPTION
This change is part of issue #876 and addresses the [`use-set-for-membership`](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/use-set-for-membership.html) check messages.

I’ll add the appropriate configuration to pyproject.toml in a separate PR later.