### PR TITLE
chore: check for None type in error output

### DIFF
--- a/src/macaron/provenance/provenance_verifier.py
+++ b/src/macaron/provenance/provenance_verifier.py
@@ -334,7 +334,10 @@ def _verify_slsa(
 
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
         logger.error(error)
-        errors.append(error.output.decode("utf-8"))
+        if error.output:
+            errors.append(error.output.decode("utf-8"))
+        else:
+            errors.append(f"Verification failed: {type(error)}")
     except OSError as error:
         logger.error(error)
         errors.append(str(error))


### PR DESCRIPTION
## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
- [x] I have referenced the issue(s) this pull request solves.

This PR fixes a bug where error output can be None during provenance verification. In these cases, a simple textual output is produced instead using the type of error encountered.

Closes #1045 
