### PR TITLE
chore: disable latest purl finding for test

### DIFF
--- a/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/config.ini
+++ b/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/config.ini
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+[repofinder]
+try_latest_purl = False

--- a/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/test.yaml
+++ b/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/test.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
@@ -15,6 +15,7 @@ steps:
 - name: Run macaron analyze
   kind: analyze
   options:
+    ini: config.ini
     main_args:
     - -lr
     - ./output/git_repos/local_repos

--- a/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/test.yaml
+++ b/tests/integration/cases/apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven/test.yaml
@@ -3,6 +3,8 @@
 
 description: |
   Analyzing local clone with the branch name, the commit digest and dependency resolution using cyclonedx maven plugin (default).
+  To keep the results from the main target's dependencies static, the Repo Finder's latest PURL finding feature is disabled for this test.
+  In particular, dependency commons-jxpath:commons-jxpath@1.3 has no readable SCM URL, while from versions 1.4 onwards, it does.
 
 tags:
 - macaron-python-package


### PR DESCRIPTION
## Summary
<!-- Briefly summarize the purpose and scope of this PR. -->
This PR disables the latest PURL feature of the Repo Finder for the integration test `apache_maven_local_path_with_branch_name_digest_deps_cyclonedx_maven`. This prevents a mismatch in the source URL of dependency `ommons-jxpath:commons-jxpath` which recently updated its SCM metadata with a resolvable URL.

## Description of changes
<!-- Provide a detailed explanation of the changes made in this PR, why they were needed, and how they address the issue(s). -->
A config file is added to the test to disable the option.

## Related issues
<!-- List any related issue(s) this PR addresses, e.g., `Closes #123`, `Fixes #456`. -->
Closes #1061 
