### PR TITLE
test: block the malware detection unit test from reaching network

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 [requests]
@@ -537,6 +537,8 @@ registry_url_netloc = pypi.org
 registry_url_scheme = https
 fileserver_url_netloc = files.pythonhosted.org
 fileserver_url_scheme = https
+inspector_url_netloc = inspector.pypi.io
+inspector_url_scheme = https
 
 # Configuration options for selecting the checks to run.
 # Both the exclude and include are defined as list of strings:

--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The heuristic analyzer to check .whl file absence."""
@@ -26,7 +26,8 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
     WHEEL: str = "bdist_wheel"
     # as per https://github.com/pypi/inspector/blob/main/inspector/main.py line 125
     INSPECTOR_TEMPLATE = (
-        "https://inspector.pypi.io/project/{name}/{version}/packages/{first}/{second}/{rest}/{filename}"
+        "{inspector_url_scheme}://{inspector_url_netloc}/project/"
+        "{name}/{version}/packages/{first}/{second}/{rest}/{filename}"
     )
 
     def __init__(self) -> None:
@@ -108,6 +109,8 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
                 wheel_present = True
 
             inspector_link = self.INSPECTOR_TEMPLATE.format(
+                inspector_url_scheme=pypi_package_json.pypi_registry.inspector_url_scheme,
+                inspector_url_netloc=pypi_package_json.pypi_registry.inspector_url_netloc,
                 name=name,
                 version=version,
                 first=blake2b_256[0:2],

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The module provides abstractions for the pypi package registry."""
@@ -34,6 +34,8 @@ class PyPIRegistry(PackageRegistry):
         registry_url_scheme: str | None = None,
         fileserver_url_netloc: str | None = None,
         fileserver_url_scheme: str | None = None,
+        inspector_url_netloc: str | None = None,
+        inspector_url_scheme: str | None = None,
         request_timeout: int | None = None,
         enabled: bool = True,
     ) -> None:
@@ -50,6 +52,10 @@ class PyPIRegistry(PackageRegistry):
             The netloc of the server url that stores package source files, which contains the hostname and port.
         fileserver_url_scheme: str | None
             The scheme of the server url that stores package source files.
+        inspector_url_netloc: str | None
+            The netloc of the inspector server url, which contains the hostname and port.
+        inspector_url_scheme: str | None
+            The scheme of the inspector server url.
         request_timeout: int | None
             The timeout (in seconds) for requests made to the package registry.
         enabled: bool
@@ -60,6 +66,8 @@ class PyPIRegistry(PackageRegistry):
         self.registry_url_scheme = registry_url_scheme or ""
         self.fileserver_url_netloc = fileserver_url_netloc or ""
         self.fileserver_url_scheme = fileserver_url_scheme or ""
+        self.inspector_url_netloc = inspector_url_netloc or ""
+        self.inspector_url_scheme = inspector_url_scheme or ""
         self.request_timeout = request_timeout or 10
         self.enabled = enabled
         self.registry_url = ""
@@ -100,6 +108,14 @@ class PyPIRegistry(PackageRegistry):
             )
         self.fileserver_url_netloc = fileserver_url_netloc
         self.fileserver_url_scheme = section.get("fileserver_url_scheme", "https")
+
+        inspector_url_netloc = section.get("inspector_url_netloc")
+        if not inspector_url_netloc:
+            raise ConfigurationError(
+                f'The "inspector_url_netloc" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+        self.inspector_url_netloc = inspector_url_netloc
+        self.inspector_url_scheme = section.get("inspector_url_scheme", "https")
 
         try:
             self.request_timeout = section.getint("request_timeout", fallback=10)

--- a/tests/malware_analyzer/pypi/test_wheel_absence.py
+++ b/tests/malware_analyzer/pypi/test_wheel_absence.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for heuristic detecting wheel (.whl) file absence from PyPI packages"""
@@ -69,6 +69,8 @@ def test_analyze_tar_present(mock_send_head_http_raw: MagicMock, pypi_package_js
     pypi_package_json.get_latest_version.return_value = version
     pypi_package_json.component.version = None
     pypi_package_json.package_json = {"info": {"name": "ttttttttest_nester"}}
+    pypi_package_json.pypi_registry.inspector_url_scheme = "https"
+    pypi_package_json.pypi_registry.inspector_url_netloc = "inspector.pypi.io"
     mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
 
     expected_detail_info = {
@@ -126,6 +128,8 @@ def test_analyze_whl_present(mock_send_head_http_raw: MagicMock, pypi_package_js
     pypi_package_json.get_releases.return_value = release
     pypi_package_json.component.version = version
     pypi_package_json.package_json = {"info": {"name": "ttttttttest_nester"}}
+    pypi_package_json.pypi_registry.inspector_url_scheme = "https"
+    pypi_package_json.pypi_registry.inspector_url_netloc = "inspector.pypi.io"
     mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
 
     expected_detail_info = {
@@ -212,6 +216,8 @@ def test_analyze_both_present(mock_send_head_http_raw: MagicMock, pypi_package_j
     pypi_package_json.get_releases.return_value = release
     pypi_package_json.component.version = version
     pypi_package_json.package_json = {"info": {"name": "ttttttttest_nester"}}
+    pypi_package_json.pypi_registry.inspector_url_scheme = "https"
+    pypi_package_json.pypi_registry.inspector_url_netloc = "inspector.pypi.io"
     mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
 
     expected_detail_info = {


### PR DESCRIPTION
The `detect_malicious_metadata` check is expected to `FAIL` for `pkg:pypi/zlibxjson` by running the heuristics, but a false negative has been introduced after the addition of the wheel presence heuristic. The unit test was passing because if the unit test was able to access the OSV knowledge base, it would identify the package as a known malware without running the heuristics. However, to ensure unit tests remain offline, network access is intentionally blocked and because of that the check passes. There is a TODO to fix this regression after adding better code-based heuristics.

This PR modifies the API URL configurations to make them compatible with offline unit tests, ensuring they work without requiring network access.