### PR TITLE
chore: fix pylint message overlapping-except

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ fail-under = 10.0
 suggestion-mode = true  # Remove this setting when pylint v4 is released.
 load-plugins = [
     "pylint.extensions.for_any_all",
+    "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.set_membership",
 ]
 disable = [

--- a/src/macaron/config/defaults.py
+++ b/src/macaron/config/defaults.py
@@ -170,6 +170,6 @@ def create_defaults(output_path: str, cwd_path: str) -> bool:
         )
         return True
     # We catch OSError to support errors on different platforms.
-    except (OSError, shutil.Error) as error:
+    except OSError as error:
         logger.error("Failed to create %s: %s.", os.path.relpath(dest_path, cwd_path), error)
         return False

--- a/src/macaron/dependency_analyzer/cyclonedx.py
+++ b/src/macaron/dependency_analyzer/cyclonedx.py
@@ -86,7 +86,7 @@ def deserialize_bom_json(file_path: Path) -> Bom:
             # This method is injected into the Bom class that is annotated by ``serializable`` but mypy is not
             # able to detect that.
             bom_from_json = Bom.from_json(json.loads(json_data))  # type: ignore[attr-defined]
-        except (ValueError, AttributeError, json.JSONDecodeError) as error:
+        except (ValueError, AttributeError) as error:
             raise CycloneDXParserError(f"Could not process the dependencies at {file_path}: {error}") from None
 
         if isinstance(bom_from_json, Bom):


### PR DESCRIPTION
This change is part of issue #876 and addresses the [`overlapping-except`](https://pylint.pycqa.org/en/latest/user_guide/messages/warning/overlapping-except.html) check messages. Because all errors were already handled in a single `except` I left it that way — if errors need to be handled according to their error class hierarchy (e.g. `shutil.Error` is a subclass of `OSError`) then please let me know.

I’ll add the appropriate configuration to pyproject.toml in a separate PR later.