### PR TITLE
feat: report known malware for all ecosystems

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -107,7 +107,7 @@ Macaron checks that report integrity issues but do not map to SLSA requirements 
    * - Check ID
      - Description
    * - ``mcn_detect_malicious_metadata_1``
-     - This check analyzes the metadata of a package and reports malicious behavior. This check currently supports PyPI packages.
+     - This check performs analysis on PyPI package metadata to detect malicious behavior. It also reports known malware from other ecosystems, but the analysis is currently limited to PyPI packages.
 
 ----------------------
 How does Macaron work?

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -13,8 +13,10 @@ In this tutorial we show how to use Macaron to find malicious packages. Imagine 
    :widths: 25
    :header-rows: 1
 
-   * - Supported packages
+   * - Supported packages for analysis
    * - Python packages (PyPI)
+
+Note that known malware is reported for packages across all ecosystems.
 
 .. contents:: :local:
 

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -51,7 +51,9 @@ class MaliciousMetadataFacts(CheckFacts):
     detail_information: Mapped[dict[str, JsonType]] = mapped_column(DBJsonDict, nullable=False)
 
     #: The result of analysis, which can be an empty dictionary.
-    result: Mapped[dict] = mapped_column(DBJsonDict, nullable=False, info={"justification": JustificationType.TEXT})
+    result: Mapped[dict[Heuristics, HeuristicResult]] = mapped_column(
+        DBJsonDict, nullable=False, info={"justification": JustificationType.TEXT}
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": "_detect_malicious_metadata_check",

--- a/src/macaron/util.py
+++ b/src/macaron/util.py
@@ -125,6 +125,80 @@ def send_get_http_raw(
     return response
 
 
+def send_post_http_raw(
+    url: str,
+    json_data: dict | None = None,
+    headers: dict | None = None,
+    timeout: int | None = None,
+    allow_redirects: bool = True,
+) -> Response | None:
+    """Send a POST HTTP request with the given url, data, and headers.
+
+    This method also handle logging when the API server returns error status code.
+
+    Parameters
+    ----------
+    url : str
+        The url of the request.
+    json_data: dict | None
+        The request payload.
+    headers : dict | None
+        The dict that describes the headers of the request.
+    timeout: int | None
+        The request timeout (optional).
+    allow_redirects: bool
+        Whether to allow redirects. Default: True.
+
+    Returns
+    -------
+    Response | None
+        If a Response object is returned and ``allow_redirects`` is ``True`` (the default) it will have a status code of
+        200 (OK). If ``allow_redirects`` is ``False`` the response can instead have a status code of 302. Otherwise, the
+        request has failed and ``None`` will be returned.
+    """
+    logger.debug("POST - %s", url)
+    if not timeout:
+        timeout = defaults.getint("requests", "timeout", fallback=10)
+    error_retries = defaults.getint("requests", "error_retries", fallback=5)
+    retry_counter = error_retries
+    try:
+        response = requests.post(
+            url=url,
+            json=json_data,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+        )
+    except requests.exceptions.RequestException as error:
+        logger.debug(error)
+        return None
+    if not allow_redirects and response.status_code == 302:
+        # Found, most likely because a redirect is about to happen.
+        return response
+    while response.status_code != 200:
+        logger.debug(
+            "Receiving error code %s from server.",
+            response.status_code,
+        )
+        if retry_counter <= 0:
+            logger.debug("Maximum retries reached: %s", error_retries)
+            return None
+        if response.status_code == 403:
+            check_rate_limit(response)
+        else:
+            return None
+        retry_counter = retry_counter - 1
+        response = requests.post(
+            url=url,
+            json=json_data,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+        )
+
+    return response
+
+
 def check_rate_limit(response: Response) -> None:
     """Check the remaining calls limit to GitHub API and wait accordingly.
 

--- a/tests/integration/cases/tautoak4-hello-world/policy.dl
+++ b/tests/integration/cases/tautoak4-hello-world/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("check-malicious-package", component_id, "Check the malicious package.") :-
+    check_failed(component_id, "mcn_detect_malicious_metadata_1").
+
+apply_policy_to("check-malicious-package", component_id) :-
+    is_component(component_id, "pkg:npm/tautoak4-hello-world").

--- a/tests/integration/cases/tautoak4-hello-world/test.yaml
+++ b/tests/integration/cases/tautoak4-hello-world/test.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a known malicious package.
+
+tags:
+- macaron-python-package
+- macaron-docker-image
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:npm/tautoak4-hello-world
+- name: Run macaron verify-policy to verify that the malicious metadata check fails.
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/integration/cases/type-extension/policy.dl
+++ b/tests/integration/cases/type-extension/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("check-malicious-package", component_id, "Check the malicious package.") :-
+    check_failed(component_id, "mcn_detect_malicious_metadata_1").
+
+apply_policy_to("check-malicious-package", component_id) :-
+    is_component(component_id, "pkg:pypi/type-extension").

--- a/tests/integration/cases/type-extension/test.yaml
+++ b/tests/integration/cases/type-extension/test.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a known malicious package.
+
+tags:
+- macaron-python-package
+- macaron-docker-image
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/type-extension
+- name: Run macaron verify-policy to verify that the malicious metadata check fails.
+  kind: verify
+  options:
+    policy: policy.dl


### PR DESCRIPTION
If a package is already known to be malicious, this PR reports it as part of the `mcn_detect_malicious_metadata_1` check. Additionally, two new integration tests for known Python and npm malware have been added.