### PR TITLE
refactor: log relative paths for file

### DIFF
--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This is the main entrypoint to run Macaron."""
@@ -537,9 +537,9 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(os.EX_USAGE)
 
     if os.path.isdir(args.output_dir):
-        logger.info("Setting the output directory to %s", args.output_dir)
+        logger.info("Setting the output directory to %s", os.path.relpath(args.output_dir, os.getcwd()))
     else:
-        logger.info("No directory at %s. Creating one ...", args.output_dir)
+        logger.info("No directory at %s. Creating one ...", os.path.relpath(args.output_dir, os.getcwd()))
         os.makedirs(args.output_dir)
 
     # Add file handler to the root logger. Remove stream handler from the

--- a/src/macaron/repo_finder/repo_utils.py
+++ b/src/macaron/repo_finder/repo_utils.py
@@ -75,7 +75,7 @@ def generate_report(purl: str, commit: str, repo: str, target_dir: str) -> bool:
     fullpath = f"{target_dir}/{filename}"
 
     os.makedirs(os.path.dirname(fullpath), exist_ok=True)
-    logger.info("Writing report to: %s", fullpath)
+    logger.info("Writing report to: %s", os.path.relpath(fullpath, os.getcwd()))
 
     try:
         with open(fullpath, "w", encoding="utf-8") as file:
@@ -84,7 +84,7 @@ def generate_report(purl: str, commit: str, repo: str, target_dir: str) -> bool:
         logger.debug("Failed to write report to file: %s", error)
         return False
 
-    logger.info("Report written to: %s", fullpath)
+    logger.info("Report written to: %s", os.path.relpath(fullpath, os.getcwd()))
 
     return True
 


### PR DESCRIPTION
The paths currently logged in the STDOUT are absolute. For example, if you run `./run_macaron.sh find-source -purl pkg:maven/fr.inria.gforge.spoon/spoon-core@11.2.0`, it logs the paths where the results are written to:
```
2025-03-26 14:22:07,335 [INFO] Setting the output directory to /home/macaron/output
2025-03-26 14:22:07,336 [INFO] The logs will be stored in debug.log
2025-03-26 14:22:07,877 [INFO] Found repository for PURL: https://github.com/INRIA/spoon
2025-03-26 14:22:07,877 [INFO] Found commit for PURL: 48659c68e53e742c562380281b90bdb76239691e
2025-03-26 14:22:07,878 [INFO] Writing report to: /home/macaron/output/reports/maven/fr_inria_gforge_spoon/spoon-core/spoon-core.source.json
2025-03-26 14:22:07,878 [INFO] Report written to: /home/macaron/output/reports/maven/fr_inria_gforge_spoon/spoon-core/spoon-core.source.json
```

However, these absolute paths exist only inside the docker container that `run_macaron` spawns and not on the host machine. To get valid paths for container and host machine, it is better to output relative paths which means stripping `/home/macaron` from it. Thus, I wrap paths in some places with `os.path.relpath(path, os.getcwd())`. I assume that `WORKDIR` inside docker is set to [`MACARON_WORKSPACE`](https://github.com/oracle/macaron/blob/4d1d8ee5db65264f5f31cb9e07fb81a4b5c8cef8/scripts/release_scripts/run_macaron.sh#L57). I have only tested my changes against the local build only.

Note that this is not much of an issue if someone runs `macaron` without using the container.