### PR TITLE
test: fix unit test case sensitivity

### DIFF
--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -18,25 +18,6 @@ from macaron.artifact.local_artifact import (
 from macaron.errors import LocalArtifactFinderError
 
 
-def is_case_sensitive_filesystem() -> bool:
-    """Check if current filesystem is case-sensitive."""
-    tmp_path = Path(".")
-
-    # using "/" overloaded operator as __truediv__ in Path class to build a lower and upper path
-    lower = tmp_path / "a"
-    upper = tmp_path / "A"
-
-    try:
-        lower.touch()
-        upper.touch()
-        return not upper.exists()
-    finally:
-        if lower.exists():
-            lower.unlink()
-        if upper.exists():
-            upper.unlink()
-
-
 @pytest.mark.parametrize(
     ("purl_str", "expectation"),
     [
@@ -224,8 +205,11 @@ def test_get_local_artifact_paths_succeeded_pypi(tmp_path: Path) -> None:
     python_venv_path = f"{tmp_path_str}/.venv/lib/python3.11/site-packages"
 
     # We are also testing if the patterns match case-insensitively.
+    lower = tmp_path / "a"
+    upper = tmp_path / "A"
 
-    if not is_case_sensitive_filesystem():
+    is_fs_case_sensitive: bool = lower.exists() and not upper.exists()
+    if not is_fs_case_sensitive:
         pypi_artifact_paths = [
             f"{python_venv_path}/macaron",
             f"{python_venv_path}/macaron-0.13.0.dist-info",

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -4,7 +4,6 @@
 """Test the local artifact utilities."""
 
 import os
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -21,14 +20,21 @@ from macaron.errors import LocalArtifactFinderError
 
 def is_case_sensitive_filesystem() -> bool:
     """Check if current filesystem is case-sensitive."""
-    with tempfile.NamedTemporaryFile(prefix="Tmp") as tmp:
-        base = tmp.name
-        lower = base.lower()
-        upper = base.upper()
+    tmp_path = Path(".")
 
-        return not (os.path.exists(lower) or os.path.exists(upper)) or (
-            os.path.exists(lower) and os.path.exists(upper) and os.stat(lower).st_ino != os.stat(upper).st_ino
-        )
+    # using "/" overloaded operator as __truediv__ in Path class to build a lower and upper path
+    lower = tmp_path / "a"
+    upper = tmp_path / "A"
+
+    try:
+        lower.touch()
+        upper.touch()
+        return not upper.exists()
+    finally:
+        if lower.exists():
+            lower.unlink()
+        if upper.exists():
+            upper.unlink()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Handling filesystem specific case sensitivity, by creating temporary files and checking if they point towards same file using their inodes. This fixes #992