### PR TITLE
chore: disable gpg signing for commit finder tests

### DIFF
--- a/tests/repo_finder/test_commit_finder.py
+++ b/tests/repo_finder/test_commit_finder.py
@@ -97,6 +97,9 @@ def test_commit_finder() -> None:
             "initial_branch": "master",
         },
     )
+    # Disable gpg signing of tags for this repository to prevent input prompt hang.
+    with git_obj.repo.config_writer() as git_config:
+        git_config.set_value("tag", "gpgsign", "false")
 
     # Create a commit from a newly created file.
     with open(os.path.join(REPO_DIR, "file_1"), "w", encoding="utf-8") as file:


### PR DESCRIPTION
This PR prevents the commit finder tests from hanging when the user has configured their Git environment to require gpg signing for tags, as noted by #938. This is achieved by overriding the configuration value for the temporary repository created by the test.

Closes #938 