### PR TITLE
fix: update already present repositories

### DIFF
--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -124,10 +124,6 @@ def check_out_repo_target(
 
     This function assumes that a remote "origin" exist and checkout from that remote ONLY.
 
-    If ``offline_mode`` is False, this function will fetch new changes from origin remote. The fetching operation
-    will prune and update all references (e.g. tags, branches) to make sure that the local repository is up-to-date
-    with the repository specified by origin remote.
-
     If ``offline_mode`` is True and neither ``branch_name`` nor commit are provided, this function will not do anything
     and the HEAD commit will be analyzed. If there are uncommitted local changes, the HEAD commit will
     appear in the report but the repo with local changes will be analyzed. We leave it up to the user to decide
@@ -277,9 +273,9 @@ def clone_remote_repo(clone_dir: str, url: str) -> Repo | None:
     """Clone the remote repository and return the `git.Repo` object for that repository.
 
     If there is an existing non-empty ``clone_dir``, Macaron assumes the repository has
-    been cloned already and cancels the clone.
-    This could happen when multiple runs of Macaron use the same `<output_dir>`, leading
-    to Macaron potentially trying to clone a repository multiple times.
+    been cloned already and will attempt to fetch the latest changes. The fetching operation
+    will prune and update all references (e.g. tags, branches) to make sure that the local
+    repository is up-to-date with the repository specified by origin remote.
 
     We use treeless partial clone to reduce clone time, by retrieving trees and blobs lazily.
     For more details, see the following:

--- a/tests/integration/cases/update_local_repositories/modify_clone.sh
+++ b/tests/integration/cases/update_local_repositories/modify_clone.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+cd output/git_repos/github_com/avaje/avaje-prisms
+git tag --delete avaje-prisms-1.1

--- a/tests/integration/cases/update_local_repositories/policy.dl
+++ b/tests/integration/cases/update_local_repositories/policy.dl
@@ -1,0 +1,11 @@
+/* Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_passed(component_id, "mcn_version_control_system_1"),
+    is_repo_url(component_id, "https://github.com/avaje/avaje-prisms").
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:maven/io.avaje/avaje-prisms@1.1").

--- a/tests/integration/cases/update_local_repositories/test.yaml
+++ b/tests/integration/cases/update_local_repositories/test.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Ensuring previously cloned repositories are updated when newer changes are available at their remote origins.
+
+tags:
+- macaron-python-package
+- macaron-docker-image
+
+steps:
+- name: Analyze a repository
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.avaje/avaje-prisms@1.1
+- name: Delete the chosen tag from the repository
+  kind: shell
+  options:
+    cmd: ./modify_clone.sh
+- name: Analyze the repository again
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.avaje/avaje-prisms@1.1
+- name: Run macaron verify-policy to verify version control check which will only pass if the tag is found
+  kind: verify
+  options:
+    policy: policy.dl


### PR DESCRIPTION
This fixes the issue with previously cloned repositories not updating when newer changes are present at their remote origins, by using `git fetch` when the target directory of the clone is already present. This comes with a small performance hit for any analysis performed on a previously cloned target.

Closes #948 