### PR TITLE
docs: add hyperlink for UTM virtualization tool in documentation

### DIFF
--- a/docs/source/pages/installation.rst
+++ b/docs/source/pages/installation.rst
@@ -15,7 +15,7 @@ Prerequisites
   - Macaron has been tested with ``bash 5.1.16(1)-release``.
 
 - Docker (or docker equivalent for your host OS) must be installed, with a docker command line equivalent to Docker 17.06 (Oracle Container Runtime 19.03) and the user should be a member of the operating system group ``docker`` (to run Docker in `rootless mode <https://docs.docker.com/engine/security/rootless/>`_).
-- We only support ``amd64`` / ``x86_64`` platforms at the moment.
+- We only support ``amd64`` / ``x86_64`` platforms at the moment. As for ``aarch64`` we suggest using `UTM <https://getutm.app/>`_ in emulator mode coupled with a ``x86_64`` VM.
 
 .. _download-macaron:
 


### PR DESCRIPTION
Added a hyperlink for the UTM virtualization tool as a workaround for running the run_macaron.sh script on aarch64 architecture.