### PR TITLE
chore: fix pylint message deprecated-typing-alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ load-plugins = [
     "pylint.extensions.for_any_all",
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.set_membership",
+    "pylint.extensions.typing",
 ]
 disable = [
     "fixme",

--- a/src/macaron/database/database_manager.py
+++ b/src/macaron/database/database_manager.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This DatabaseManager module handles the sqlite database connection."""
+import collections.abc
 import functools
 import logging
 import os
@@ -69,7 +70,7 @@ _P = typing.ParamSpec("_P")
 class cache_return(typing.Generic[_T, _P]):  # pylint: disable=invalid-name # noqa: N801
     """The decorator to create a singleton DB session."""
 
-    def __init__(self, function: typing.Callable[_P, _T]) -> None:
+    def __init__(self, function: collections.abc.Callable[_P, _T]) -> None:
         functools.update_wrapper(self, function)
         self.function = function
 


### PR DESCRIPTION
This change is part of issue #876 and addresses the [`deprecated-typing-alias`](https://pylint.pycqa.org/en/latest/user_guide/messages/warning/deprecated-typing-alias.html) check messages.

I’ll add the appropriate configuration to pyproject.toml in a separate PR later.