### PR TITLE
test(integration): handle missing steps info in GitHub API response

### DIFF
--- a/tests/integration/cases/micronaut-projects_micronaut-test/micronaut-test.dl
+++ b/tests/integration/cases/micronaut-projects_micronaut-test/micronaut-test.dl
@@ -14,11 +14,25 @@ Policy("test_policy", component_id, "") :-
     build_tool_check(gradle_id, "gradle", "java"),
     check_facts(gradle_id, _, component_id,_,_),
     check_passed(component_id, "mcn_provenance_level_three_1"),
-    check_passed(component_id, "mcn_find_artifact_pipeline_1"),
     check_failed(component_id, "mcn_provenance_derived_commit_1"),
     check_failed(component_id, "mcn_provenance_witness_level_one_1"),
     check_failed(component_id, "mcn_trusted_builder_level_three_1"),
-    is_repo_url(component_id, "https://github.com/micronaut-projects/micronaut-test").
+    is_repo_url(component_id, "https://github.com/micronaut-projects/micronaut-test"),
+    // The GitHub API for some reasons does not return the steps information anymore.
+    // Note that mcn_find_artifact_pipeline_1 fails because it returns UNKNOWN, in this case with low confidence.
+    check_failed_with_confidence(component_id, "mcn_find_artifact_pipeline_1", confidence),
+    confidence = 0.4,
+    artifact_pipeline_check(
+        apc_check_id,
+        "https://github.com/micronaut-projects/micronaut-test/blob/0ffa4e86ee4311f744f1a2b8ccd740a15af3a52b/.github/workflows/release.yml",
+        "release",
+        "publish",
+        _,
+        1,  // From provenance.
+        1,  // Run deleted.
+        0   // Published before the code was committed.
+    ),
+    check_facts(apc_check_id, confidence, component_id,_,_).
 
 apply_policy_to("test_policy", component_id) :-
     is_component(component_id, purl),


### PR DESCRIPTION
The GitHub API for some reason does not anymore return the steps information of the job that has published `pkg:maven/io.micronaut.test/micronaut-test-junit5@4.5.0` even though it was published in Aug 2024, which is much earlier than [the 400 retention policy](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28#retention-of-checks-data). This PR raises a new exception to handle this case and allows the corresponding integration test to fail.