### PR TITLE
chore: add suggestion mode to pylint settings, and silence the “too many try statements” checker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,9 @@ ignore_missing_imports = true
 # https://pylint.pycqa.org/en/latest/user_guide/configuration/index.html
 [tool.pylint.MASTER]
 fail-under = 10.0
+suggestion-mode = true
+load-plugins = [
+]
 disable = [
     "fixme",
     "line-too-long",  # Replaced by Flake8 Bugbear B950 check.
@@ -218,15 +221,16 @@ disable = [
     "too-many-arguments",
     "too-many-boolean-expressions",
     "too-many-branches",
+    "too-many-function-args",
     "too-many-instance-attributes",
     "too-many-lines",
     "too-many-locals",
     "too-many-nested-blocks",
+    "too-many-positional-arguments",
     "too-many-public-methods",
     "too-many-return-statements",
     "too-many-statements",
-    "too-many-function-args",
-    "too-many-positional-arguments",
+    "too-many-try-statements",
     "duplicate-code",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ ignore_missing_imports = true
 # https://pylint.pycqa.org/en/latest/user_guide/configuration/index.html
 [tool.pylint.MASTER]
 fail-under = 10.0
-suggestion-mode = true
+suggestion-mode = true  # Remove this setting when pylint v4 is released.
 load-plugins = [
 ]
 disable = [


### PR DESCRIPTION
This change is part of issue https://github.com/oracle/macaron/issues/876 and prepares the `pyproject.toml` file for the optional plugins. I also sorted the existing disabled checkers alphabetically, and enabled the [suggestion mode](https://pylint.pycqa.org/en/latest/user_guide/configuration/all-options.html#suggestion-mode).[^1]

If we can merge this first then other lint fixes can just add their respective plugins with a one-line change.

[^1]: Huh, as of `pylint` v4 it defaults to `True` anyway, so perhaps that setting will become redundant anyway.