### PR TITLE
refactor: log the SLSA summary in verbose mode only

### DIFF
--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -265,7 +265,7 @@ class Analyzer:
                 self.generate_reports(report)
 
                 # Print the analysis result into the console output.
-                logger.info(str(report))
+                logger.debug(str(report))
 
                 db_session.add(analysis)
 


### PR DESCRIPTION
## Summary
Refactor logging behavior to print the SLSA summary only when verbose mode is enabled. We can revisit if the summary should be removed or improved in the verbose mode in the future.

## Description of changes
This PR updates the logging to ensure the SLSA summary is printed only when the application is run in verbose mode. Previously, the summary was always printed regardless of the verbosity level, which could result in unnecessary output in standard use cases.

This change helps reduce noise in the logs for users who do not require detailed internal information, while still allowing full visibility during debugging or detailed inspection when verbose mode is explicitly enabled.
