### PR TITLE
chore: add support for Git tag aliases in vuln GHA check

### DIFF
--- a/src/macaron/errors.py
+++ b/src/macaron/errors.py
@@ -32,6 +32,10 @@ class CloneError(MacaronError):
     """Happens when cannot clone a git repository."""
 
 
+class GitTagError(MacaronError):
+    """Happens when there is a Git tag related error."""
+
+
 class RepoCheckOutError(MacaronError):
     """Happens when there is an error when checking out the correct revision of a git repository."""
 

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -16,12 +16,13 @@ from pathlib import Path
 from git import GitCommandError
 from git.objects import Commit
 from git.repo import Repo
+from packaging import version
 from pydriller.git import Git
 
 from macaron.config.defaults import defaults
 from macaron.config.global_config import global_config
 from macaron.environment_variables import get_patched_env
-from macaron.errors import CloneError
+from macaron.errors import CloneError, GitTagError
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -984,3 +985,70 @@ def get_tags_via_git_remote(repo: str) -> dict[str, str] | None:
     logger.debug("Found %s tags via ls-remote of %s", len(tags), repo)
 
     return tags
+
+
+def find_highest_git_tag(tags: set[str]) -> str:
+    """
+    Find and return the highest (most recent) semantic version tag from a set of Git tags.
+
+    Parameters
+    ----------
+    tags : set[str]
+        A set of version strings (e.g., {"v1.0.0", "v2.3.4", "v2.1.0"}). Tags must follow PEP 440 or
+        semver format, otherwise they will be skipped.
+
+    Returns
+    -------
+    str
+        The tag string corresponding to the highest version.
+
+    Raises
+    ------
+    GitTagError
+        If no valid tag is found or if a tag is not a valid version.
+
+    Example
+    -------
+    >>> find_highest_git_tag({"v2.0.0"})
+    'v2.0.0'
+
+    >>> find_highest_git_tag({"1.2.3", "2.0.0", "1.10.1"})
+    '2.0.0'
+
+    >>> find_highest_git_tag({"0.1", "0.1.1", "0.0.9"})
+    '0.1.1'
+
+    >>> find_highest_git_tag({"invalid", "1.0.0"})
+    '1.0.0'
+
+    >>> find_highest_git_tag(set())
+    Traceback (most recent call last):
+        ...
+    GitTagError: No tags provided.
+
+    >>> find_highest_git_tag({"invalid"})
+    Traceback (most recent call last):
+        ...
+    GitTagError: No valid version tag found.
+    """
+    if not tags:
+        raise GitTagError("No tags provided.")
+
+    highest_tag = None
+    highest_parsed_tag = version.Version("0")
+
+    for tag in tags:
+        try:
+            parsed_tag = version.Version(tag)
+        except version.InvalidVersion:
+            logger.debug("Invalid version tag encountered while finding the highest tag: %s", tag)
+            continue
+
+        if parsed_tag > highest_parsed_tag:
+            highest_parsed_tag = parsed_tag
+            highest_tag = tag
+
+    if highest_tag is None:
+        raise GitTagError("No valid version tag found.")
+
+    return highest_tag

--- a/src/macaron/slsa_analyzer/git_url.py
+++ b/src/macaron/slsa_analyzer/git_url.py
@@ -1012,6 +1012,9 @@ def find_highest_git_tag(tags: set[str]) -> str:
     >>> find_highest_git_tag({"v2.0.0"})
     'v2.0.0'
 
+    >>> find_highest_git_tag({"v4", "v4.2.1"})
+    'v4.2.1'
+
     >>> find_highest_git_tag({"1.2.3", "2.0.0", "1.10.1"})
     '2.0.0'
 


### PR DESCRIPTION
## Summary
This PR adds a utility function to identify the highest semantic version tag from a set of Git tags, specifically for cases where multiple tags point to the same commit SHA in a third-party GitHub Action. This is necessary because a single release may have multiple tag aliases, such as `v4` and `v4.2.1` and we want to consistently resolve to the most specific and recent tag.


## Description of changes
The new `find_highest_git_tag` function uses Python’s `packaging.version` module to determine the highest (most recent) version according to semantic versioning rules. It handles common edge cases such as empty tag sets and invalid version strings, raising a custom `GitTagError` when appropriate.

This functionality is especially useful for automation workflows that need to programmatically resolve the latest stable tag associated with a GitHub Action or similar dependency, ensuring accurate and consistent version comparisons.

## Related issues
This change addresses [an issue](https://github.com/oracle/macaron/actions/runs/14608735245/job/40982682956?pr=1064#step:8:12367) where the `v4` tag (an alias for `v4.2.1`) was incorrectly selected during the GitHub Action vulnerability check. Since` v4` is numerically lower than the patched version `v4.1.3`, the check failed even though the underlying code was up to date. By resolving to the highest version (`v4.2.1`), this function ensures the highest tag is used if there are aliases.