### PR TITLE
fix: fix incorrect skip result evaluation causing false positives in PyPI malware reporting"

### DIFF
--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -61,8 +61,9 @@ When contributing an analyzer, it must meet the following requirements:
 - The analyzer name must be added to [heuristics.py](./pypi_heuristics/heuristics.py) file so it can be used for rule combinations in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py)
 - Update the `malware_rules_problog_model` in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py) with logical statements where the heuristic should be included. When adding new rules, please follow the following guidelines:
    - Provide a [confidence value](../slsa_analyzer/checks/check_result.py) using the `Confidence` enum.
-   - Provide a name based on this confidence value (i.e. `high`, `medium`, or `low`)
-   - If it does not already exist, make sure to assign this to the result variable (`problog_result_access`)
+   - Ensure it is assigned to the "result" string name, otherwise it will not be queried and evaluated.
+   - Assign a string rule ID to the rule. This will be used to backtrack to determine if it was triggered.
+   - Make sure to wrap pass/fail statements in `passed()` and `failed()`. Not doing so may result in undesirable behaviour, see the comments in the model for more details.
    - If there are commonly used combinations introduced by adding the heuristic, combine and justify them at the top of the static model (see `quickUndetailed` and `forceSetup` as current examples).  
 
 ### Confidence Score Motivation

--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -61,8 +61,8 @@ When contributing an analyzer, it must meet the following requirements:
 - The analyzer name must be added to [heuristics.py](./pypi_heuristics/heuristics.py) file so it can be used for rule combinations in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py)
 - Update the `malware_rules_problog_model` in [detect_malicious_metadata_check.py](../slsa_analyzer/checks/detect_malicious_metadata_check.py) with logical statements where the heuristic should be included. When adding new rules, please follow the following guidelines:
    - Provide a [confidence value](../slsa_analyzer/checks/check_result.py) using the `Confidence` enum.
-   - Ensure it is assigned to the "result" string name, otherwise it will not be queried and evaluated.
-   - Assign a string rule ID to the rule. This will be used to backtrack to determine if it was triggered.
+   - Ensure it is assigned to the `problog_result_access` string variable, otherwise it will not be queried and evaluated.
+   - Assign a rule ID to the rule. This will be used to backtrack to determine if it was triggered.
    - Make sure to wrap pass/fail statements in `passed()` and `failed()`. Not doing so may result in undesirable behaviour, see the comments in the model for more details.
    - If there are commonly used combinations introduced by adding the heuristic, combine and justify them at the top of the static model (see `quickUndetailed` and `forceSetup` as current examples).  
 

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -336,9 +336,7 @@ class DetectMaliciousMetadataCheck(BaseCheck):
     % ----- Heuristic groupings -----
     % These are common combinations of heuristics that are used in many of the rules, thus themselves representing
     % certain behaviors. When changing or adding rules here, if there are frequent combinations of particular
-    % heuristics, group them together here. Note, these should only be used to check if a grouping statement
-    % is true. Evaluating 'not quickUndetailed' would be true if empty project link and closer release join
-    % date passed, or if they were both skipped, which is not desired behaviour.
+    % heuristics, group them together here.
 
     % Maintainer has recently joined, publishing an undetailed page with no links.
     quickUndetailed :- failed({Heuristics.EMPTY_PROJECT_LINK.value}), failed({Heuristics.CLOSER_RELEASE_JOIN_DATE.value}).

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -140,9 +140,9 @@ class DetectMaliciousMetadataCheck(BaseCheck):
 
         Returns
         -------
-        tuple[float, list[str]]
+        tuple[float, JsonType]
             Returns the confidence associated with the detected malicious combination, and associated rule IDs detailing
-            what rules were triggered.
+            what rules were triggered and their confidence as a dict[str, float] type.
         """
         facts_list: list[str] = []
         triggered_rules: dict[str, JsonType] = {}
@@ -328,6 +328,7 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         AnomalousVersionAnalyzer,
     ]
 
+    # name used to query the result of all problog rules, so it can be accessed outside the model.
     problog_result_access = "result"
 
     malware_rules_problog_model = f"""

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -347,14 +347,14 @@ class DetectMaliciousMetadataCheck(BaseCheck):
     % ----- Suspicious Combinations -----
 
     % Package released recently with little detail, forcing the setup.py to run.
-    {Confidence.HIGH.value}::result("high_confidence_1") :-
+    {Confidence.HIGH.value}::result("malware_high_confidence_1") :-
         quickUndetailed, forceSetup, failed({Heuristics.ONE_RELEASE.value}).
