### PR TITLE
fix: report known malware even when not labeled

### DIFF
--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.package_registry.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.package_registry.rst
@@ -9,6 +9,14 @@ macaron.slsa\_analyzer.package\_registry package
 Submodules
 ----------
 
+macaron.slsa\_analyzer.package\_registry.deps\_dev module
+---------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.package_registry.deps_dev
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.slsa\_analyzer.package\_registry.jfrog\_maven\_registry module
 ----------------------------------------------------------------------
 

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -543,7 +543,7 @@ inspector_url_scheme = https
 [deps_dev]
 url_netloc = api.deps.dev
 url_scheme = https
-v3alpha_purl_endpoint = v3alpha/purl
+purl_endpoint = v3alpha/purl
 
 # Configuration options for selecting the checks to run.
 # Both the exclude and include are defined as list of strings:

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -540,6 +540,11 @@ fileserver_url_scheme = https
 inspector_url_netloc = inspector.pypi.io
 inspector_url_scheme = https
 
+[deps_dev]
+url_netloc = api.deps.dev
+url_scheme = https
+v3alpha_purl_endpoint = v3alpha/purl
+
 # Configuration options for selecting the checks to run.
 # Both the exclude and include are defined as list of strings:
 #   - The exclude list is used to specify the checks that will not run.

