### PR TITLE
test(ci): update log4j-core@3.0.0-beta2 to log4j-core@3.0.0-beta3

### DIFF
--- a/docs/source/pages/tutorials/detect_malicious_java_dep.rst
+++ b/docs/source/pages/tutorials/detect_malicious_java_dep.rst
@@ -25,7 +25,7 @@ dependencies:
    * - Artifact name
      - `Package URL (PURL) <https://github.com/package-url/purl-spec>`_
    * - `log4j-core <https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-core>`_
-     - ``pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta2?type=jar``
+     - ``pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3?type=jar``
    * - `jackson-databind <https://central.sonatype.com/artifact/io.github.behnazh-w.demo/jackson-databind>`_
      - ``pkg:maven/io.github.behnazh-w.demo/jackson-databind@1.0?type=jar``
 
@@ -110,20 +110,20 @@ As you scroll down in the HTML report, you will see a section for the dependenci
 | Macaron has found the two dependencies as expected:
 
 * ``io.github.behnazh-w.demo:jackson-databind:1.0``
-* ``org.apache.logging.log4j:log4j-core:3.0.0-beta2``
+* ``org.apache.logging.log4j:log4j-core:3.0.0-beta3``
 
-When we open the reports for each dependency, we see that ``mcn_find_artifact_pipeline_1`` is passed for ``org.apache.logging.log4j:log4j-core:3.0.0-beta2``
-and a GitHub Actions workflow run is found for publishing version ``3.0.0-beta2``. However, this check is failing for ``io.github.behnazh-w.demo:jackson-databind:1.0``.
+When we open the reports for each dependency, we see that ``mcn_find_artifact_pipeline_1`` is passed for ``org.apache.logging.log4j:log4j-core:3.0.0-beta3``
+and a GitHub Actions workflow run is found for publishing version ``3.0.0-beta3``. However, this check is failing for ``io.github.behnazh-w.demo:jackson-databind:1.0``.
 This means that ``io.github.behnazh-w.demo:jackson-databind:1.0`` could have been built and published manually to Maven Central
 and could potentially be malicious.
 
 .. _fig_find_artifact_pipeline_log4j:
 
 .. figure:: ../../_static/images/tutorial_log4j_find_pipeline.png
-   :alt: mcn_find_artifact_pipeline_1 for org.apache.logging.log4j:log4j-core:3.0.0-beta2
+   :alt: mcn_find_artifact_pipeline_1 for org.apache.logging.log4j:log4j-core:3.0.0-beta3
    :align: center
 
-   ``org.apache.logging.log4j:log4j-core:3.0.0-beta2``
+   ``org.apache.logging.log4j:log4j-core:3.0.0-beta3``
 
 .. _fig_infer_artifact_pipeline_bh_jackson_databind:
 

--- a/tests/integration/cases/log4j_release_pipeline/policy.dl
+++ b/tests/integration/cases/log4j_release_pipeline/policy.dl
@@ -19,4 +19,4 @@ Policy("test_policy", component_id, "") :-
     is_repo_url(component_id, "https://github.com/apache/logging-log4j2").
 
 apply_policy_to("test_policy", component_id) :-
-    is_component(component_id, "pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta2").
+    is_component(component_id, "pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3").

--- a/tests/integration/cases/log4j_release_pipeline/test.yaml
+++ b/tests/integration/cases/log4j_release_pipeline/test.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
@@ -14,7 +14,7 @@ steps:
   options:
     command_args:
     - -purl
-    - pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta2
+    - pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:


### PR DESCRIPTION
This PR changes the version of `org.apache.logging.log4j:log4j-core` to a newer version, as the GitHUb pipeline for the older version is removed.