### PR TITLE
chore: add config option to disable latest PURL retrieval

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -60,6 +60,7 @@ redirect_urls =
     gitbox.apache.org
     git-wip-us.apache.org
 find_source_should_clone = False
+try_latest_purl = True
 
 [repofinder.java]
 # The list of maven-like repositories to attempt to retrieve artifact POMs from.

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -59,7 +59,10 @@ use_open_source_insights = True
 redirect_urls =
     gitbox.apache.org
     git-wip-us.apache.org
+# If False, the find-source operation will use git ls-remote to find tags, instead of cloning repositories.
 find_source_should_clone = False
+# If True, the Repo Finder will try to find and use the latest version of a PURL when the provided version fails
+# to return a valid repository.
 try_latest_purl = True
 
 [repofinder.java]

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -103,6 +103,9 @@ def find_repo(purl: PackageURL, check_latest_version: bool = True) -> tuple[str,
     logger.debug("Analyzing %s with Repo Finder: %s", purl, type(repo_finder))
     found_repo, outcome = repo_finder.find_repo(purl)
 
+    if check_latest_version and not defaults.getboolean("repofinder", "try_latest_purl"):
+        check_latest_version = False
+
     if found_repo or not check_latest_version:
         return found_repo, outcome
 

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -103,7 +103,7 @@ def find_repo(purl: PackageURL, check_latest_version: bool = True) -> tuple[str,
     logger.debug("Analyzing %s with Repo Finder: %s", purl, type(repo_finder))
     found_repo, outcome = repo_finder.find_repo(purl)
 
-    if check_latest_version and not defaults.getboolean("repofinder", "try_latest_purl"):
+    if check_latest_version and not defaults.getboolean("repofinder", "try_latest_purl", fallback=True):
         check_latest_version = False
 
     if found_repo or not check_latest_version:

--- a/tests/integration/cases/apache_maven_sbom/config.ini
+++ b/tests/integration/cases/apache_maven_sbom/config.ini
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+[repofinder]
+try_latest_purl = False

--- a/tests/integration/cases/apache_maven_sbom/test.yaml
+++ b/tests/integration/cases/apache_maven_sbom/test.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
@@ -12,6 +12,7 @@ steps:
 - name: Run macaron analyze
   kind: analyze
   options:
+    ini: config.ini
     command_args:
     - -purl
     - pkg:maven/org.apache.maven/maven@4.0.0-alpha-1-SNAPSHOT?type=pom


### PR DESCRIPTION
This PR adds a configuration option to disable the latest PURL retrieval feature, and disables the feature in the `apache_maven_sbom` integration test so that the results of that test are static.

Closes #1010 