--- a/src/macaron/errors.py
+++ b/src/macaron/errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains error classes for Macaron."""
@@ -54,6 +54,17 @@ class DuplicateError(MacaronError):
 
 class InvalidHTTPResponseError(MacaronError):
     """Happens when the HTTP response is invalid or unexpected."""
+
+
+class APIAccessError(MacaronError):
+    """Happens when a service API cannot be accessed.
+
+    Reasons can include:
+        * misconfiguration issues
+        * invalid API request
+        * network errors
+        * unexpected response returned by the API
+    """
 
 
 class CheckRegistryError(MacaronError):

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -310,15 +310,15 @@ class DetectMaliciousMetadataCheck(BaseCheck):
                     logger.debug("Unable to get a valid response from %s: %s", self.osv_query_url, error)
             if res_obj:
                 for vuln in res_obj.get("vulns", {}):
-                    v_id = json_extract(vuln, ["id"], str)
-                    result_tables.append(
-                        MaliciousMetadataFacts(
-                            known_malware=f"https://osv.dev/vulnerability/{v_id}",
-                            result={},
-                            detail_information=vuln,
-                            confidence=Confidence.HIGH,
+                    if v_id := json_extract(vuln, ["id"], str):
+                        result_tables.append(
+                            MaliciousMetadataFacts(
+                                known_malware=f"https://osv.dev/vulnerability/{v_id}",
+                                result={},
+                                detail_information=vuln,
+                                confidence=Confidence.HIGH,
+                            )
                         )
-                    )
                 if result_tables:
                     return CheckResultData(
                         result_tables=result_tables,

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from macaron.database.db_custom_types import DBJsonDict
 from macaron.database.table_definitions import CheckFacts
-from macaron.errors import HeuristicAnalyzerValueError, InvalidHTTPResponseError
+from macaron.errors import HeuristicAnalyzerValueError
 from macaron.json_tools import JsonType, json_extract
 from macaron.malware_analyzer.pypi_heuristics.base_analyzer import BaseHeuristicAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.heuristics import HeuristicResult, Heuristics
@@ -29,7 +29,7 @@ from macaron.slsa_analyzer.build_tool.pip import Pip
 from macaron.slsa_analyzer.build_tool.poetry import Poetry
 from macaron.slsa_analyzer.checks.base_check import BaseCheck
 from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType, Confidence, JustificationType
-from macaron.slsa_analyzer.package_registry.deps_dev import DepsDevService
+from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset, PyPIRegistry
 from macaron.slsa_analyzer.registry import registry
 from macaron.slsa_analyzer.specs.package_registry_spec import PackageRegistryInfo
@@ -296,7 +296,7 @@ class DetectMaliciousMetadataCheck(BaseCheck):
 
         try:
             package_exists = bool(DepsDevService.get_package_info(ctx.component.purl))
-        except InvalidHTTPResponseError as error:
+        except APIAccessError as error:
             logger.debug(error)
 
         # Known malicious packages must have been removed.

--- a/src/macaron/slsa_analyzer/package_registry/deps_dev.py
+++ b/src/macaron/slsa_analyzer/package_registry/deps_dev.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module contains implementation of deps.dev service."""
+
+import json
+import logging
+import urllib.parse
+from json.decoder import JSONDecodeError
+from urllib.parse import quote as encode
+
+from macaron.config.defaults import defaults
+from macaron.errors import ConfigurationError, InvalidHTTPResponseError
+from macaron.util import send_get_http_raw
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class DepsDevService:
+    """The deps.dev service class."""
+
+    @staticmethod
+    def get_package_info(purl: str) -> dict | None:
+        """Check if the package identified by the PackageURL (PURL) exists and return its information.
+
+        Parameters
+        ----------
+        purl: str
+            The PackageURL (PURL).
+
+        Returns
+        -------
+        dict | None
+            The package metadata or None if it doesn't exist.
+
+        Raises
+        ------
+        InvalidHTTPResponseError
+            If a network error happens or unexpected response is returned by the API.
+        """
+        section_name = "deps_dev"
+        if not defaults.has_section(section_name):
+            return None
+        section = defaults[section_name]
+
+        url_netloc = section.get("url_netloc")
+        if not url_netloc:
+            raise ConfigurationError(
+                f'The "url_netloc" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+        url_scheme = section.get("url_scheme", "https")
+        v3alpha_purl_endpoint = section.get("v3alpha_purl_endpoint")
+        if not v3alpha_purl_endpoint:
+            raise ConfigurationError(
+                f'The "v3alpha_purl_endpoint" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+
+        path_params = "/".join([v3alpha_purl_endpoint, encode(purl, safe="")])
+        try:
+            url = urllib.parse.urlunsplit(
+                urllib.parse.SplitResult(
+                    scheme=url_scheme,
+                    netloc=url_netloc,
+                    path=path_params,
+                    query="",
+                    fragment="",
+                )
+            )
+        except ValueError as error:
+            raise InvalidHTTPResponseError("Failed to construct the API URL.") from error
+
+        response = send_get_http_raw(url)
+        if response and response.text:
+            try:
+                metadata: dict = json.loads(response.text)
+            except JSONDecodeError as error:
+                raise InvalidHTTPResponseError(f"Failed to process response from deps.dev for {url}.") from error
+            if not metadata:
+                raise InvalidHTTPResponseError(f"Empty response returned by {url} .")
+            return metadata
+
+        return None

--- a/src/macaron/slsa_analyzer/package_registry/jfrog_maven_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/jfrog_maven_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Assets on a package registry."""
@@ -816,7 +816,7 @@ class JFrogMavenRegistry(PackageRegistry):
 
         return True
 
-    def find_publish_timestamp(self, purl: str, registry_url: str | None = None) -> datetime:
+    def find_publish_timestamp(self, purl: str) -> datetime:
         """Make a search request to Maven Central to find the publishing timestamp of an artifact.
 
         The reason for directly fetching timestamps from Maven Central is that deps.dev occasionally
@@ -829,8 +829,6 @@ class JFrogMavenRegistry(PackageRegistry):
         purl: str
             The Package URL (purl) of the package whose publication timestamp is to be retrieved.
             This should conform to the PURL specification.
-        registry_url: str | None
-            The registry URL that can be set for testing.
 
         Returns
         -------

--- a/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The module provides abstractions for the Maven Central package registry."""
@@ -182,7 +182,7 @@ class MavenCentralRegistry(PackageRegistry):
         compatible_build_tool_classes = [Maven, Gradle]
         return any(isinstance(build_tool, build_tool_class) for build_tool_class in compatible_build_tool_classes)
 
-    def find_publish_timestamp(self, purl: str, registry_url: str | None = None) -> datetime:
+    def find_publish_timestamp(self, purl: str) -> datetime:
         """Make a search request to Maven Central to find the publishing timestamp of an artifact.
 
         The reason for directly fetching timestamps from Maven Central is that deps.dev occasionally
@@ -195,8 +195,6 @@ class MavenCentralRegistry(PackageRegistry):
         purl: str
             The Package URL (purl) of the package whose publication timestamp is to be retrieved.
             This should conform to the PURL specification.
-        registry_url: str | None
-            The registry URL that can be set for testing.
 
         Returns
         -------

--- a/src/macaron/slsa_analyzer/package_registry/package_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/package_registry.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from macaron.errors import InvalidHTTPResponseError
 from macaron.json_tools import json_extract
 from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool
-from macaron.slsa_analyzer.package_registry.deps_dev import DepsDevService
+from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class PackageRegistry(ABC):
         # is available for subsequent processing.
         try:
             metadata = DepsDevService.get_package_info(purl)
-        except InvalidHTTPResponseError as error:
+        except APIAccessError as error:
             raise InvalidHTTPResponseError(f"Invalid response from deps.dev for {purl}.") from error
         if metadata:
             timestamp = json_extract(metadata, ["version", "publishedAt"], str)

--- a/tests/integration/cases/ultralytics/policy.dl
+++ b/tests/integration/cases/ultralytics/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("check-malicious-package", component_id, "Check the malicious package.") :-
+    check_passed(component_id, "mcn_detect_malicious_metadata_1").
+
+apply_policy_to("check-malicious-package", component_id) :-
+    is_component(component_id, "pkg:pypi/ultralytics").

--- a/tests/integration/cases/ultralytics/test.yaml
+++ b/tests/integration/cases/ultralytics/test.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a popular package that some of its versions are compromised.
+
+tags:
+- macaron-python-package
+- macaron-docker-image
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/ultralytics
+- name: Run macaron verify-policy to verify that the malicious metadata check passes.
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/integration/cases/ultralytics_8.3.46/policy.dl
+++ b/tests/integration/cases/ultralytics_8.3.46/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("check-malicious-package", component_id, "Check the malicious package.") :-
+    check_failed(component_id, "mcn_detect_malicious_metadata_1").
+
+apply_policy_to("check-malicious-package", component_id) :-
+    is_component(component_id, "pkg:pypi/ultralytics@8.3.46").

--- a/tests/integration/cases/ultralytics_8.3.46/test.yaml
+++ b/tests/integration/cases/ultralytics_8.3.46/test.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a known malicious package.
+
+tags:
+- macaron-python-package
+- macaron-docker-image
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/ultralytics@8.3.46
+- name: Run macaron verify-policy to verify that the malicious metadata check fails.
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
+++ b/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
@@ -68,6 +68,10 @@ def test_detect_malicious_metadata(
     fileserver_url_scheme = {base_url_parsed.scheme}
     inspector_url_netloc = {base_url_parsed.netloc}
     inspector_url_scheme = {base_url_parsed.scheme}
+
+    [deps_dev]
+    url_netloc = {base_url_parsed.netloc}
+    url_scheme = {base_url_parsed.scheme}
     """
 
     check.osv_query_url = f"{base_url_parsed.scheme}://{base_url_parsed.netloc}"

--- a/tests/slsa_analyzer/package_registry/test_deps_dev.py
+++ b/tests/slsa_analyzer/package_registry/test_deps_dev.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Tests for the deps.dev service."""
+
+import os
+import urllib
+from pathlib import Path
+
+import pytest
+from pytest_httpserver import HTTPServer
+from werkzeug import Response
+
+from macaron.config.defaults import load_defaults
+from macaron.errors import InvalidHTTPResponseError
+from macaron.slsa_analyzer.package_registry.deps_dev import DepsDevService
+
+
+@pytest.mark.parametrize(
+    ("purl", "data", "expected"),
+    [
+        ("pkg%3Apypi%2Fultralytics%408.3.46", "", None),
+        ("pkg%3Apypi%2Fultralytics", '{"foo": "bar"}', {"foo": "bar"}),
+    ],
+)
+def test_get_package_info(httpserver: HTTPServer, tmp_path: Path, purl: str, data: str, expected: dict | None) -> None:
+    """Test getting package info."""
+    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
+    user_config_input = f"""
+    [deps_dev]
+    url_netloc = {base_url_parsed.netloc}
+    url_scheme = {base_url_parsed.scheme}
+    """
+
+    user_config_path = os.path.join(tmp_path, "config.ini")
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+    # We don't have to worry about modifying the ``defaults`` object causing test
+    # pollution here, since we reload the ``defaults`` object before every test with the
+    # ``setup_test`` fixture.
+    load_defaults(user_config_path)
+
+    httpserver.expect_request(f"/v3alpha/purl/{purl}").respond_with_response(Response(data))
+
+    assert DepsDevService.get_package_info(purl) == expected
+
+
+def test_get_package_info_exception(httpserver: HTTPServer, tmp_path: Path) -> None:
+    """Test if the function correctly returns an exception."""
+    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
+    user_config_input = f"""
+    [deps_dev]
+    url_netloc = {base_url_parsed.netloc}
+    url_scheme = {base_url_parsed.scheme}
+    """
+
+    user_config_path = os.path.join(tmp_path, "config.ini")
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+    # We don't have to worry about modifying the ``defaults`` object causing test
+    # pollution here, since we reload the ``defaults`` object before every test with the
+    # ``setup_test`` fixture.
+    load_defaults(user_config_path)
+
+    purl = "pkg%3Apypi%2Fexample"
+    httpserver.expect_request(f"/v3alpha/purl/{purl}").respond_with_data("Not Valid")
+
+    with pytest.raises(InvalidHTTPResponseError):
+        DepsDevService.get_package_info(purl)

--- a/tests/slsa_analyzer/package_registry/test_deps_dev.py
+++ b/tests/slsa_analyzer/package_registry/test_deps_dev.py
@@ -12,8 +12,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Response
 
 from macaron.config.defaults import load_defaults
-from macaron.errors import InvalidHTTPResponseError
-from macaron.slsa_analyzer.package_registry.deps_dev import DepsDevService
+from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 
 
 @pytest.mark.parametrize(
@@ -65,5 +64,5 @@ def test_get_package_info_exception(httpserver: HTTPServer, tmp_path: Path) -> N
     purl = "pkg%3Apypi%2Fexample"
     httpserver.expect_request(f"/v3alpha/purl/{purl}").respond_with_data("Not Valid")
 
-    with pytest.raises(InvalidHTTPResponseError):
+    with pytest.raises(APIAccessError):
         DepsDevService.get_package_info(purl)


### PR DESCRIPTION
Some of the malicious packages are not clearly labeled in the OSV knowledge base. This PR improves the known malware detection in `detect_malicious_metadata_check`. It also adds a new abstraction for the deps.dev service to improve code reusability.