### PR TITLE
refactor: use problog for suspicious combinations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "cyclonedx-bom >=4.0.0,<5.0.0",
     "cyclonedx-python-lib[validation] >=7.3.4,<8.0.0",
     "beautifulsoup4 >= 4.12.0,<5.0.0",
+    "problog >= 2.2.6,<3.0.0",
 ]
 keywords = []
 # https://pypi.org/classifiers/
@@ -203,6 +204,7 @@ module = [
     "gitdb.*",
     "yamale.*",
     "defusedxml.*",
+    "problog.*",
 ]
 ignore_missing_imports = true
 

--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -52,6 +52,19 @@ When a heuristic fails, with `HeuristicResult.FAIL`, then that is an indicator b
    - **Rule**: Return `HeuristicResult.FAIL` if the major or epoch is abnormally high; otherwise, return `HeuristicResult.PASS`.
    - **Dependency**: Will be run if the One Release heuristic fails.
 
+### Contributing
+
+When contributing an analyzer, it must meet the following requirements:
+
+- The analyzer must be implemented in a separate file, placed in the relevant folder based on what it analyzes ([metadata](./pypi_heuristics/metadata/) or [sourcecode](./pypi_heuristics/sourcecode/)).
+- The analyzer must inherit from the `BaseHeuristicAnalyzer` class and implement the `analyze` function, returning relevant information specific to the analysis.
+- The analyzer name must be added to [heuristics.py](./pypi_heuristics/heuristics.py) file so it can be used for rule combinations in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py)
+- Update the `STATIC_PROBLOG_MODEL` in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py) with logical statements where the heuristic should be included. When adding new rules, please follow the following guidelines:
+   - Provide a [confidence value](../slsa_analyzer/checks/check_result.py) using the `Confidence` enum.
+   - Provide a name based on this confidence value (i.e. `high`, `medium`, or `low`)
+   - If it does not already exist, make sure to assign this to the result variable (`RESULT`)
+   - If there are commonly used combinations introduced by adding the heuristic, combine and justify them at the top of the static model (see `quickUndetailed` and `forceSetup` as current examples).  
+
 ### Confidence Score Motivation
 
 The original seven heuristics which started this work were Empty Project Link, Unreachable Project Links, One Release, High Release Frequency, Unchange Release, Closer Release Join Date, and Suspicious Setup. These heuristics (excluding those with a dependency) were run on 1167 packages from trusted organizations, with the following results:

--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -59,10 +59,10 @@ When contributing an analyzer, it must meet the following requirements:
 - The analyzer must be implemented in a separate file, placed in the relevant folder based on what it analyzes ([metadata](./pypi_heuristics/metadata/) or [sourcecode](./pypi_heuristics/sourcecode/)).
 - The analyzer must inherit from the `BaseHeuristicAnalyzer` class and implement the `analyze` function, returning relevant information specific to the analysis.
 - The analyzer name must be added to [heuristics.py](./pypi_heuristics/heuristics.py) file so it can be used for rule combinations in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py)
-- Update the `STATIC_PROBLOG_MODEL` in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py) with logical statements where the heuristic should be included. When adding new rules, please follow the following guidelines:
+- Update the `malware_rules_problog_model` in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py) with logical statements where the heuristic should be included. When adding new rules, please follow the following guidelines:
    - Provide a [confidence value](../slsa_analyzer/checks/check_result.py) using the `Confidence` enum.
    - Provide a name based on this confidence value (i.e. `high`, `medium`, or `low`)
-   - If it does not already exist, make sure to assign this to the result variable (`RESULT`)
+   - If it does not already exist, make sure to assign this to the result variable (`problog_result_access`)
    - If there are commonly used combinations introduced by adding the heuristic, combine and justify them at the top of the static model (see `quickUndetailed` and `forceSetup` as current examples).  
 
 ### Confidence Score Motivation

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -91,7 +91,7 @@ STATIC_PROBLOG_MODEL = f"""
 quickUndetailed :- not {Heuristics.EMPTY_PROJECT_LINK.value}, not {Heuristics.CLOSER_RELEASE_JOIN_DATE.value}.
 
 % Maintainer releases a suspicious setup.py and forces it to run by omitting a .whl file.
-forceSetup :- not {Heuristics.SUSPICIOUS_SETUP.value}, {Heuristics.WHEEL_ABSENCE.value}.
+forceSetup :- not {Heuristics.SUSPICIOUS_SETUP.value}, not {Heuristics.WHEEL_ABSENCE.value}.
 
 % Suspicious Combinations
 

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -216,7 +216,7 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         problog_model = PrologString(problog_code)
         problog_results: dict[Term, float] = get_evaluatable().create_from(problog_model).evaluate()
 
-        confidence = problog_results.get(Term(RESULT))
+        confidence: float | None = problog_results.get(Term(RESULT))
         if confidence == 0.0:
             return None  # no rules were triggered
         return confidence


### PR DESCRIPTION
Refactor the `SUSPICIOUS_COMBOS` dictionary to instead use a `problog` model. The purpose of this is to simplify the dictionary into logical statements, and allow for future development of probabilistic rules. This model transforms the `HeuristicResult` types as follows:

- `HeuristicResult.FAIL` results in `<name> :- false.`
- `HeuristicResult.PASS` results in `<name> :- true.`
- `HeuristicResult.SKIP` results in `0.0::<name>`, which means any rules which require this heuristic do not trigger.

To do:
- [x] Simplify logical statements into a readable, yet simpler form

Current issues with including `problog` that need to be resolved:
- [x] `problog` has no typing stubs. Currently it's just been ignored in `pyproject.toml`.
- This will be kept the same. Type hints are offered manually in the code where it was used in `detect_malicious_metadata_check.py`
- [x] `problog` currently causes the following warnings on tests:
```
=============================== warnings summary ===============================
.venv/lib/python3.11/site-packages/problog/setup.py:111
  /home/carl_flottmann/macaron/.venv/lib/python3.11/site-packages/problog/setup.py:111: DeprecationWarning: Use shutil.which instead of find_executable
    system_info["dsharp"] = distutils.spawn.find_executable("dsharp") is not None

.venv/lib/python3.11/site-packages/problog/setup.py:114
  /home/carl_flottmann/macaron/.venv/lib/python3.11/site-packages/problog/setup.py:114: DeprecationWarning: Use shutil.which instead of find_executable
    system_info["c2d"] = distutils.spawn.find_executable("cnf2dDNNF") is not None

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
- This was raised as an issue on ProbLog's GitHub [here](https://github.com/ML-KULeuven/problog/issues/126), and has now been resolved with [version 2.2.7](https://pypi.org/project/problog/2.2.7/).