### PR TITLE
docs: add hyperlink for UTM virtualization tool in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.14.0 (2024-11-26)
+
+### Feat
+
+- report known malware for all ecosystems (#922)
+- add command to run repo and commit finder without analysis (#827)
+- add a new check to report the build tool (#914)
+- verify whether the reported repository can be linked back to the artifact (#873)
+- allow specifying the dependency depth resolution through CLI and make dependency resolution off by default (#840)
+
+### Fix
+
+- block terminal prompts in find source (#918)
+- fix a bug in GitHub Actions matrix variable resolution (#896)
+- prevent endless loop on 403 GitHub response (#866)
+
+### Refactor
+
+- accept provenance data in artifact pipeline check (#872)
+- remove --config-path from CLI (#844)
+
 ## v0.13.0 (2024-09-16)
 
 ### Feat

--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -15,7 +15,7 @@ Prerequisites
   - Macaron has been tested with ``bash 5.1.16(1)-release``.
 
 - Docker (or docker equivalent for your host OS) must be installed, with a docker command line equivalent to Docker 17.06 (Oracle Container Runtime 19.03) and the user should be a member of the operating system group ``docker`` (to run Docker in `rootless mode <https://docs.docker.com/engine/security/rootless/>`_).
-- We only support ``amd64`` / ``x86_64`` platforms at the moment.
+- We only support ``amd64`` / ``x86_64`` platforms at the moment. As for ``aarch64`` we suggest using `UTM <https://getutm.app/>`_ in emulator mode coupled with a ``x86_64`` VM.
 
 .. _download-macaron:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ version_files = [
     "src/macaron/__init__.py:__version__",
 ]
 major_version_zero = true
-version = "0.13.0"
+version = "0.14.0"
 
 
 # https://github.com/pytest-dev/pytest-cov

--- a/src/macaron/__init__.py
+++ b/src/macaron/__init__.py
@@ -8,7 +8,7 @@ import os
 # The version of this package. There's no comprehensive, official list of other
 # magic constants, so we stick with this one only for now. See also this conversation:
 # https://stackoverflow.com/questions/38344848/is-there-a-comprehensive-table-of-pythons-magic-constants
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 # The path to the Macaron package.
 MACARON_PATH = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Added a hyperlink for the UTM virtualization tool as a workaround for running the run_macaron.sh script on aarch64 architecture.