### PR TITLE
chore(deps): update cyclonedx-python-lib and other required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # https://flit.pypa.io/en/latest/pyproject_toml.html
@@ -32,8 +32,8 @@ dependencies = [
     "packageurl-python >= 0.11.1,<1.0.0",
     "ruamel.yaml >= 0.18.6,<1.0.0",
     "jsonschema >= 4.22.0,<5.0.0",
-    "cyclonedx-bom >=4.0.0,<5.0.0",
-    "cyclonedx-python-lib[validation] >=7.3.4,<8.0.0",
+    "cyclonedx-bom >=5.3.0,<6.0.0",
+    "cyclonedx-python-lib[validation] >=8.0.0,<10.0.0",
     "beautifulsoup4 >= 4.12.0,<5.0.0",
 ]
 keywords = []
@@ -72,9 +72,8 @@ dev = [
     "types-pyyaml >=6.0.4,<7.0.0",
     "types-requests >=2.25.6,<3.0.0",
     "types-jsonschema >=4.22.0,<5.0.0",
-    "pip-audit >=2.5.6,<3.0.0",
+    "pip-audit >=2.8.0,<3.0.0",
     "pylint >=3.0.3,<4.0.0",
-    "cyclonedx-bom >=4.0.0,<5.0.0",
     "types-beautifulsoup4 >= 4.12.0,<5.0.0",
 ]
 docs = [


### PR DESCRIPTION
TODO:

- [ ] Address deprecation warnings: `DeprecationWarning: `@.tools` is deprecated from CycloneDX v1.5 onwards. Please use `@.components` and `@.services` instead.` 
- [ ] Update `cyclonedx-python-lib[validation]` to `>=9.0.0,<10.0.0` the when pip-audit releases a new version, which addresses the dependency conflicts.