### PR TITLE
fix: set problem workflows' OS to ubuntu 22.04

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -9,7 +9,7 @@
 #
 # Even though we run the build in a matrix to check against different platforms, due to a known
 # limitation of reusable workflows that do not support setting strategy property from the caller
-# workflow, we only generate artifacts for ubuntu-latest and Python 3.11, which can be used to
+# workflow, we only generate artifacts for ubuntu-22.04 and Python 3.11, which can be used to
 # create a release. For details see:
 #
 # https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
@@ -148,4 +148,4 @@ jobs:
       artifact-sha256: ${{ needs.build.outputs.artifacts-sha256 }}
       # TODO: use ${{ env.ARTIFACT_OS }} and ${{ env.ARTIFACT_PYTHON }}
       # when this issue is addressed: https://github.com/actions/runner/issues/2394.
-      artifact-name: artifact-ubuntu-latest-python-3.11
+      artifact-name: artifact-ubuntu-22.04-python-3.11

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This is a trusted builder implemented as a reusable workflow that can be called by other
@@ -32,7 +32,7 @@ on:
 permissions:
   contents: read
 env:
-  ARTIFACT_OS: ubuntu-latest # The default OS for release.
+  ARTIFACT_OS: ubuntu-22.04 # The default OS for release.
   ARTIFACT_PYTHON: '3.11' # The default Python version for release.
   PACKAGE_PATH: src/macaron   # The relative Python package path to the repo.
 
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # It is recommended to pin a Runner version specifically:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python: ['3.11']
     steps:
 

--- a/.github/workflows/_build_docker.yaml
+++ b/.github/workflows/_build_docker.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This is a reuseable workflow to build and test the Docker image. Note that this workflow does not
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: read
     steps:

--- a/.github/workflows/_deploy-github-pages.yaml
+++ b/.github/workflows/_deploy-github-pages.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This workflow deploys the documentations to GitHub Pages.
@@ -26,7 +26,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Check out repository

--- a/.github/workflows/_generate-rebase.yaml
+++ b/.github/workflows/_generate-rebase.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Automatically rebase one staging branch on top of main after a new package version was published.
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   rebase:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Check out repository

--- a/.github/workflows/_release-notifications.yaml
+++ b/.github/workflows/_release-notifications.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Send a Slack release notification. Instructions to set up Slack to receive
@@ -27,7 +27,7 @@ permissions: {}
 jobs:
   slack:
     name: Slack release notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Notify via Slack

--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This workflow builds the base Docker image. The base image will be pushed to ghcr.io.
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build-base-image:
     name: Build base image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write # To push the base Docker image.
     steps:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Run CodeQL over the package. For more configuration options see codeql/codeql-config.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Automatically merge Dependabot PRs upon approval by leaving
@@ -15,7 +15,7 @@ permissions:
 jobs:
   comment:
     if: ${{ github.event.review.state == 'approved' && github.event.pull_request.user.login == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Merge Dependabot PR
       run: gh pr comment --body "@dependabot squash and merge" "$PR_URL"

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This workflow lints the PR's title and commits. It uses the commitizen
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   conventional-commits:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Check out repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # We run checks on pushing to the specified branches.
@@ -13,7 +13,7 @@ on:
 permissions:
   contents: read
 env:
-  ARTIFACT_NAME: artifact-ubuntu-latest-python-3.11
+  ARTIFACT_NAME: artifact-ubuntu-22.04-python-3.11
   # This is the username and email for the user who commits and pushes the release
   # commit. In an organisation that should be a dedicated devops account.
   USER_NAME: behnazh-w
@@ -33,7 +33,7 @@ jobs:
   bump:
     needs: check
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -108,7 +108,7 @@ jobs:
       release-url: ${{ steps.release-info.outputs.release-url }}
       image-name: ${{ steps.push-docker.outputs.image-name }}
       image-digest: ${{ steps.push-docker.outputs.image-digest }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # To publish release notes.
       packages: write # To push the Docker image.
@@ -299,7 +299,7 @@ jobs:
   # publish_provenance:
   #   needs: [release, provenance]
   #   name: Publish provenance
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   permissions:
   #     contents: write # To publish release notes.
   #   steps:
@@ -331,7 +331,7 @@ jobs:
     with:
       # TODO: use ${{ env.ARTIFACT_NAME }} when this issue is addressed:
       # https://github.com/actions/runner/issues/2394.
-      artifact-name: artifact-ubuntu-latest-python-3.11
+      artifact-name: artifact-ubuntu-22.04-python-3.11
       artifact-sha256: ${{ needs.build.outputs.artifacts-sha256 }}
 
   # Send out release notifications after the Release was published on GitHub.

--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Run Scorecard for this repository to further check and harden software and process.
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
This PR sets the version of ubuntu used by the workflows to `22.04` instead of `latest`, as that has been updated to `24.04` and does not provide the required `libffi7` dependency.
See issue #962 and alternative solution PR #964 