### PR TITLE
fix: disable gpg signing for commit finder tests

### DIFF
--- a/src/macaron/database/table_definitions.py
+++ b/src/macaron/database/table_definitions.py
@@ -103,7 +103,7 @@ class PackageURLMixin:
     name: Mapped[str] = mapped_column(String(100), nullable=False, comment="Name of the package.")
 
     #: Version of the package.
-    version: Mapped[str] = mapped_column(String(100), nullable=True, comment="Version of the package.")
+    version: Mapped[str | None] = mapped_column(String(100), nullable=True, comment="Version of the package.")
 
     #: Extra qualifying data for a package such as the name of an OS.
     qualifiers: Mapped[str] = mapped_column(

--- a/src/macaron/errors.py
+++ b/src/macaron/errors.py
@@ -86,3 +86,7 @@ class CycloneDXParserError(MacaronError):
 
 class DependencyAnalyzerError(MacaronError):
     """The DependencyAnalyzer error class."""
+
+
+class HeuristicAnalyzerValueError(MacaronError):
+    """Error class for BaseHeuristicAnalyzer errors when parsing data."""

--- a/src/macaron/malware_analyzer/pypi_heuristics/heuristics.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/heuristics.py
@@ -31,6 +31,9 @@ class Heuristics(str, Enum):
     #: Indicates that the setup.py file contains suspicious imports, such as base64 and requests.
     SUSPICIOUS_SETUP = "suspicious_setup"
 
+    #: Indicates that the package does not include a .whl file
+    WHEEL_ABSENCE = "wheel_absence"
+
 
 class HeuristicResult(str, Enum):
     """Result type indicating the outcome of a heuristic."""

--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
@@ -6,10 +6,11 @@
 import logging
 
 from macaron.errors import HeuristicAnalyzerValueError
-from macaron.json_tools import JsonType
+from macaron.json_tools import JsonType, json_extract
 from macaron.malware_analyzer.pypi_heuristics.base_analyzer import BaseHeuristicAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.heuristics import HeuristicResult, Heuristics
 from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset
+from macaron.util import send_head_http_raw
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -23,6 +24,10 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
     """
 
     WHEEL: str = "bdist_wheel"
+    # as per https://github.com/pypi/inspector/blob/main/inspector/main.py line 125
+    INSPECTOR_TEMPLATE = (
+        "https://inspector.pypi.io/project/{name}/{version}/packages/{first}/{second}/{rest}/{filename}"
+    )
 
     def __init__(self) -> None:
         super().__init__(
@@ -47,7 +52,7 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
         Raises
         ------
         HeuristicAnalyzerValueError
-            If there is no release information, or has no most recent version (if queried).
+            If there is no release information, or has other missing package information.
         """
         releases = pypi_package_json.get_releases()
         if releases is None:  # no release information
@@ -64,21 +69,64 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
                 logger.debug(error_msg)
                 raise HeuristicAnalyzerValueError(error_msg)
 
-        release_files: list[JsonType] = []
+        inspector_links: list[JsonType] = []
         wheel_present: bool = False
 
-        try:
-            for release_metadata in releases[version]:
-                if release_metadata["packagetype"] == self.WHEEL:
-                    wheel_present = True
-
-                release_files.append(release_metadata["filename"])
-        except KeyError as error:
+        release_distributions = json_extract(releases, [version], list)
+        if release_distributions is None:
             error_msg = f"The version {version} is not available as a release."
             logger.debug(error_msg)
-            raise HeuristicAnalyzerValueError(error_msg) from error
+            raise HeuristicAnalyzerValueError(error_msg)
+
+        for distribution in release_distributions:
+            # validate data
+            package_type = json_extract(distribution, ["packagetype"], str)
+            if package_type is None:
+                error_msg = f"The version {version} has no 'package type' field in a distribution"
+                logger.debug(error_msg)
+                raise HeuristicAnalyzerValueError(error_msg)
+
+            name = json_extract(pypi_package_json.package_json, ["info", "name"], str)
+            if name is None:
+                error_msg = f"The version {version} has no 'name' field in a distribution"
+                logger.debug(error_msg)
+                raise HeuristicAnalyzerValueError(error_msg)
+
+            blake2b_256 = json_extract(distribution, ["digests", "blake2b_256"], str)
+            if blake2b_256 is None:
+                error_msg = f"The version {version} has no 'blake2b_256' field in a distribution"
+                logger.debug(error_msg)
+                raise HeuristicAnalyzerValueError(error_msg)
+
+            filename = json_extract(distribution, ["filename"], str)
+            if filename is None:
+                error_msg = f"The version {version} has no 'filename' field in a distribution"
+                logger.debug(error_msg)
+                raise HeuristicAnalyzerValueError(error_msg)
+
+            if package_type == self.WHEEL:
+                wheel_present = True
+
+            inspector_link = self.INSPECTOR_TEMPLATE.format(
+                name=name,
+                version=version,
+                first=blake2b_256[0:2],
+                second=blake2b_256[2:4],
+                rest=blake2b_256[4:],
+                filename=filename,
+            )
+
+            # use a head request because we don't care about the response contents
+            if send_head_http_raw(inspector_link) is None:
+                inspector_links.append(None)
+            else:
+                inspector_links.append(inspector_link)
+
+        detail_info: dict[str, JsonType] = {
+            "inspector_links": inspector_links,
+        }
 
         if wheel_present:
-            return HeuristicResult.PASS, {version: release_files}
+            return HeuristicResult.PASS, detail_info
 
-        return HeuristicResult.FAIL, {version: release_files}
+        return HeuristicResult.FAIL, detail_info

--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""The heuristic analyzer to check .whl file absence."""
+
+import logging
+
+from macaron.errors import HeuristicAnalyzerValueError
+from macaron.json_tools import JsonType
+from macaron.malware_analyzer.pypi_heuristics.base_analyzer import BaseHeuristicAnalyzer
+from macaron.malware_analyzer.pypi_heuristics.heuristics import HeuristicResult, Heuristics
+from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
+    """
+    Analyze to see if a .whl file is available for the package.
+
+    If a package is distributed with a .whl file, this heuristic passes. Otherwise, the
+    heuristic fails.
+    """
+
+    WHEEL: str = "bdist_wheel"
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="wheel_absence_analyzer",
+            heuristic=Heuristics.WHEEL_ABSENCE,
+            depends_on=None,
+        )
+
+    def analyze(self, pypi_package_json: PyPIPackageJsonAsset) -> tuple[HeuristicResult, dict[str, JsonType]]:
+        """Analyze the package.
+
+        Parameters
+        ----------
+        pypi_package_json: PyPIPackageJsonAsset
+            The PyPI package JSON asset object.
+
+        Returns
+        -------
+        tuple[HeuristicResult, dict[str, JsonType]]:
+            The result and related information collected during the analysis.
+
+        Raises
+        ------
+        HeuristicAnalyzerValueError
+            If there is no release information, or has no most recent version (if queried).
+        """
+        releases = pypi_package_json.get_releases()
+        if releases is None:  # no release information
+            error_msg = "There is no information for any release of this package."
+            logger.debug(error_msg)
+            raise HeuristicAnalyzerValueError(error_msg)
+
+        version = pypi_package_json.component.version
+        if version is None:  # check latest release version
+            version = pypi_package_json.get_latest_version()
+
+            if version is None:
+                error_msg = "There is no latest version of this package."
+                logger.debug(error_msg)
+                raise HeuristicAnalyzerValueError(error_msg)
+
+        release_files: list[JsonType] = []
+        wheel_present: bool = False
+
+        try:
+            for release_metadata in releases[version]:
+                if release_metadata["packagetype"] == self.WHEEL:
+                    wheel_present = True
+
+                release_files.append(release_metadata["filename"])
+        except KeyError as error:
+            error_msg = f"The version {version} is not available as a release."
+            logger.debug(error_msg)
+            raise HeuristicAnalyzerValueError(error_msg) from error
+
+        if wheel_present:
+            return HeuristicResult.PASS, {version: release_files}
+
+        return HeuristicResult.FAIL, {version: release_files}

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from macaron.database.db_custom_types import DBJsonDict
 from macaron.database.table_definitions import CheckFacts
+from macaron.errors import HeuristicAnalyzerValueError
 from macaron.json_tools import JsonType, json_extract
 from macaron.malware_analyzer.pypi_heuristics.base_analyzer import BaseHeuristicAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.heuristics import HeuristicResult, Heuristics
@@ -20,6 +21,7 @@ from macaron.malware_analyzer.pypi_heuristics.metadata.high_release_frequency im
 from macaron.malware_analyzer.pypi_heuristics.metadata.one_release import OneReleaseAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.metadata.unchanged_release import UnchangedReleaseAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.metadata.unreachable_project_links import UnreachableProjectLinksAnalyzer
+from macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence import WheelAbsenceAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.sourcecode.suspicious_setup import SuspiciousSetupAnalyzer
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 from macaron.slsa_analyzer.build_tool.pip import Pip
@@ -70,11 +72,13 @@ ANALYZERS: list = [
     UnchangedReleaseAnalyzer,
     CloserReleaseJoinDateAnalyzer,
     SuspiciousSetupAnalyzer,
+    WheelAbsenceAnalyzer,
 ]
 
 # The HeuristicResult sequence is aligned with the sequence of ANALYZERS list
 SUSPICIOUS_COMBO: dict[
     tuple[
+        HeuristicResult,
         HeuristicResult,
         HeuristicResult,
         HeuristicResult,
@@ -93,9 +97,10 @@ SUSPICIOUS_COMBO: dict[
         HeuristicResult.SKIP,  # Unchanged Release
         HeuristicResult.FAIL,  # Closer Release Join Date
         HeuristicResult.FAIL,  # Suspicious Setup
+        HeuristicResult.FAIL,  # Wheel Absence
         # No project link, only one release, and the maintainer released it shortly
         # after account registration.
-        # The setup.py file contains suspicious imports.
+        # The setup.py file contains suspicious imports and .whl file isn't present.
     ): Confidence.HIGH,
     (
         HeuristicResult.FAIL,  # Empty Project
@@ -105,9 +110,10 @@ SUSPICIOUS_COMBO: dict[
         HeuristicResult.FAIL,  # Unchanged Release
         HeuristicResult.FAIL,  # Closer Release Join Date
         HeuristicResult.FAIL,  # Suspicious Setup
+        HeuristicResult.FAIL,  # Wheel Absence
         # No project link, frequent releases of multiple versions without modifying the content,
         # and the maintainer released it shortly after account registration.
-        # The setup.py file contains suspicious imports.
+        # The setup.py file contains suspicious imports and .whl file isn't present.
     ): Confidence.HIGH,
     (
         HeuristicResult.FAIL,  # Empty Project
@@ -117,9 +123,10 @@ SUSPICIOUS_COMBO: dict[
         HeuristicResult.PASS,  # Unchanged Release
         HeuristicResult.FAIL,  # Closer Release Join Date
         HeuristicResult.FAIL,  # Suspicious Setup
+        HeuristicResult.FAIL,  # Wheel Absence
         # No project link, frequent releases of multiple versions,
         # and the maintainer released it shortly after account registration.
-        # The setup.py file contains suspicious imports.
+        # The setup.py file contains suspicious imports and .whl file isn't present.
     ): Confidence.HIGH,
     (
         HeuristicResult.FAIL,  # Empty Project
@@ -129,8 +136,23 @@ SUSPICIOUS_COMBO: dict[
         HeuristicResult.FAIL,  # Unchanged Release
         HeuristicResult.FAIL,  # Closer Release Join Date
         HeuristicResult.PASS,  # Suspicious Setup
+        HeuristicResult.PASS,  # Wheel Absence
         # No project link, frequent releases of multiple versions without modifying the content,
-        # and the maintainer released it shortly after account registration.
+        # and the maintainer released it shortly after account registration. Presence/Absence of
+        # .whl file has no effect
+    ): Confidence.MEDIUM,
+    (
+        HeuristicResult.FAIL,  # Empty Project
+        HeuristicResult.SKIP,  # Unreachable Project Links
+        HeuristicResult.PASS,  # One Release
+        HeuristicResult.FAIL,  # High Release Frequency
+        HeuristicResult.FAIL,  # Unchanged Release
+        HeuristicResult.FAIL,  # Closer Release Join Date
+        HeuristicResult.PASS,  # Suspicious Setup
+        HeuristicResult.FAIL,  # Wheel Absence
+        # No project link, frequent releases of multiple versions without modifying the content,
+        # and the maintainer released it shortly after account registration. Presence/Absence of
+        # .whl file has no effect
     ): Confidence.MEDIUM,
     (
         HeuristicResult.PASS,  # Empty Project
@@ -140,9 +162,10 @@ SUSPICIOUS_COMBO: dict[
         HeuristicResult.PASS,  # Unchanged Release
         HeuristicResult.FAIL,  # Closer Release Join Date
         HeuristicResult.FAIL,  # Suspicious Setup
+        HeuristicResult.FAIL,  # Wheel Absence
         # All project links are unreachable, frequent releases of multiple versions,
         # and the maintainer released it shortly after account registration.
-        # The setup.py file contains suspicious imports.
+        # The setup.py file contains suspicious imports and .whl file isn't present.
     ): Confidence.HIGH,
 }
 
@@ -197,6 +220,11 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         -------
         tuple[dict[Heuristics, HeuristicResult], dict[str, JsonType]]
             Containing the analysis results and relevant metadata.
+
+        Raises
+        ------
+        HeuristicAnalyzerValueError
+            If a heuristic analysis fails due to malformed package information.
         """
         results: dict[Heuristics, HeuristicResult] = {}
         detail_info: dict[str, JsonType] = {}
@@ -277,7 +305,11 @@ class DetectMaliciousMetadataCheck(BaseCheck):
 
                     # Download the PyPI package JSON, but no need to persist it to the filesystem.
                     if pypi_package_json.download(dest=""):
-                        result, detail_info = self.run_heuristics(pypi_package_json)
+                        try:
+                            result, detail_info = self.run_heuristics(pypi_package_json)
+                        except HeuristicAnalyzerValueError:
+                            return CheckResultData(result_tables=[], result_type=CheckResultType.UNKNOWN)
+
                         result_combo: tuple = tuple(result.values())
                         confidence: float | None = SUSPICIOUS_COMBO.get(result_combo, None)
                         result_type = CheckResultType.FAILED

--- a/src/macaron/util.py
+++ b/src/macaron/util.py
@@ -59,6 +59,72 @@ def send_get_http(url: str, headers: dict) -> dict:
     return dict(response.json())
 
 
+def send_head_http_raw(
+    url: str, headers: dict | None = None, timeout: int | None = None, allow_redirects: bool = True
+) -> Response | None:
+    """Send the HEAD HTTP request with the given url and headers.
+
+    This method also handle logging when the API server return error status code.
+
+    Parameters
+    ----------
+    url : str
+        The url of the request.
+    headers : dict | None
+        The dict that describes the headers of the request.
+    timeout: int | None
+        The request timeout (optional).
+    allow_redirects: bool
+        Whether to allow redirects. Default: True.
+
+    Returns
+    -------
+    Response | None
+        If a Response object is returned and ``allow_redirects`` is ``True`` (the default) it will have a status code of
+        200 (OK). If ``allow_redirects`` is ``False`` the response can instead have a status code of 302. Otherwise, the
+        request has failed and ``None`` will be returned.
+    """
+    logger.debug("HEAD - %s", url)
+    if not timeout:
+        timeout = defaults.getint("requests", "timeout", fallback=10)
+    error_retries = defaults.getint("requests", "error_retries", fallback=5)
+    retry_counter = error_retries
+    try:
+        response = requests.head(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+        )
+    except requests.exceptions.RequestException as error:
+        logger.debug(error)
+        return None
+    if not allow_redirects and response.status_code == 302:
+        # Found, most likely because a redirect is about to happen.
+        return response
+    while response.status_code != 200:
+        logger.debug(
+            "Receiving error code %s from server.",
+            response.status_code,
+        )
+        if retry_counter <= 0:
+            logger.debug("Maximum retries reached: %s", error_retries)
+            return None
+        if response.status_code == 403:
+            check_rate_limit(response)
+        else:
+            return None
+        retry_counter = retry_counter - 1
+        response = requests.head(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+        )
+
+    return response
+
+
 def send_get_http_raw(
     url: str, headers: dict | None = None, timeout: int | None = None, allow_redirects: bool = True
 ) -> Response | None:

--- a/tests/integration/cases/ajax-requester_pypi_malware_analyzer/policy.dl
+++ b/tests/integration/cases/ajax-requester_pypi_malware_analyzer/policy.dl
@@ -1,0 +1,11 @@
+/* Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("check-ajax-requester", component_id, "Check ajax-requester artifacts") :-
+    check_passed(component_id, "mcn_detect_malicious_metadata_1").
+
+apply_policy_to("check-ajax-requester", component_id) :-
+    is_component(component_id, purl),
+    match("pkg:pypi/ajax-requester", purl).

--- a/tests/integration/cases/ajax-requester_pypi_malware_analyzer/test.yaml
+++ b/tests/integration/cases/ajax-requester_pypi_malware_analyzer/test.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing the metadata of a project with unreachable links, frequent releases, and the maintainer
+  released it shortly after account registration with a suspicious setup.py file, but a wheel file
+  is present. Macaron should report a pass for such a package.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze against ajax-requester
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/ajax-requester
+- name: Run macaron verify-policy to check the results
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/malware_analyzer/pypi/test_wheel_absence.py
+++ b/tests/malware_analyzer/pypi/test_wheel_absence.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Tests for heuristic detecting wheel (.whl) file absence from PyPI packages"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from macaron.errors import HeuristicAnalyzerValueError
+from macaron.malware_analyzer.pypi_heuristics.heuristics import HeuristicResult
+from macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence import WheelAbsenceAnalyzer
+
+
+def test_analyze_no_information(pypi_package_json: MagicMock) -> None:
+    """Test for when there is no release information, so error"""
+    analyzer = WheelAbsenceAnalyzer()
+
+    pypi_package_json.get_releases.return_value = None
+
+    with pytest.raises(HeuristicAnalyzerValueError):
+        analyzer.analyze(pypi_package_json)
+
+
+def test_analyze_tar_present(pypi_package_json: MagicMock) -> None:
+    """Test for when only .tar.gz is present, so failed"""
+    analyzer = WheelAbsenceAnalyzer()
+    version = "0.1.0"
+    filename = "ttttttttest_nester.py-0.1.0.tar.gz"
+
+    release = {
+        version: [
+            {
+                "comment_text": "",
+                "digests": {
+                    "blake2b_256": "defa2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3",
+                    "md5": "9203bbb130f8ddb38269f4861c170d04",
+                    "sha256": "168bcccbf5106132e90b85659297700194369b8f6b3e5a03769614f0d200e370",
+                },
+                "downloads": -1,
+                "filename": filename,
+                "has_sig": False,
+                "md5_digest": "9203bbb130f8ddb38269f4861c170d04",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": None,
+                "size": 546,
+                "upload_time": "2016-10-13T05:42:27",
+                "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
+                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
+                ac4a77ab2452ba72b49a22b12981b2f375b3/{filename}",
+                "yanked": False,
+                "yanked_reason": None,
+            }
+        ]
+    }
+
+    pypi_package_json.get_releases.return_value = release
+    pypi_package_json.get_latest_version.return_value = version
+    pypi_package_json.component.version = None
+    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.FAIL, {version: [filename]})
+
+    actual_result = analyzer.analyze(pypi_package_json)
+
+    assert actual_result == expected_result
+
+
+def test_analyze_whl_present(pypi_package_json: MagicMock) -> None:
+    """Test for when only .whl is present, so pass"""
+    analyzer = WheelAbsenceAnalyzer()
+    version = "0.1.0"
+    filename = "ttttttttest_nester.py-0.1.0.whl"
+
+    release = {
+        version: [
+            {
+                "comment_text": "",
+                "digests": {
+                    "blake2b_256": "defa2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3",
+                    "md5": "9203bbb130f8ddb38269f4861c170d04",
+                    "sha256": "168bcccbf5106132e90b85659297700194369b8f6b3e5a03769614f0d200e370",
+                },
+                "downloads": -1,
+                "filename": filename,
+                "has_sig": False,
+                "md5_digest": "9203bbb130f8ddb38269f4861c170d04",
+                "packagetype": "bdist_wheel",
+                "python_version": "py2.py3",
+                "requires_python": None,
+                "size": 546,
+                "upload_time": "2016-10-13T05:42:27",
+                "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
+                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
+                ac4a77ab2452ba72b49a22b12981b2f375b3/{filename}",
+                "yanked": False,
+                "yanked_reason": None,
+            }
+        ]
+    }
+
+    pypi_package_json.get_releases.return_value = release
+    pypi_package_json.component.version = version
+    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.PASS, {version: [filename]})
+
+    actual_result = analyzer.analyze(pypi_package_json)
+
+    assert actual_result == expected_result
+
+
+def test_analyze_both_present(pypi_package_json: MagicMock) -> None:
+    """Test for when both .tar.gz and .whl are present, so passed"""
+    analyzer = WheelAbsenceAnalyzer()
+    version = "0.1.0"
+    file_prefix = "ttttttttest_nester.py-0.1.0"
+
+    release = {
+        version: [
+            {
+                "comment_text": "",
+                "digests": {
+                    "blake2b_256": "defa2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3",
+                    "md5": "9203bbb130f8ddb38269f4861c170d04",
+                    "sha256": "168bcccbf5106132e90b85659297700194369b8f6b3e5a03769614f0d200e370",
+                },
+                "downloads": -1,
+                "filename": f"{file_prefix}.whl",
+                "has_sig": False,
+                "md5_digest": "9203bbb130f8ddb38269f4861c170d04",
+                "packagetype": "bdist_wheel",
+                "python_version": "py2.py3",
+                "requires_python": None,
+                "size": 546,
+                "upload_time": "2016-10-13T05:42:27",
+                "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
+                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
+                ac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.whl",
+                "yanked": False,
+                "yanked_reason": None,
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "blake2b_256": "defa2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3",
+                    "md5": "9203bbb130f8ddb38269f4861c170d04",
+                    "sha256": "168bcccbf5106132e90b85659297700194369b8f6b3e5a03769614f0d200e370",
+                },
+                "downloads": -1,
+                "filename": f"{file_prefix}.tar.gz",
+                "has_sig": False,
+                "md5_digest": "9203bbb130f8ddb38269f4861c170d04",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": None,
+                "size": 546,
+                "upload_time": "2016-10-13T05:42:27",
+                "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
+                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
+                ac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.tar.gz",
+                "yanked": False,
+                "yanked_reason": None,
+            },
+        ]
+    }
+
+    pypi_package_json.get_releases.return_value = release
+    pypi_package_json.component.version = version
+    expected_result: tuple[HeuristicResult, dict] = (
+        HeuristicResult.PASS,
+        {version: [f"{file_prefix}.whl", f"{file_prefix}.tar.gz"]},
+    )
+
+    actual_result = analyzer.analyze(pypi_package_json)
+
+    assert actual_result == expected_result

--- a/tests/malware_analyzer/pypi/test_wheel_absence.py
+++ b/tests/malware_analyzer/pypi/test_wheel_absence.py
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for heuristic detecting wheel (.whl) file absence from PyPI packages"""
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,11 +21,23 @@ def test_analyze_no_information(pypi_package_json: MagicMock) -> None:
         analyzer.analyze(pypi_package_json)
 
 
-def test_analyze_tar_present(pypi_package_json: MagicMock) -> None:
+# Note: to patch a function, the way it is imported matters.
+# e.g. if it is imported like this: import os; os.listdir() then you patch os.listdir
+# if it is imported like this: from os import listdir; listdir() then you patch <module>.listdir
+@patch("macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence.send_head_http_raw")
+def test_analyze_tar_present(mock_send_head_http_raw: MagicMock, pypi_package_json: MagicMock) -> None:
     """Test for when only .tar.gz is present, so failed"""
     analyzer = WheelAbsenceAnalyzer()
     version = "0.1.0"
     filename = "ttttttttest_nester.py-0.1.0.tar.gz"
+    url = (
+        "https://files.pythonhosted.org/packages/de/fa/"
+        + f"2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{filename}"
+    )
+    inspector_link_expected = (
+        "https://inspector.pypi.io/project/ttttttttest_nester/0.1.0/packages/"
+        + f"de/fa/2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{filename}"
+    )
 
     release = {
         version: [
@@ -46,8 +58,7 @@ def test_analyze_tar_present(pypi_package_json: MagicMock) -> None:
                 "size": 546,
                 "upload_time": "2016-10-13T05:42:27",
                 "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
-                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
-                ac4a77ab2452ba72b49a22b12981b2f375b3/{filename}",
+                "url": url,
                 "yanked": False,
                 "yanked_reason": None,
             }
@@ -57,18 +68,34 @@ def test_analyze_tar_present(pypi_package_json: MagicMock) -> None:
     pypi_package_json.get_releases.return_value = release
     pypi_package_json.get_latest_version.return_value = version
     pypi_package_json.component.version = None
-    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.FAIL, {version: [filename]})
+    pypi_package_json.package_json = {"info": {"name": "ttttttttest_nester"}}
+    mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
+
+    expected_detail_info = {
+        "inspector_links": [inspector_link_expected],
+    }
+
+    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.FAIL, expected_detail_info)
 
     actual_result = analyzer.analyze(pypi_package_json)
 
     assert actual_result == expected_result
 
 
-def test_analyze_whl_present(pypi_package_json: MagicMock) -> None:
+@patch("macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence.send_head_http_raw")
+def test_analyze_whl_present(mock_send_head_http_raw: MagicMock, pypi_package_json: MagicMock) -> None:
     """Test for when only .whl is present, so pass"""
     analyzer = WheelAbsenceAnalyzer()
     version = "0.1.0"
     filename = "ttttttttest_nester.py-0.1.0.whl"
+    url = (
+        "https://files.pythonhosted.org/packages/de/fa/"
+        + f"2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{filename}"
+    )
+    inspector_link_expected = (
+        "https://inspector.pypi.io/project/ttttttttest_nester/0.1.0/packages/"
+        + f"de/fa/2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{filename}"
+    )
 
     release = {
         version: [
@@ -89,8 +116,7 @@ def test_analyze_whl_present(pypi_package_json: MagicMock) -> None:
                 "size": 546,
                 "upload_time": "2016-10-13T05:42:27",
                 "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
-                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
-                ac4a77ab2452ba72b49a22b12981b2f375b3/{filename}",
+                "url": url,
                 "yanked": False,
                 "yanked_reason": None,
             }
@@ -99,18 +125,42 @@ def test_analyze_whl_present(pypi_package_json: MagicMock) -> None:
 
     pypi_package_json.get_releases.return_value = release
     pypi_package_json.component.version = version
-    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.PASS, {version: [filename]})
+    pypi_package_json.package_json = {"info": {"name": "ttttttttest_nester"}}
+    mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
+
+    expected_detail_info = {
+        "inspector_links": [inspector_link_expected],
+    }
+
+    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.PASS, expected_detail_info)
 
     actual_result = analyzer.analyze(pypi_package_json)
 
     assert actual_result == expected_result
 
 
-def test_analyze_both_present(pypi_package_json: MagicMock) -> None:
+@patch("macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence.send_head_http_raw")
+def test_analyze_both_present(mock_send_head_http_raw: MagicMock, pypi_package_json: MagicMock) -> None:
     """Test for when both .tar.gz and .whl are present, so passed"""
     analyzer = WheelAbsenceAnalyzer()
     version = "0.1.0"
     file_prefix = "ttttttttest_nester.py-0.1.0"
+    wheel_url = (
+        "https://files.pythonhosted.org/packages/de/fa/"
+        + f"2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.whl"
+    )
+    tar_url = (
+        "https://files.pythonhosted.org/packages/de/fa/"
+        + f"2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.tar.gz"
+    )
+    wheel_link_expected = (
+        "https://inspector.pypi.io/project/ttttttttest_nester/0.1.0/packages/"
+        + f"de/fa/2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.whl"
+    )
+    tar_link_expected = (
+        "https://inspector.pypi.io/project/ttttttttest_nester/0.1.0/packages/"
+        + f"de/fa/2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.tar.gz"
+    )
 
     release = {
         version: [
@@ -131,8 +181,7 @@ def test_analyze_both_present(pypi_package_json: MagicMock) -> None:
                 "size": 546,
                 "upload_time": "2016-10-13T05:42:27",
                 "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
-                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
-                ac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.whl",
+                "url": wheel_url,
                 "yanked": False,
                 "yanked_reason": None,
             },
@@ -153,8 +202,7 @@ def test_analyze_both_present(pypi_package_json: MagicMock) -> None:
                 "size": 546,
                 "upload_time": "2016-10-13T05:42:27",
                 "upload_time_iso_8601": "2016-10-13T05:42:27.073842Z",
-                "url": f"https://files.pythonhosted.org/packages/de/fa/2fbcebaeeb909511139ce28d \
-                ac4a77ab2452ba72b49a22b12981b2f375b3/{file_prefix}.tar.gz",
+                "url": tar_url,
                 "yanked": False,
                 "yanked_reason": None,
             },
@@ -163,10 +211,14 @@ def test_analyze_both_present(pypi_package_json: MagicMock) -> None:
 
     pypi_package_json.get_releases.return_value = release
     pypi_package_json.component.version = version
-    expected_result: tuple[HeuristicResult, dict] = (
-        HeuristicResult.PASS,
-        {version: [f"{file_prefix}.whl", f"{file_prefix}.tar.gz"]},
-    )
+    pypi_package_json.package_json = {"info": {"name": "ttttttttest_nester"}}
+    mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
+
+    expected_detail_info = {
+        "inspector_links": [wheel_link_expected, tar_link_expected],
+    }
+
+    expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.PASS, expected_detail_info)
 
     actual_result = analyzer.analyze(pypi_package_json)
 

--- a/tests/repo_finder/test_commit_finder.py
+++ b/tests/repo_finder/test_commit_finder.py
@@ -97,6 +97,9 @@ def test_commit_finder() -> None:
             "initial_branch": "master",
         },
     )
+    # Disable gpg signing of tags for this repository to prevent input prompt hang.
+    with git_obj.repo.config_writer() as git_config:
+        git_config.set_value("tag", "gpgsign", "false")
 
     # Create a commit from a newly created file.
     with open(os.path.join(REPO_DIR, "file_1"), "w", encoding="utf-8") as file:


### PR DESCRIPTION
This PR prevents the commit finder tests from hanging if the user's Git is configured to require gpg signing for tags, as noted by #938. This is achieved by overriding the config value for the temporary repository created by the test.

Closes #938 