### PR TITLE
feat: add GitHub attestation discovery

### DIFF
--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -1,16 +1,21 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module declares types and utilities for handling local artifacts."""
 
 import fnmatch
 import glob
+import hashlib
+import logging
 import os
 
 from packageurl import PackageURL
 
 from macaron.artifact.maven import construct_maven_repository_path
 from macaron.errors import LocalArtifactFinderError
+from macaron.slsa_analyzer.package_registry import MavenCentralRegistry
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def construct_local_artifact_dirs_glob_pattern_maven_purl(maven_purl: PackageURL) -> list[str] | None:
@@ -247,3 +252,53 @@ def get_local_artifact_dirs(
         )
 
     raise LocalArtifactFinderError(f"Unsupported PURL type {purl_type}")
+
+
+def get_local_artifact_hash(purl: PackageURL, artifact_dirs: list[str], hash_algorithm_name: str) -> str | None:
+    """Compute the hash of the local artifact.
+
+    Parameters
+    ----------
+    purl: PackageURL
+        The PURL of the artifact being sought.
+    artifact_dirs: list[str]
+        The possible locations of the artifact.
+    hash_algorithm_name: str
+        The hash algorithm to use.
+
+    Returns
+    -------
+    str | None
+        The hash, or None if not found.
+    """
+    if not artifact_dirs:
+        logger.debug("No artifact directories provided.")
+        return None
+
+    if not purl.version:
+        logger.debug("PURL is missing version.")
+        return None
+
+    artifact_target = None
+    if purl.type == "maven":
+        artifact_target = MavenCentralRegistry.get_artifact_file_name(purl)
+
+    if not artifact_target:
+        logger.debug("PURL type not supported: %s", purl.type)
+        return None
+
+    for artifact_dir in artifact_dirs:
+        full_path = os.path.join(artifact_dir, artifact_target)
+        if not os.path.exists(full_path):
+            continue
+
+        with open(full_path, "rb") as file:
+            try:
+                hash_result = hashlib.file_digest(file, hash_algorithm_name)
+            except ValueError as error:
+                logger.debug("Error while hashing file: %s", error)
+                continue
+
+            return hash_result.hexdigest()
+
+    return None

--- a/src/macaron/artifact/local_artifact.py
+++ b/src/macaron/artifact/local_artifact.py
@@ -281,6 +281,8 @@ def get_local_artifact_hash(purl: PackageURL, artifact_dirs: list[str]) -> str |
         artifact_target = construct_primary_jar_file_name(purl)
 
     # TODO add support for other PURL types here.
+    # Other purl types can be easily supported if user provided artifacts are accepted from the command line.
+    # See https://github.com/oracle/macaron/issues/498.
 
     if not artifact_target:
         logger.debug("PURL type not supported: %s", purl.type)

--- a/src/macaron/artifact/maven.py
+++ b/src/macaron/artifact/maven.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module declares types and utilities for Maven artifacts."""
@@ -196,3 +196,22 @@ def construct_maven_repository_path(
     if asset_name:
         path = "/".join([path, asset_name])
     return path
+
+
+def construct_primary_jar_file_name(purl: PackageURL) -> str | None:
+    """Return the name of the primary JAR for the passed PURL based on the Maven registry standard.
+
+    Parameters
+    ----------
+    purl: PackageURL
+        The PURL of the artifact.
+
+    Returns
+    -------
+    str | None
+        The artifact file name, or None if invalid.
+    """
+    if not purl.version:
+        return None
+
+    return purl.name + "-" + purl.version + ".jar"

--- a/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/suspicious_setup.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/suspicious_setup.py
@@ -59,7 +59,7 @@ class SuspiciousSetupAnalyzer(BaseHeuristicAnalyzer):
                 response = requests.get(sourcecode_url, stream=True, timeout=40)
                 response.raise_for_status()
             except requests.exceptions.HTTPError as http_err:
-                logger.debug("HTTP error occurred: %s", http_err)
+                logger.debug("HTTP error occurred when trying to download source: %s", http_err)
                 return None
 
             if response.status_code != 200:

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -111,8 +111,6 @@ def find_repo(
     logger.debug("Analyzing %s with Repo Finder: %s", purl, type(repo_finder))
     found_repo, outcome = repo_finder.find_repo(purl)
 
-    print(package_registries_info)
-
     if not found_repo:
         found_repo, outcome = find_repo_alternative(purl, outcome, package_registries_info)
 

--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -111,6 +111,8 @@ def find_repo(
     logger.debug("Analyzing %s with Repo Finder: %s", purl, type(repo_finder))
     found_repo, outcome = repo_finder.find_repo(purl)
 
+    print(package_registries_info)
+
     if not found_repo:
         found_repo, outcome = find_repo_alternative(purl, outcome, package_registries_info)
 
@@ -166,7 +168,12 @@ def find_repo_alternative(
         found_repo, outcome = repo_finder_pypi.find_repo(purl, package_registries_info)
 
     if not found_repo:
-        logger.debug("Could not find repository using type specific (%s) methods for PURL: %s", purl.type, purl)
+        logger.debug(
+            "Could not find repository using type specific (%s) methods for PURL %s. Outcome: %s",
+            purl.type,
+            purl,
+            outcome,
+        )
 
     return found_repo, outcome
 

--- a/src/macaron/repo_finder/repo_finder_pypi.py
+++ b/src/macaron/repo_finder/repo_finder_pypi.py
@@ -58,7 +58,7 @@ def find_repo(
         pypi_registry = next((registry for registry in PACKAGE_REGISTRIES if isinstance(registry, PyPIRegistry)), None)
         if not pypi_registry:
             return "", RepoFinderInfo.PYPI_NO_REGISTRY
-        pypi_asset = PyPIPackageJsonAsset(purl.name, purl.version, False, pypi_registry, {})
+        pypi_asset = PyPIPackageJsonAsset(purl.name, purl.version, False, pypi_registry, {}, "")
 
     if not pypi_asset:
         # This should be unreachable, as the pypi_registry has already been confirmed to be of type PyPIRegistry.

--- a/src/macaron/repo_finder/repo_finder_pypi.py
+++ b/src/macaron/repo_finder/repo_finder_pypi.py
@@ -8,8 +8,8 @@ from packageurl import PackageURL
 
 from macaron.repo_finder.repo_finder_enums import RepoFinderInfo
 from macaron.repo_finder.repo_validator import find_valid_repository_url
-from macaron.slsa_analyzer.package_registry import PyPIRegistry
-from macaron.slsa_analyzer.package_registry.pypi_registry import find_or_create_pypi_asset
+from macaron.slsa_analyzer.package_registry import PACKAGE_REGISTRIES, PyPIRegistry
+from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset, find_or_create_pypi_asset
 from macaron.slsa_analyzer.specs.package_registry_spec import PackageRegistryInfo
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -44,14 +44,21 @@ def find_repo(
             ),
             None,
         )
-
-    if not pypi_info:
-        return "", RepoFinderInfo.PYPI_NO_REGISTRY
+        if not pypi_info:
+            return "", RepoFinderInfo.PYPI_NO_REGISTRY
 
     if not purl.version:
         return "", RepoFinderInfo.NO_VERSION_PROVIDED
 
-    pypi_asset = find_or_create_pypi_asset(purl.name, purl.version, pypi_info)
+    # Create the asset.
+    if pypi_info:
+        pypi_asset = find_or_create_pypi_asset(purl.name, purl.version, pypi_info)
+    else:
+        # If this function has been reached via find-source, we do not store the asset.
+        pypi_registry = next((registry for registry in PACKAGE_REGISTRIES if isinstance(registry, PyPIRegistry)), None)
+        if not pypi_registry:
+            return "", RepoFinderInfo.PYPI_NO_REGISTRY
+        pypi_asset = PyPIPackageJsonAsset(purl.name, purl.version, False, pypi_registry, {})
 
     if not pypi_asset:
         # This should be unreachable, as the pypi_registry has already been confirmed to be of type PyPIRegistry.

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -523,7 +523,7 @@ class Analyzer:
                 logger.debug("Failed to parse repository path as URL: %s", error)
             if url and url.hostname == "github.com":
                 artifact_hash = self.get_artifact_hash(
-                    parsed_purl, local_artifact_dirs, hashlib.sha256(), all_package_registries
+                    parsed_purl, local_artifact_dirs, hashlib.sha256(), package_registries_info
                 )
                 if artifact_hash:
                     git_attestation_dict = git_service.api_client.get_attestation(
@@ -1006,7 +1006,7 @@ class Analyzer:
         purl: PackageURL,
         cached_artifacts: list[str] | None,
         hash_algorithm: Any,
-        all_package_registries: list[PackageRegistryInfo],
+        package_registries_info: list[PackageRegistryInfo],
     ) -> str | None:
         """Get the hash of the artifact found from the passed PURL using local or remote files.
 
@@ -1018,7 +1018,7 @@ class Analyzer:
             The list of local files that match the PURL.
         hash_algorithm: Any
             The hash algorithm to use.
-        all_package_registries: list[PackageRegistryInfo]
+        package_registries_info: list[PackageRegistryInfo]
             The list of package registry information.
 
         Returns
@@ -1064,7 +1064,7 @@ class Analyzer:
             registry_info = next(
                 (
                     info
-                    for info in all_package_registries
+                    for info in package_registries_info
                     if info.package_registry == pypi_registry and info.build_tool_name in {"pip", "poetry"}
                 ),
                 None,

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -1081,6 +1081,10 @@ class Analyzer:
             if not pypi_asset.download(""):
                 return None
 
+            artifact_hash = pypi_asset.get_sha256()
+            if artifact_hash:
+                return artifact_hash
+
             source_url = pypi_asset.get_sourcecode_url("bdist_wheel")
             if not source_url:
                 return None

--- a/src/macaron/slsa_analyzer/checks/build_script_check.py
+++ b/src/macaron/slsa_analyzer/checks/build_script_check.py
@@ -27,10 +27,6 @@ class BuildScriptFacts(CheckFacts):
 
     __tablename__ = "_build_script_check"
 
-    # This check is disabled here due to a bug in pylint. The Mapped class triggers a false positive.
-    # It may arbitrarily become true that this is no longer needed in this check, or will be needed in another check.
-    # pylint: disable=unsubscriptable-object
-
     #: The primary key.
     id: Mapped[int] = mapped_column(ForeignKey("_check_facts.id"), primary_key=True)  # noqa: A003
 

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -286,12 +286,10 @@ class DetectMaliciousMetadataCheck(BaseCheck):
                     package_registry=PyPIRegistry(),
                 ) as pypi_registry_info:
                     # Retrieve the pre-existing asset, or create a new one.
-                    pypi_package_json = None
-                    if ctx.component.version:
-                        pypi_package_json = find_or_create_pypi_asset(
-                            ctx.component.name, ctx.component.version, pypi_registry_info
-                        )
-                    if pypi_package_json is None:
+                    pypi_package_json = find_or_create_pypi_asset(
+                        ctx.component.name, ctx.component.version, pypi_registry_info
+                    )
+                    if not pypi_package_json:
                         return CheckResultData(result_tables=[], result_type=CheckResultType.UNKNOWN)
 
                     pypi_package_json.has_repository = ctx.component.repository is not None

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -33,7 +33,6 @@ from macaron.slsa_analyzer.checks.base_check import BaseCheck
 from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResultType, Confidence, JustificationType
 from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 from macaron.slsa_analyzer.package_registry.osv_dev import OSVDevService
-from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset, PyPIRegistry
 from macaron.slsa_analyzer.package_registry.pypi_registry import (
     PyPIPackageJsonAsset,
     PyPIRegistry,

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -286,9 +286,11 @@ class DetectMaliciousMetadataCheck(BaseCheck):
                     package_registry=PyPIRegistry(),
                 ) as pypi_registry_info:
                     # Retrieve the pre-existing asset, or create a new one.
-                    pypi_package_json = find_or_create_pypi_asset(
-                        ctx.component.name, ctx.component.version, pypi_registry_info
-                    )
+                    pypi_package_json = None
+                    if ctx.component.version:
+                        pypi_package_json = find_or_create_pypi_asset(
+                            ctx.component.name, ctx.component.version, pypi_registry_info
+                        )
                     if pypi_package_json is None:
                         return CheckResultData(result_tables=[], result_type=CheckResultType.UNKNOWN)
 

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -34,6 +34,11 @@ from macaron.slsa_analyzer.checks.check_result import CheckResultData, CheckResu
 from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 from macaron.slsa_analyzer.package_registry.osv_dev import OSVDevService
 from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset, PyPIRegistry
+from macaron.slsa_analyzer.package_registry.pypi_registry import (
+    PyPIPackageJsonAsset,
+    PyPIRegistry,
+    find_or_create_pypi_asset,
+)
 from macaron.slsa_analyzer.registry import registry
 from macaron.slsa_analyzer.specs.package_registry_spec import PackageRegistryInfo
 
@@ -279,29 +284,16 @@ class DetectMaliciousMetadataCheck(BaseCheck):
                 case PackageRegistryInfo(
                     build_tool_name="pip" | "poetry",
                     build_tool_purl_type="pypi",
-                    package_registry=PyPIRegistry() as pypi_registry,
+                    package_registry=PyPIRegistry(),
                 ) as pypi_registry_info:
-                    # Retrieve the pre-existing AssetLocator object for the PyPI package JSON object, if it exists.
-                    pypi_package_json = next(
-                        (
-                            asset
-                            for asset in pypi_registry_info.metadata
-                            if isinstance(asset, PyPIPackageJsonAsset)
-                            and asset.component_name == ctx.component.name
-                            and asset.component_version == ctx.component.version
-                        ),
-                        None,
+                    # Retrieve the pre-existing asset, or create a new one.
+                    pypi_package_json = find_or_create_pypi_asset(
+                        ctx.component.name, ctx.component.version, pypi_registry_info
                     )
-                    if not pypi_package_json:
-                        # Create an AssetLocator object for the PyPI package JSON object.
-                        pypi_package_json = PyPIPackageJsonAsset(
-                            component_name=ctx.component.name,
-                            component_version=ctx.component.version,
-                            has_repository=ctx.component.repository is not None,
-                            pypi_registry=pypi_registry,
-                            package_json={},
-                            package_sourcecode_path="",
-                        )
+                    if pypi_package_json is None:
+                        return CheckResultData(result_tables=[], result_type=CheckResultType.UNKNOWN)
+
+                    pypi_package_json.has_repository = ctx.component.repository is not None
 
                     pypi_registry_info.metadata.append(pypi_package_json)
 

--- a/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_commit_check.py
@@ -22,10 +22,6 @@ class ProvenanceDerivedCommitFacts(CheckFacts):
 
     __tablename__ = "_provenance_derived_commit_check"
 
-    # This check is disabled here due to a bug in pylint. The Mapped class triggers a false positive.
-    # It may arbitrarily become true that this is no longer needed in this check, or will be needed in another check.
-    # pylint: disable=unsubscriptable-object
-
     #: The primary key.
     id: Mapped[int] = mapped_column(ForeignKey("_check_facts.id"), primary_key=True)  # noqa: A003
 

--- a/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
+++ b/src/macaron/slsa_analyzer/checks/provenance_repo_check.py
@@ -22,6 +22,10 @@ class ProvenanceDerivedRepoFacts(CheckFacts):
 
     __tablename__ = "_provenance_derived_repo_check"
 
+    # This check is disabled here due to a bug in pylint. The Mapped class triggers a false positive.
+    # It may arbitrarily become true that this is no longer needed in this check, or will be needed in another check.
+    # pylint: disable=unsubscriptable-object
+
     #: The primary key.
     id: Mapped[int] = mapped_column(ForeignKey("_check_facts.id"), primary_key=True)  # noqa: A003
 

--- a/src/macaron/slsa_analyzer/git_service/api_client.py
+++ b/src/macaron/slsa_analyzer/git_service/api_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The module provides API clients for VCS services, such as GitHub."""
@@ -658,6 +658,25 @@ class GhAPIClient(BaseAPIClient):
             return False
 
         return True
+
+    def get_attestation(self, full_name: str, artifact_hash: str) -> dict:
+        """Download and return the attestation associated with the passed artifact hash, if any.
+
+        Parameters
+        ----------
+        full_name : str
+            The full name of the repo.
+        artifact_hash: str
+            The SHA256 hash of an artifact.
+
+        Returns
+        -------
+        dict
+            The attestation data, or an empty dict if not found.
+        """
+        url = f"{GhAPIClient._REPO_END_POINT}/{full_name}/attestations/sha256:{artifact_hash}"
+        response_data = send_get_http(url, self.headers)
+        return response_data or {}
 
 
 def get_default_gh_client(access_token: str) -> GhAPIClient:

--- a/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
@@ -274,15 +274,15 @@ class MavenCentralRegistry(PackageRegistry):
         str | None
             The hash of the artifact, or None if not found.
         """
-        if not (purl.namespace and purl.version):
+        if not purl.namespace:
             return None
 
-        artifact_path = construct_maven_repository_path(purl.namespace, purl.name, purl.version)
         file_name = MavenCentralRegistry.get_artifact_file_name(purl)
-        if not file_name:
+        if not (purl.version and file_name):
             return None
 
         # Maven supports but does not require a sha256 hash of uploaded artifacts.
+        artifact_path = construct_maven_repository_path(purl.namespace, purl.name, purl.version)
         artifact_url = self.registry_url + "/" + artifact_path + "/" + file_name
         sha256_url = artifact_url + ".sha256"
         logger.debug("Search for artifact hash using URL: %s", [sha256_url, artifact_url])

--- a/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
@@ -282,8 +282,15 @@ class MavenCentralRegistry(PackageRegistry):
         if not file_name:
             return None
 
+        # Maven supports but does not require a sha256 hash of uploaded artifacts. Check that first.
         artifact_url = self.registry_url + "/" + artifact_path + "/" + file_name
-        logger.debug("Search for artifact using URL: %s", artifact_url)
+        sha256_url = artifact_url + ".sha256"
+        logger.debug("Search for artifact hash using URL: %s", [sha256_url, artifact_url])
+
+        response = send_get_http_raw(sha256_url, {})
+        if response and response.text:
+            logger.debug("Found hash of artifact: %s", response.text)
+            return response.text
 
         try:
             response = requests.get(artifact_url, stream=True, timeout=40)

--- a/src/macaron/slsa_analyzer/package_registry/package_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/package_registry.py
@@ -7,9 +7,9 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-from macaron.errors import InvalidHTTPResponseError
+from macaron.errors import APIAccessError, InvalidHTTPResponseError
 from macaron.json_tools import json_extract
-from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
+from macaron.slsa_analyzer.package_registry.deps_dev import DepsDevService
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -747,7 +747,7 @@ def find_or_create_pypi_asset(
     asset_version: str | None
         The version of the asset.
     pypi_registry_info:
-        The package registry information.
+        The package registry information. If a new asset is created, it will be added to the metadata of this registry.
 
     Returns
     -------

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -716,6 +716,26 @@ class PyPIPackageJsonAsset:
 
                 yield filepath, contents
 
+    def get_sha256(self) -> str | None:
+        """Get the sha256 hash of the artifact from its payload.
+
+        Returns
+        -------
+        str | None
+            The sha256 hash of the artifact, or None if not found.
+        """
+        if not self.package_json and not self.download(""):
+            return None
+
+        if not self.component_version:
+            artifact_hash = json_extract(self.package_json, ["urls", 0, "digests", "sha256"], str)
+        else:
+            artifact_hash = json_extract(
+                self.package_json, ["releases", self.component_version, "digests", "sha256"], str
+            )
+        logger.debug("Found sha256 hash: %s", artifact_hash)
+        return artifact_hash
+
 
 def find_or_create_pypi_asset(
     asset_name: str, asset_version: str | None, pypi_registry_info: PackageRegistryInfo

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -736,7 +736,7 @@ class PyPIPackageJsonAsset:
 
 
 def find_or_create_pypi_asset(
-    asset_name: str, asset_version: str, pypi_registry_info: PackageRegistryInfo
+    asset_name: str, asset_version: str | None, pypi_registry_info: PackageRegistryInfo
 ) -> PyPIPackageJsonAsset | None:
     """Find the matching asset in the provided package registry information, or if not found, create and add it.
 
@@ -744,7 +744,7 @@ def find_or_create_pypi_asset(
     ----------
     asset_name: str
         The name of the asset.
-    asset_version: str
+    asset_version: str | None
         The version of the asset.
     pypi_registry_info:
         The package registry information.

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -731,7 +731,7 @@ class PyPIPackageJsonAsset:
             artifact_hash = json_extract(self.package_json, ["urls", 0, "digests", "sha256"], str)
         else:
             artifact_hash = json_extract(
-                self.package_json, ["releases", self.component_version, "digests", "sha256"], str
+                self.package_json, ["releases", self.component_version, 0, "digests", "sha256"], str
             )
         logger.debug("Found sha256 hash: %s", artifact_hash)
         return artifact_hash

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -2,6 +2,8 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The module provides abstractions for the pypi package registry."""
+from __future__ import annotations
+
 import hashlib
 import logging
 import os
@@ -14,6 +16,7 @@ from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import requests
 from bs4 import BeautifulSoup, Tag
@@ -24,8 +27,10 @@ from macaron.errors import ConfigurationError, InvalidHTTPResponseError, SourceC
 from macaron.json_tools import json_extract
 from macaron.malware_analyzer.datetime_parser import parse_datetime
 from macaron.slsa_analyzer.package_registry.package_registry import PackageRegistry
-from macaron.slsa_analyzer.specs.package_registry_spec import PackageRegistryInfo
 from macaron.util import send_get_http_raw
+
+if TYPE_CHECKING:
+    from macaron.slsa_analyzer.specs.package_registry_spec import PackageRegistryInfo
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/src/macaron/slsa_analyzer/provenance/loader.py
+++ b/src/macaron/slsa_analyzer/provenance/loader.py
@@ -80,15 +80,33 @@ def _load_provenance_file_content(
         try:
             decompressed_file_content = gzip.decompress(file_content)
             decoded_file_content = decompressed_file_content.decode()
-            provenance = json.loads(decoded_file_content)
+            return decode_provenance(json.loads(decoded_file_content))
         except (gzip.BadGzipFile, EOFError, zlib.error):
             decoded_file_content = file_content.decode()
-            provenance = json.loads(decoded_file_content)
+            return decode_provenance(json.loads(decoded_file_content))
     except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as error:
         raise LoadIntotoAttestationError(
             "Cannot deserialize the file content as JSON.",
         ) from error
 
+
+def decode_provenance(provenance: dict) -> dict[str, JsonType]:
+    """Find and decode the provenance payload.
+
+    Parameters
+    ----------
+    provenance: dict
+        The contents of the provenance from which the payload will be decoded.
+
+    Returns
+    -------
+    The decoded payload.
+
+    Raises
+    ------
+    LoadIntotoAttestationError
+        If the payload could not be decoded.
+    """
     # The GitHub Attestation stores the DSSE envelope in `dsseEnvelope` property.
     dsse_envelope = provenance.get("dsseEnvelope", None)
     if dsse_envelope:

--- a/src/macaron/slsa_analyzer/provenance/loader.py
+++ b/src/macaron/slsa_analyzer/provenance/loader.py
@@ -102,6 +102,10 @@ def _load_provenance_file_content(
         # PyPI Attestation.
         provenance_payload = json_extract(provenance, ["envelope", "statement"], str)
     if not provenance_payload:
+        # GitHub Attestation.
+        # TODO Check if old method (above) actually works.
+        provenance_payload = json_extract(provenance, ["bundle", "dsseEnvelope", "payload"], str)
+    if not provenance_payload:
         raise LoadIntotoAttestationError(
             'Cannot find the "payload" field in the decoded provenance.',
         )

--- a/tests/artifact/test_local_artifact.py
+++ b/tests/artifact/test_local_artifact.py
@@ -15,7 +15,9 @@ from macaron.artifact.local_artifact import (
     construct_local_artifact_dirs_glob_pattern_pypi_purl,
     find_artifact_dirs_from_python_venv,
     get_local_artifact_dirs,
+    get_local_artifact_hash,
 )
+from macaron.artifact.maven import construct_primary_jar_file_name
 from macaron.errors import LocalArtifactFinderError
 
 
@@ -249,3 +251,21 @@ def test_get_local_artifact_paths_succeeded_pypi(tmp_path: Path) -> None:
     )
 
     assert sorted(result) == sorted(pypi_artifact_paths)
+
+
+def test_get_local_artifact_hash() -> None:
+    """Test the get local artifact hash function."""
+    artifact_purl = PackageURL.from_string("pkg:maven/test/test@1")
+    artifact_jar_name = construct_primary_jar_file_name(artifact_purl)
+
+    assert artifact_jar_name
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        artifact_path = os.path.join(temp_dir, artifact_jar_name)
+        with open(artifact_path, "w", encoding="utf8") as file:
+            file.write("1")
+
+        # A file containing: "1".
+        target_hash = "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+
+        assert target_hash == get_local_artifact_hash(artifact_purl, [temp_dir])

--- a/tests/artifact/test_maven.py
+++ b/tests/artifact/test_maven.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for types and utilities for Maven artifacts."""
@@ -6,7 +6,11 @@
 import pytest
 from packageurl import PackageURL
 
-from macaron.artifact.maven import MavenSubjectPURLMatcher, construct_maven_repository_path
+from macaron.artifact.maven import (
+    MavenSubjectPURLMatcher,
+    construct_maven_repository_path,
+    construct_primary_jar_file_name,
+)
 from macaron.slsa_analyzer.provenance.intoto import InTotoPayload, validate_intoto_payload
 
 
@@ -161,3 +165,10 @@ def test_to_group_folder_path(
 ) -> None:
     """Test the ``to_gorup_folder_path`` method."""
     assert construct_maven_repository_path(group_id) == expected_group_path
+
+
+def test_construct_primary_jar_file_name() -> None:
+    """Test the artifact file name function."""
+    assert not construct_primary_jar_file_name(PackageURL.from_string("pkg:maven/test/example"))
+
+    assert construct_primary_jar_file_name(PackageURL.from_string("pkg:maven/text/example@1")) == "example-1.jar"

--- a/tests/integration/cases/github_maven_attestation/policy.dl
+++ b/tests/integration/cases/github_maven_attestation/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_passed(component_id, "mcn_provenance_available_1").
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:maven/io.liftwizard/liftwizard-checkstyle@2.1.22").

--- a/tests/integration/cases/github_maven_attestation/test.yaml
+++ b/tests/integration/cases/github_maven_attestation/test.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Discovering attestation of a Maven artifact on GitHub
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.liftwizard/liftwizard-checkstyle@2.1.22
+    - -rp
+    - https://github.com/liftwizard/liftwizard
+- name: Run macaron verify-policy to verify passed/failed checks
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/integration/cases/github_maven_attestation_local/policy.dl
+++ b/tests/integration/cases/github_maven_attestation_local/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_failed(component_id, "mcn_provenance_available_1").
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:maven/io.liftwizard/liftwizard-checkstyle@2.1.22").

--- a/tests/integration/cases/github_maven_attestation_local/test.yaml
+++ b/tests/integration/cases/github_maven_attestation_local/test.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Discovering GitHub attestation of a local Maven artifact but failing because the artifact is wrong
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Download artifact POM instead of the JAR
+  kind: shell
+  options:
+    cmd: curl --create-dirs -o ./output/.m2/repository/io/liftwizard/liftwizard-checkstyle/2.1.22/liftwizard-checkstyle-2.1.22.jar https://repo1.maven.org/maven2/io/liftwizard/liftwizard-checkstyle/2.1.22/liftwizard-checkstyle-2.1.22.pom
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:maven/io.liftwizard/liftwizard-checkstyle@2.1.22
+    - -rp
+    - https://github.com/liftwizard/liftwizard
+    - --local-maven-repo
+    - ./output/.m2
+- name: Run macaron verify-policy to verify no provenance was found
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/integration/cases/github_maven_attestation_local/test.yaml
+++ b/tests/integration/cases/github_maven_attestation_local/test.yaml
@@ -2,10 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
-  Discovering GitHub attestation of a local Maven artifact but failing because the artifact is wrong
+  Discovering GitHub attestation of a local Maven artifact but failing because the artifact is wrong. In this case
+  we download the artifact's POM file and save it as a JAR file.
 
 tags:
 - macaron-python-package
+- macaron-docker-image
 
 steps:
 - name: Download artifact POM instead of the JAR

--- a/tests/integration/cases/github_pypi_attestation/policy.dl
+++ b/tests/integration/cases/github_pypi_attestation/policy.dl
@@ -7,4 +7,4 @@ Policy("test_policy", component_id, "") :-
     check_passed(component_id, "mcn_provenance_available_1").
 
 apply_policy_to("test_policy", component_id) :-
-    is_component(component_id, "pkg:pypi/toga@0.5.0").
+    is_component(component_id, "pkg:pypi/toga@0.4.8").

--- a/tests/integration/cases/github_pypi_attestation/policy.dl
+++ b/tests/integration/cases/github_pypi_attestation/policy.dl
@@ -1,0 +1,10 @@
+/* Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_passed(component_id, "mcn_provenance_available_1").
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:pypi/toga@0.5.0").

--- a/tests/integration/cases/github_pypi_attestation/test.yaml
+++ b/tests/integration/cases/github_pypi_attestation/test.yaml
@@ -13,7 +13,7 @@ steps:
   options:
     command_args:
     - -purl
-    - pkg:pypi/toga@0.5.0
+    - pkg:pypi/toga@0.4.8
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:

--- a/tests/integration/cases/github_pypi_attestation/test.yaml
+++ b/tests/integration/cases/github_pypi_attestation/test.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Discovering attestation of a PyPI artifact on GitHub
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/toga@0.5.0
+- name: Run macaron verify-policy to verify passed/failed checks
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/slsa_analyzer/package_registry/test_maven_central_registry.py
+++ b/tests/slsa_analyzer/package_registry/test_maven_central_registry.py
@@ -7,11 +7,14 @@ import json
 import os
 import urllib.parse
 from datetime import datetime
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
+from packageurl import PackageURL
 from pytest_httpserver import HTTPServer
 
+from macaron.artifact.maven import construct_maven_repository_path
 from macaron.config.defaults import load_defaults
 from macaron.errors import ConfigurationError, InvalidHTTPResponseError
 from macaron.slsa_analyzer.package_registry.maven_central_registry import MavenCentralRegistry
@@ -33,6 +36,28 @@ def maven_central_instance() -> MavenCentralRegistry:
         registry_url_netloc="repo1.maven.org/maven2",
         registry_url_scheme="https",
     )
+
+
+@pytest.fixture(name="maven_service")
+def maven_service_(httpserver: HTTPServer, tmp_path: Path) -> None:
+    """Set up the Maven httpserver."""
+    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
+
+    user_config_input = f"""
+    [package_registry.maven_central]
+    request_timeout = 20
+    search_netloc = {base_url_parsed.netloc}
+    search_scheme = {base_url_parsed.scheme}
+    registry_url_netloc = {base_url_parsed.netloc}
+    registry_url_scheme = {base_url_parsed.scheme}
+    """
+    user_config_path = os.path.join(tmp_path, "config.ini")
+    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
+        user_config_file.write(user_config_input)
+    # We don't have to worry about modifying the ``defaults`` object causing test
+    # pollution here, since we reload the ``defaults`` object before every test with the
+    # ``setup_test`` fixture.
+    load_defaults(user_config_path)
 
 
 def test_load_defaults(tmp_path: Path) -> None:
@@ -150,31 +175,14 @@ def test_is_detected(
 def test_find_publish_timestamp(
     resources_path: Path,
     httpserver: HTTPServer,
-    tmp_path: Path,
+    maven_service: dict,  # pylint: disable=unused-argument
     purl: str,
     mc_json_path: str,
     query_string: str,
     expected_timestamp: str,
 ) -> None:
     """Test that the function finds the timestamp correctly."""
-    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
-
     maven_central = MavenCentralRegistry()
-
-    # Set up responses of solrsearch endpoints using the httpserver plugin.
-    user_config_input = f"""
-    [package_registry.maven_central]
-    request_timeout = 20
-    search_netloc = {base_url_parsed.netloc}
-    search_scheme = {base_url_parsed.scheme}
-    """
-    user_config_path = os.path.join(tmp_path, "config.ini")
-    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
-        user_config_file.write(user_config_input)
-    # We don't have to worry about modifying the ``defaults`` object causing test
-    # pollution here, since we reload the ``defaults`` object before every test with the
-    # ``setup_test`` fixture.
-    load_defaults(user_config_path)
     maven_central.load_defaults()
 
     with open(os.path.join(resources_path, "maven_central_files", mc_json_path), encoding="utf8") as page:
@@ -208,35 +216,19 @@ def test_find_publish_timestamp(
 def test_find_publish_timestamp_errors(
     resources_path: Path,
     httpserver: HTTPServer,
-    tmp_path: Path,
+    maven_service: dict,  # pylint: disable=unused-argument
     purl: str,
     mc_json_path: str,
     expected_msg: str,
 ) -> None:
     """Test that the function handles errors correctly."""
-    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
-
     maven_central = MavenCentralRegistry()
-
-    # Set up responses of solrsearch endpoints using the httpserver plugin.
-    user_config_input = f"""
-    [package_registry.maven_central]
-    request_timeout = 20
-    search_netloc = {base_url_parsed.netloc}
-    search_scheme = {base_url_parsed.scheme}
-    """
-    user_config_path = os.path.join(tmp_path, "config.ini")
-    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
-        user_config_file.write(user_config_input)
-    # We don't have to worry about modifying the ``defaults`` object causing test
-    # pollution here, since we reload the ``defaults`` object before every test with the
-    # ``setup_test`` fixture.
-    load_defaults(user_config_path)
     maven_central.load_defaults()
 
     with open(os.path.join(resources_path, "maven_central_files", mc_json_path), encoding="utf8") as page:
         mc_json_response = json.load(page)
 
+    # Set up responses of solrsearch endpoints using the httpserver plugin.
     httpserver.expect_request(
         "/solrsearch/select",
         query_string="q=g:org.apache.logging.log4j+AND+a:log4j-core+AND+v:3.0.0-beta2&core=gav&rows=1&wt=json",
@@ -245,3 +237,67 @@ def test_find_publish_timestamp_errors(
     pat = f"^{expected_msg}"
     with pytest.raises(InvalidHTTPResponseError, match=pat):
         maven_central.find_publish_timestamp(purl=purl)
+
+
+def test_get_artifact_file_name() -> None:
+    """Test the artifact file name function."""
+    assert not MavenCentralRegistry().get_artifact_file_name(PackageURL.from_string("pkg:maven/test/example"))
+
+    assert (
+        MavenCentralRegistry().get_artifact_file_name(PackageURL.from_string("pkg:maven/text/example@1"))
+        == "example-1.jar"
+    )
+
+
+@pytest.mark.parametrize("purl_string", ["pkg:maven/example", "pkg:maven/example/test", "pkg:maven/example/test@1"])
+def test_get_artifact_hash_failures(
+    httpserver: HTTPServer, maven_service: dict, purl_string: str  # pylint: disable=unused-argument
+) -> None:
+    """Test failures of get artifact hash."""
+    purl = PackageURL.from_string(purl_string)
+
+    maven_registry = MavenCentralRegistry()
+    maven_registry.load_defaults()
+
+    if (
+        purl.namespace
+        and purl.version
+        and (file_name := MavenCentralRegistry().get_artifact_file_name(purl))
+        and file_name
+    ):
+        artifact_path = "/" + construct_maven_repository_path(purl.namespace, purl.name, purl.version) + "/" + file_name
+        hash_algorithm = sha256()
+        hash_algorithm.update(b"example_data")
+        expected_hash = hash_algorithm.hexdigest()
+        httpserver.expect_request(artifact_path + ".sha256").respond_with_data(expected_hash)
+        httpserver.expect_request(artifact_path).respond_with_data(b"example_data_2")
+
+    result = maven_registry.get_artifact_hash(purl, sha256())
+
+    assert not result
+
+
+def test_get_artifact_hash_success(
+    httpserver: HTTPServer, maven_service: dict  # pylint: disable=unused-argument
+) -> None:
+    """Test success of get artifact hash."""
+    purl = PackageURL.from_string("pkg:maven/example/test@1")
+    assert purl.namespace
+    assert purl.version
+
+    maven_registry = MavenCentralRegistry()
+    maven_registry.load_defaults()
+
+    file_name = MavenCentralRegistry().get_artifact_file_name(purl)
+    assert file_name
+
+    artifact_path = "/" + construct_maven_repository_path(purl.namespace, purl.name, purl.version) + "/" + file_name
+    hash_algorithm = sha256()
+    hash_algorithm.update(b"example_data")
+    expected_hash = hash_algorithm.hexdigest()
+    httpserver.expect_request(artifact_path + ".sha256").respond_with_data(expected_hash)
+    httpserver.expect_request(artifact_path).respond_with_data(b"example_data")
+
+    result = maven_registry.get_artifact_hash(purl, sha256())
+
+    assert result


### PR DESCRIPTION
This PR adds support for GitHub attestation discovery. To access GitHub attestations, the SHA256 hash of the repositories artefacts must be generated and submitted via the API. Artefacts may be found in local caches, or downloaded from remote repositories.

- [x] Support for Maven artefacts
- [x] Support for PyPI artefacts

Closes #915 