### PR TITLE
fix: use 'isDefault' version from deps dev api

### DIFF
--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -148,12 +148,14 @@ class DepsDevRepoFinder(BaseRepoFinder):
             return None, RepoFinderInfo.DDEV_JSON_INVALID
 
         latest_version = None
-        for index, version_result in enumerate(versions):
-            if version_result["isDefault"] or (index == (len(versions) - 1) and not latest_version):
+        for version_result in reversed(versions):
+            if version_result["isDefault"]:
+                # Accept the version as the latest if it is marked with the "isDefault" property.
                 latest_version = json_extract(version_result, ["versionKey", "version"], str)
                 break
 
         if not latest_version:
+            logger.debug("No latest version found in version list: %s", len(versions))
             return None, RepoFinderInfo.DDEV_JSON_INVALID
 
         namespace = purl.namespace + "/" if purl.namespace else ""

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -146,7 +146,13 @@ class DepsDevRepoFinder(BaseRepoFinder):
         versions = json_extract(metadata, versions_keys, list)
         if not versions:
             return None, RepoFinderInfo.DDEV_JSON_INVALID
-        latest_version = json_extract(versions[-1], ["versionKey", "version"], str)
+
+        latest_version = None
+        for index, version_result in enumerate(versions):
+            if version_result["isDefault"] or (index == (len(versions) - 1) and not latest_version):
+                latest_version = json_extract(version_result, ["versionKey", "version"], str)
+                break
+
         if not latest_version:
             return None, RepoFinderInfo.DDEV_JSON_INVALID
 

--- a/tests/integration/cases/google_guava_latest/policy.dl
+++ b/tests/integration/cases/google_guava_latest/policy.dl
@@ -4,7 +4,8 @@
 #include "prelude.dl"
 
 Policy("test_policy", component_id, "") :-
-    check_passed(component_id, "mcn_version_control_system_1").
+    check_passed(component_id, "mcn_version_control_system_1"),
+    is_repo_url(component_id, "https://github.com/google/guava").
 
 apply_policy_to("test_policy", component_id) :-
     is_component(component_id, "pkg:maven/com.google.guava/guava@14.0.1?type=jar").

--- a/tests/integration/cases/google_guava_latest/policy.dl
+++ b/tests/integration/cases/google_guava_latest/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_passed(component_id, "mcn_version_control_system_1").
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:maven/com.google.guava/guava@14.0.1?type=jar").

--- a/tests/integration/cases/google_guava_latest/test.yaml
+++ b/tests/integration/cases/google_guava_latest/test.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a PURL that requires fetching the latest version, and the ordering of its versions is atypical
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/com.google.guava/guava@14.0.1?type=jar
+- name: Run macaron verify-policy to verify passed/failed checks
+  kind: verify
+  options:
+    policy: policy.dl


### PR DESCRIPTION
When retrieving versions of artefacts from `deps.dev` API, one of the entries will have the `isDefault` property set to `True`. It is this version that is considered to be the latest version in the list, not the last entry as was previously assumed.

Closes #1018 