### PR TITLE
docs: add in the api docs entry for wheel absence heuristic

### DIFF
--- a/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.metadata.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.metadata.rst
@@ -56,3 +56,11 @@ macaron.malware\_analyzer.pypi\_heuristics.metadata.unreachable\_project\_links 
    :members:
    :undoc-members:
    :show-inheritance:
+
+macaron.malware\_analyzer.pypi\_heuristics.metadata.wheel\_absence module
+-------------------------------------------------------------------------
+
+.. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Addressing issue #942, the `make docs-api` command has been run and has included an entry in `macaron.malware_analyzer.pypi_heuristics.metadata.rst` with the following content:

```
macaron.malware\_analyzer.pypi\_heuristics.metadata.wheel\_absence module
-------------------------------------------------------------------------

.. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence
   :members:
   :undoc-members:
   :show-inheritance:
```