### PR TITLE
fix: block terminal prompts in find source

### DIFF
--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -235,7 +235,9 @@ def get_tags_via_git_remote(repo: str) -> dict[str, str] | None:
     """
     tags = {}
     try:
-        tag_data = git.cmd.Git().ls_remote("--tags", repo)
+        command = git.cmd.Git()
+        command.update_environment(GIT_TERMINAL_PROMPT="")
+        tag_data = command.ls_remote("--tags", repo)
     except git.exc.GitCommandError as error:
         logger.debug("Failed to retrieve tags: %s", error)
         return None

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -236,13 +236,6 @@ def get_tags_via_git_remote(repo: str) -> dict[str, str] | None:
     if not tag_data:
         return None
     tags = {}
-    # try:
-    #    command = git.cmd.Git()
-    # command.update_environment(GIT_TERMINAL_PROMPT="")
-    #    tag_data = command.ls_remote("--tags", repo)
-    # except git.exc.GitCommandError as error:
-    #    logger.debug("Failed to retrieve tags: %s", error)
-    #    return None
 
     for tag_line in tag_data.splitlines():
         tag_line = tag_line.strip()

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -36,7 +36,6 @@ import logging
 import os
 from urllib.parse import ParseResult, urlunparse
 
-import git
 from packageurl import PackageURL
 
 from macaron.config.defaults import defaults
@@ -47,7 +46,7 @@ from macaron.repo_finder.repo_finder_base import BaseRepoFinder
 from macaron.repo_finder.repo_finder_deps_dev import DepsDevRepoFinder
 from macaron.repo_finder.repo_finder_java import JavaRepoFinder
 from macaron.repo_finder.repo_utils import generate_report, prepare_repo
-from macaron.slsa_analyzer.git_url import GIT_REPOS_DIR
+from macaron.slsa_analyzer.git_url import GIT_REPOS_DIR, list_remote_references
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -170,11 +169,11 @@ def find_source(purl_string: str, input_repo: str | None) -> bool:
 
     # Disable other loggers for cleaner output.
     logging.getLogger("macaron.slsa_analyzer.analyzer").disabled = True
-    logging.getLogger("macaron.slsa_analyzer.git_url").disabled = True
 
     if defaults.getboolean("repofinder", "find_source_should_clone"):
         logger.debug("Preparing repo: %s", found_repo)
         repo_dir = os.path.join(global_config.output_path, GIT_REPOS_DIR)
+        logging.getLogger("macaron.slsa_analyzer.git_url").disabled = True
         git_obj = prepare_repo(
             repo_dir,
             found_repo,
@@ -233,14 +232,17 @@ def get_tags_via_git_remote(repo: str) -> dict[str, str] | None:
     dict[str]
         A dictionary of tags mapped to their commits, or None if the operation failed..
     """
-    tags = {}
-    try:
-        command = git.cmd.Git()
-        command.update_environment(GIT_TERMINAL_PROMPT="")
-        tag_data = command.ls_remote("--tags", repo)
-    except git.exc.GitCommandError as error:
-        logger.debug("Failed to retrieve tags: %s", error)
+    tag_data = list_remote_references(["--tags"], repo)
+    if not tag_data:
         return None
+    tags = {}
+    # try:
+    #    command = git.cmd.Git()
+    # command.update_environment(GIT_TERMINAL_PROMPT="")
+    #    tag_data = command.ls_remote("--tags", repo)
+    # except git.exc.GitCommandError as error:
+    #    logger.debug("Failed to retrieve tags: %s", error)
+    #    return None
 
     for tag_line in tag_data.splitlines():
         tag_line = tag_line.strip()

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -413,7 +413,7 @@ def list_remote_references(arguments: list[str], repo: str) -> str | None:
             logger.error("Could not access repository: %s", repo)
         return None
 
-    return str(result.stdout)
+    return result.stdout.decode("utf-8")
 
 
 def resolve_local_path(start_dir: str, local_path: str) -> str:

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -408,9 +408,11 @@ def list_remote_references(arguments: list[str], repo: str) -> str | None:
     if result.returncode != 0:
         error_string = result.stderr.decode("utf-8").strip()
         if error_string.startswith("fatal: could not read Username"):
-            # Occurs when a repository cannot be accesses either because it does not exist, or it requires a login
+            # Occurs when a repository cannot be accessed either because it does not exist, or it requires a login
             # that is blocked.
             logger.error("Could not access repository: %s", repo)
+        else:
+            logger.error("Failed to retrieve remote references from repo: %s", repo)
         return None
 
     return result.stdout.decode("utf-8")

--- a/tests/integration/cases/find_source_fail/test.yaml
+++ b/tests/integration/cases/find_source_fail/test.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
-  Analyzing the find source command on the a non-existent repository.
+  Analyzing the find source command on a non-existent repository.
 
 tags:
 - macaron-python-package

--- a/tests/integration/cases/find_source_fail/test.yaml
+++ b/tests/integration/cases/find_source_fail/test.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing the find source command on the a non-existent repository.
+
+tags:
+- macaron-python-package
+- macaron-docker-image
+
+steps:
+- name: Run macaron find source on private repository
+  kind: find-source
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/com.example/example@1.0.0
+    - -rp
+    - https://github.com/oracle/hopefully-this-repository-will-never-exist-0
+    expect_fail: true


### PR DESCRIPTION
Applies a fix for the standalone commit finder feature: preventing login related terminal prompts from interrupting the process.