### PR TITLE
docs: add in the api docs entry for anomalous version heuristic

### DIFF
--- a/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.metadata.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.metadata.rst
@@ -9,6 +9,14 @@ macaron.malware\_analyzer.pypi\_heuristics.metadata package
 Submodules
 ----------
 
+macaron.malware\_analyzer.pypi\_heuristics.metadata.anomalous\_version module
+-----------------------------------------------------------------------------
+
+.. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.anomalous_version
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 macaron.malware\_analyzer.pypi\_heuristics.metadata.closer\_release\_join\_date module
 --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The entry for the anomalous version heuristic was missing in `macaron.malware_analyzer.pypi_heuristics.metadata.rst`, so `make docs-api` has been run to include it.