-    {Confidence.HIGH.value}::result("high_confidence_2") :-
+    {Confidence.HIGH.value}::result("malware_high_confidence_2") :-
         quickUndetailed, forceSetup, failed({Heuristics.HIGH_RELEASE_FREQUENCY.value}).
 
     % Package released recently with little detail, with some more refined trust markers introduced: project links,
     % multiple different releases, but there is no source code repository matching it and the setup is suspicious.
-    {Confidence.HIGH.value}::result("high_confidence_3") :-
+    {Confidence.HIGH.value}::result("malware_high_confidence_3") :-
         failed({Heuristics.SOURCE_CODE_REPO.value}),
         failed({Heuristics.HIGH_RELEASE_FREQUENCY.value}),
         passed({Heuristics.UNCHANGED_RELEASE.value}),
@@ -363,14 +363,14 @@ class DetectMaliciousMetadataCheck(BaseCheck):
 
     % Package released recently with little detail, with multiple releases as a trust marker, but frequent and with
     % the same code.
-    {Confidence.MEDIUM.value}::result("medium_confidence_1") :-
+    {Confidence.MEDIUM.value}::result("malware_medium_confidence_1") :-
         quickUndetailed,
         failed({Heuristics.HIGH_RELEASE_FREQUENCY.value}),
         failed({Heuristics.UNCHANGED_RELEASE.value}),
         passed({Heuristics.SUSPICIOUS_SETUP.value}).
 
     % Package released recently with little detail and an anomalous version number for a single-release package.
-    {Confidence.MEDIUM.value}::result("medium_confidence_2") :-
+    {Confidence.MEDIUM.value}::result("malware_medium_confidence_2") :-
         quickUndetailed,
         failed({Heuristics.ONE_RELEASE.value}),
         passed({Heuristics.WHEEL_ABSENCE.value}),

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -150,6 +150,9 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         # in the problog model. Multiplying these probabilities together on several triggers will further decrease the probability
         # of the package being benign. This is then negated after calculation to get the probability of the package being malicious.
         # If no rules are triggered, this will simply result in 1.0 - 1.0 = 0.0.
+        # For example, if a LOW rule and MEDIUM rule are triggered, with confidences 0.4 and 0.7 respectively, this would result in
+        # the following calculation for confidence in package maliciousness:
+        # 1 - (1.0 * (1 - 0.4) * (1 - 0.7)) = 0.82
         confidence: float = 1.0
 
         for heuristic, result in heuristic_results.items():

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -386,7 +386,6 @@ class DetectMaliciousMetadataCheck(BaseCheck):
     {Confidence.MEDIUM.value}::trigger(malware_medium_confidence_2) :-
         quickUndetailed,
         failed({Heuristics.ONE_RELEASE.value}),
-        passed({Heuristics.WHEEL_ABSENCE.value}),
         failed({Heuristics.ANOMALOUS_VERSION.value}).
 
     % ----- Evaluation -----

--- a/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
+++ b/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
@@ -106,7 +106,7 @@ def test_detect_malicious_metadata(
     [
         pytest.param(
             {
-                # similar to rule ID high_confidence_1, but SUSPICIOUS_SETUP is skipped since the file does not exist,
+                # similar to rule ID malware_high_confidence_1, but SUSPICIOUS_SETUP is skipped since the file does not exist,
                 # so the rule should not trigger.
                 Heuristics.EMPTY_PROJECT_LINK: HeuristicResult.FAIL,
                 Heuristics.SOURCE_CODE_REPO: HeuristicResult.SKIP,

--- a/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
+++ b/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
@@ -126,6 +126,7 @@ def test_evaluations(combination: dict[Heuristics, HeuristicResult]) -> None:
     """Test heuristic combinations to ensure they evaluate as expected."""
     check = DetectMaliciousMetadataCheck()
 
-    confidence, _ = check.evaluate_heuristic_results(combination)
-
+    confidence, triggered_rules = check.evaluate_heuristic_results(combination)
     assert confidence == 0
+    # Expecting this to be a dictionary, so we can ignore the type problems
+    assert len(dict(triggered_rules)) == 0  # type: ignore[arg-type]


### PR DESCRIPTION
Addressing issue identified in #1027, where skips were being evaluated as false. This PR introduces wrappers `passed()` and `failed()` into the ProbLog model that use `try_call()` statements. Skipped heuristics are no longer defined in the ProbLog model, which is why this `try_call()` statement is used. This means that evaluating `failed(heuristic)` will be false if the heuristic passed, or if it was not defined (i.e. was skipped). Similarly, for evaluating `passed()`, this will be false if the heuristic failed, or if it was not defined. This should handle situations where skips should not cause rules they are part of to trigger. This method was the easiest way to keep as much of the ProbLog model in a static string as possible, without having to perform extensive string operations.

Rule IDs have also been added for debugging purposes, and a method to extract them, so that it is evident what rule was triggered. 