### PR TITLE
feat: add pypi attestation discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "cyclonedx-python-lib[validation] >=7.3.4,<8.0.0",
     "beautifulsoup4 >= 4.12.0,<5.0.0",
     "problog >= 2.2.6,<3.0.0",
-    "pypi-attestations >= 0.0.23,<1.0.0",
+    "cryptography >=44.0.0,<45.0.0",
 ]
 keywords = []
 # https://pypi.org/classifiers/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "cyclonedx-python-lib[validation] >=7.3.4,<8.0.0",
     "beautifulsoup4 >= 4.12.0,<5.0.0",
     "problog >= 2.2.6,<3.0.0",
+    "pypi-attestations >= 0.0.23,<1.0.0",
 ]
 keywords = []
 # https://pypi.org/classifiers/

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -542,7 +542,8 @@ inspector_url_scheme = https
 [deps_dev]
 url_netloc = api.deps.dev
 url_scheme = https
-purl_endpoint = v3alpha/purl
+api_endpoint = v3alpha
+purl_endpoint = purl
 
 [osv_dev]
 url_netloc = api.osv.dev

--- a/src/macaron/provenance/provenance_extractor.py
+++ b/src/macaron/provenance/provenance_extractor.py
@@ -201,6 +201,9 @@ def _extract_from_slsa_v1(payload: InTotoV1Payload) -> tuple[str | None, str | N
 def _extract_from_pypi_v1(payload: InTotoV1Payload) -> tuple[str | None, str | None]:
     """Extract the repository and commit metadata from the pypi provenance file found at the passed path.
 
+    This payload represents a custom predicate created from the certificate of a PyPI v1 attestation file.
+    By design, these attestations come without a predicate.
+
     Parameters
     ----------
     payload: InTotoPayload

--- a/src/macaron/provenance/provenance_finder.py
+++ b/src/macaron/provenance/provenance_finder.py
@@ -293,11 +293,6 @@ def find_pypi_provenance(purl: PackageURL) -> list[InTotoPayload]:
     -------
     list[InTotoPayload] | None
         The provenance payload if found, or an empty list otherwise.
-
-    Raises
-    ------
-    ProvenanceAvailableException
-        If the discovered provenance file size exceeds the configured limit.
     """
     attestation, verified = DepsDevRepoFinder.get_attestation(purl)
     if not attestation:

--- a/src/macaron/provenance/provenance_finder.py
+++ b/src/macaron/provenance/provenance_finder.py
@@ -2,6 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains methods for finding provenance files."""
+import json
 import logging
 import os
 import tempfile
@@ -12,6 +13,7 @@ from pydriller import Git
 
 from macaron.config.defaults import defaults
 from macaron.repo_finder.commit_finder import AbstractPurlType, determine_abstract_purl_type
+from macaron.repo_finder.repo_finder_deps_dev import DepsDevRepoFinder
 from macaron.slsa_analyzer.analyze_context import AnalyzeContext
 from macaron.slsa_analyzer.checks.provenance_available_check import ProvenanceAvailableException
 from macaron.slsa_analyzer.ci_service import GitHubActions
@@ -76,6 +78,10 @@ class ProvenanceFinder:
                 return []
 
             discovery_functions = [partial(find_gav_provenance, purl, self.jfrog_registry)]
+            return self._find_provenance(discovery_functions)
+
+        if purl.type == "pypi":
+            discovery_functions = [partial(find_pypi_provenance, purl)]
             return self._find_provenance(discovery_functions)
 
         # TODO add other possible discovery functions.
@@ -273,6 +279,42 @@ def find_gav_provenance(purl: PackageURL, registry: JFrogMavenRegistry) -> list[
 
     # We assume that there is only one provenance per GAV.
     return provenances[:1]
+
+
+def find_pypi_provenance(purl: PackageURL) -> list[InTotoPayload]:
+    """Find and download the PyPI based provenance for the passed PURL.
+
+    Parameters
+    ----------
+    purl: PackageURL
+        The PURL of the analysis target.
+
+    Returns
+    -------
+    list[InTotoPayload] | None
+        The provenance payload if found, or an empty list otherwise.
+
+    Raises
+    ------
+    ProvenanceAvailableException
+        If the discovered provenance file size exceeds the configured limit.
+    """
+    attestation, verified = DepsDevRepoFinder.get_attestation(purl)
+    if not attestation:
+        return []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_name = os.path.join(temp_dir, f"{purl.name}")
+        with open(file_name, "w", encoding="utf-8") as file:
+            json.dump(attestation, file)
+
+        try:
+            payload = load_provenance_payload(file_name)
+            payload.verified = verified
+            return [payload]
+        except LoadIntotoAttestationError as load_error:
+            logger.error("Error while loading provenance: %s", load_error)
+            return []
 
 
 def find_provenance_from_ci(

--- a/src/macaron/provenance/provenance_verifier.py
+++ b/src/macaron/provenance/provenance_verifier.py
@@ -82,10 +82,12 @@ def verify_npm_provenance(purl: PackageURL, provenance: list[InTotoPayload]) -> 
 
     signed_subjects = provenance[1].statement.get("subject")
     if not signed_subjects:
+        logger.debug("Missing signed subjects.")
         return False
 
     unsigned_subjects = provenance[0].statement.get("subject")
     if not unsigned_subjects:
+        logger.debug("Missing unsigned subjects.")
         return False
 
     found_signed_subject = None
@@ -97,6 +99,7 @@ def verify_npm_provenance(purl: PackageURL, provenance: list[InTotoPayload]) -> 
         break
 
     if not found_signed_subject:
+        logger.debug("Missing signed subject.")
         return False
 
     found_unsigned_subject = None
@@ -108,15 +111,18 @@ def verify_npm_provenance(purl: PackageURL, provenance: list[InTotoPayload]) -> 
         break
 
     if not found_unsigned_subject:
+        logger.debug("Missing unsigned subject.")
         return False
 
     signed_digest = found_signed_subject.get("digest")
     unsigned_digest = found_unsigned_subject.get("digest")
     if not (signed_digest and unsigned_digest):
+        logger.debug("Missing %ssigned digest.", "un" if signed_digest else "")
         return False
 
     # For signed and unsigned to match, the digests must be identical.
     if signed_digest != unsigned_digest:
+        logger.debug("Signed and unsigned digests do not match.")
         return False
 
     key = list(signed_digest.keys())[0]

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -188,7 +188,11 @@ class DepsDevRepoFinder(BaseRepoFinder):
         if not result:
             return None, False
 
-        result_attestations = json_extract(result, ["attestations"], list)
+        attestation_keys = ["attestations"]
+        if "version" in result:
+            attestation_keys.insert(0, "version")
+
+        result_attestations = json_extract(result, attestation_keys, list)
         if not result_attestations:
             logger.debug("No attestations in result.")
             return None, False

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -181,6 +181,8 @@ class DepsDevRepoFinder(BaseRepoFinder):
                 return None, False
             purl = latest_purl
 
+        # Example of a PURL endpoint for deps.dev with '/' encoded as '%2F':
+        # https://api.deps.dev/v3alpha/purl/pkg:npm%2F@sigstore%2Fmock@0.7.5
         purl_endpoint = DepsDevService().get_purl_endpoint(purl)
         target_url = urllib.parse.urlunsplit(purl_endpoint)
 

--- a/src/macaron/repo_finder/repo_finder_enums.py
+++ b/src/macaron/repo_finder/repo_finder_enums.py
@@ -45,17 +45,17 @@ class RepoFinderInfo(Enum):
     #: Reported for all other bad status codes that a host could return. E.g. 500, etc.
     HTTP_OTHER = "HTTP other"
 
-    #: Reported if deps.dev produces no response to the HTTP request.
-    DDEV_BAD_RESPONSE = "deps.dev bad response"
-
-    #: Reported if deps.dev returns JSON data that cannot be parsed.
-    DDEV_JSON_FETCH_ERROR = "deps.dev fetch error"
+    #: Reported if deps.dev produces an invalid response to an API request.
+    DDEV_API_ERROR = "deps.dev bad response"
 
     #: Reported if deps.dev returns JSON data that is missing expected fields.
     DDEV_JSON_INVALID = "deps.dev JSON invalid"
 
-    #: Reported if deps.dev returns data that does not contain the desired SCM URL. E.g. The repository URL.
-    DDEV_NO_URLS = "deps.dev no URLs"
+    #: Reported if deps.dev returns JSON data with no repository URLs.
+    DDEV_NO_URLS = "deps.dev no urls"
+
+    #: Reported if deps.dev returns JSON data with no valid repository URLs.
+    DDEV_NO_VALID_URLS = "deps.dev no valid URLs"
 
     #: Reported if there was an error with the request sent to the PyPI registry.
     PYPI_HTTP_ERROR = "PyPI HTTP error"

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -363,7 +363,9 @@ class Analyzer:
             provenances = provenance_finder.find_provenance(parsed_purl)
             if provenances:
                 provenance_payload = provenances[0]
-                if verify_provenance:
+                if provenance_payload.verified:
+                    provenance_is_verified = True
+                elif verify_provenance:
                     provenance_is_verified = provenance_verifier.verify_provenance(parsed_purl, provenances)
 
         # Try to extract the repository URL and commit digest from the Provenance, if it exists.
@@ -425,7 +427,7 @@ class Analyzer:
             found_commit=final_digest,
         )
 
-        # Check if only one of the repo or digest came from direct input.
+        # Check if repo came from direct input.
         if parsed_purl:
             if check_if_input_purl_provenance_conflict(
                 bool(repo_path_input),

--- a/src/macaron/slsa_analyzer/package_registry/deps_dev.py
+++ b/src/macaron/slsa_analyzer/package_registry/deps_dev.py
@@ -7,7 +7,6 @@ import json
 import logging
 import urllib.parse
 from json.decoder import JSONDecodeError
-from typing import Any
 from urllib.parse import quote as encode
 from urllib.parse import unquote as decode
 
@@ -22,7 +21,7 @@ class DepsDevService:
     """The deps.dev service class."""
 
     @staticmethod
-    def get_endpoint(purl: bool = True, path: str | None = None) -> Any:
+    def get_endpoint(purl: bool = True, path: str | None = None) -> urllib.parse.SplitResult:
         """Build the API endpoint for the deps.dev service and return it.
 
         Parameters

--- a/src/macaron/slsa_analyzer/package_registry/deps_dev.py
+++ b/src/macaron/slsa_analyzer/package_registry/deps_dev.py
@@ -8,6 +8,8 @@ import logging
 import urllib.parse
 from json.decoder import JSONDecodeError
 from typing import Any
+from urllib.parse import quote as encode
+from urllib.parse import unquote as decode
 
 from macaron.config.defaults import defaults
 from macaron.errors import APIAccessError
@@ -104,6 +106,10 @@ class DepsDevService:
             If the service is misconfigured, the API is invalid, a network error happens,
             or unexpected response is returned by the API.
         """
+        if "%" in purl:
+            purl = decode(purl)
+        purl = encode(purl, safe="")
+
         api_endpoint = DepsDevService.get_endpoint(path=purl)
         url = urllib.parse.urlunsplit(api_endpoint)
 

--- a/src/macaron/slsa_analyzer/package_registry/deps_dev.py
+++ b/src/macaron/slsa_analyzer/package_registry/deps_dev.py
@@ -7,7 +7,7 @@ import json
 import logging
 import urllib.parse
 from json.decoder import JSONDecodeError
-from urllib.parse import quote as encode
+from typing import Any
 
 from macaron.config.defaults import defaults
 from macaron.errors import APIAccessError
@@ -20,7 +20,72 @@ class DepsDevService:
     """The deps.dev service class."""
 
     @staticmethod
-    def get_package_info(purl: str) -> dict | None:
+    def get_endpoint(purl: bool = True, path: str | None = None) -> Any:
+        """Build the API endpoint for the deps.dev service and return it.
+
+        Parameters
+        ----------
+        purl: bool
+            A flag to determine whether the PURL or BASE endpoint should be returned.
+        path: str | None
+            A path to be added to the URL.
+
+        Returns
+        -------
+        Any
+            The API endpoint.
+        """
+        section_name = "deps_dev"
+        if not defaults.has_section(section_name):
+            raise APIAccessError(f"The {section_name} section is missing in the .ini configuration file.")
+        section = defaults[section_name]
+
+        url_netloc = section.get("url_netloc")
+        if not url_netloc:
+            raise APIAccessError(
+                f'The "url_netloc" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+        url_scheme = section.get("url_scheme", "https")
+
+        api_endpoint = section.get("api_endpoint")
+        if not api_endpoint:
+            raise APIAccessError(
+                f'The "api_endpoint" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+        endpoint_path = [api_endpoint]
+        if path:
+            endpoint_path.append(path)
+        if not purl:
+            try:
+                return urllib.parse.SplitResult(
+                    scheme=url_scheme,
+                    netloc=url_netloc,
+                    path="/".join(endpoint_path),
+                    query="",
+                    fragment="",
+                )
+            except ValueError as error:
+                raise APIAccessError("Failed to construct the API URL.") from error
+
+        purl_endpoint = section.get("purl_endpoint")
+        if not purl_endpoint:
+            raise APIAccessError(
+                f'The "purl_endpoint" key is missing in section [{section_name}] of the .ini configuration file.'
+            )
+        endpoint_path.insert(1, purl_endpoint)
+        try:
+            return urllib.parse.SplitResult(
+                scheme=url_scheme,
+                netloc=url_netloc,
+                path="/".join(endpoint_path),
+                query="",
+                fragment="",
+            )
+        except ValueError as error:
+            raise APIAccessError("Failed to construct the API URL.") from error
+
+    @staticmethod
+    def get_package_info(purl: str) -> dict:
         """Check if the package identified by the PackageURL (PURL) exists and return its information.
 
         Parameters
@@ -30,8 +95,8 @@ class DepsDevService:
 
         Returns
         -------
-        dict | None
-            The package metadata or None if it doesn't exist.
+        dict
+            The package metadata.
 
         Raises
         ------
@@ -39,45 +104,15 @@ class DepsDevService:
             If the service is misconfigured, the API is invalid, a network error happens,
             or unexpected response is returned by the API.
         """
-        section_name = "deps_dev"
-        if not defaults.has_section(section_name):
-            return None
-        section = defaults[section_name]
-
-        url_netloc = section.get("url_netloc")
-        if not url_netloc:
-            raise APIAccessError(
-                f'The "url_netloc" key is missing in section [{section_name}] of the .ini configuration file.'
-            )
-        url_scheme = section.get("url_scheme", "https")
-        purl_endpoint = section.get("purl_endpoint")
-        if not purl_endpoint:
-            raise APIAccessError(
-                f'The "purl_endpoint" key is missing in section [{section_name}] of the .ini configuration file.'
-            )
-
-        path_params = "/".join([purl_endpoint, encode(purl, safe="")])
-        try:
-            url = urllib.parse.urlunsplit(
-                urllib.parse.SplitResult(
-                    scheme=url_scheme,
-                    netloc=url_netloc,
-                    path=path_params,
-                    query="",
-                    fragment="",
-                )
-            )
-        except ValueError as error:
-            raise APIAccessError("Failed to construct the API URL.") from error
+        api_endpoint = DepsDevService.get_endpoint(path=purl)
+        url = urllib.parse.urlunsplit(api_endpoint)
 
         response = send_get_http_raw(url)
         if response and response.text:
             try:
                 metadata: dict = json.loads(response.text)
+                return metadata
             except JSONDecodeError as error:
                 raise APIAccessError(f"Failed to process response from deps.dev for {url}.") from error
-            if not metadata:
-                raise APIAccessError(f"Empty response returned by {url} .")
-            return metadata
 
-        return None
+        raise APIAccessError(f"No valid response from deps.dev for {url}")

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -335,6 +335,40 @@ class PyPIRegistry(PackageRegistry):
 
         return res.replace(tzinfo=None) if res else None
 
+    @staticmethod
+    def extract_attestation(attestation_data: dict) -> dict | None:
+        """Extract the first attestation file from a PyPI attestation response.
+
+        Parameters
+        ----------
+        attestation_data: dict
+            The JSON data representing a bundle of attestations.
+
+        Returns
+        -------
+        dict | None
+            The first attestation, or None if not found.
+        """
+        bundle = json_extract(attestation_data, ["attestation_bundles"], list)
+        if not bundle:
+            logger.debug("No attestation bundle in response.")
+            return None
+        if len(bundle) > 1:
+            logger.debug("Bundle length greater than one: %s", len(bundle))
+
+        attestations = json_extract(bundle[0], ["attestations"], list)
+        if not attestations:
+            logger.debug("No attestations in response.")
+            return None
+        if len(attestations) > 1:
+            logger.debug("More than one attestation: %s", len(attestations))
+
+        if not isinstance(attestations[0], dict):
+            logger.debug("Attestation invalid.")
+            return None
+
+        return attestations[0]
+
 
 @dataclass
 class PyPIPackageJsonAsset:

--- a/src/macaron/slsa_analyzer/provenance/intoto/__init__.py
+++ b/src/macaron/slsa_analyzer/provenance/intoto/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """In-toto provenance schemas and validation."""
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import NamedTuple, Protocol, TypeVar
+from dataclasses import dataclass
+from typing import Protocol, TypeVar
 
 from packageurl import PackageURL
 
@@ -21,7 +22,8 @@ from macaron.slsa_analyzer.provenance.intoto.v1 import InTotoV1ResourceDescripto
 StatementT = TypeVar("StatementT", bound=Mapping)
 
 
-class InTotoV01Payload(NamedTuple):
+@dataclass
+class InTotoV01Payload:
     """The provenance payload following in-toto v0.1 schema.
 
     The payload is a field within a DSSE envelope, having the type "Statement".
@@ -36,9 +38,11 @@ class InTotoV01Payload(NamedTuple):
     """
 
     statement: v01.InTotoV01Statement
+    verified: bool = False
 
 
-class InTotoV1Payload(NamedTuple):
+@dataclass
+class InTotoV1Payload:
     """The provenance payload following in-toto v1 schema.
 
     The payload is a field within a DSSE envelope, having the type "Statement".
@@ -53,6 +57,7 @@ class InTotoV1Payload(NamedTuple):
     """
 
     statement: v1.InTotoV1Statement
+    verified: bool = False
 
 
 # The payload is a field within a DSSE envelope, having the type "Statement".

--- a/src/macaron/slsa_analyzer/provenance/loader.py
+++ b/src/macaron/slsa_analyzer/provenance/loader.py
@@ -144,7 +144,7 @@ def _load_provenance_file_content(
         logger.debug(error)
         raise LoadIntotoAttestationError("Error parsing certificate.") from error
 
-    json_payload["predicate"] = certificate_predicate
+    json_payload["predicate"] = certificate_predicate.build_predicate()
     return json_payload
 
 

--- a/src/macaron/slsa_analyzer/provenance/loader.py
+++ b/src/macaron/slsa_analyzer/provenance/loader.py
@@ -127,7 +127,8 @@ def _load_provenance_file_content(
     if not predicate_type:
         raise LoadIntotoAttestationError("The payload is missing a predicate type.")
 
-    if "predicate" in json_payload:
+    predicate = json_extract(json_payload, ["predicate"], dict)
+    if predicate:
         if predicate_type == "https://docs.pypi.org/attestations/publish/v1":
             raise LoadIntotoAttestationError("PyPI attestation should not have a predicate.")
         return json_payload

--- a/src/macaron/slsa_analyzer/provenance/loader.py
+++ b/src/macaron/slsa_analyzer/provenance/loader.py
@@ -99,10 +99,6 @@ def _load_provenance_file_content(
         # property but contain its value directly.
         provenance_payload = provenance.get("payload", None)
     if not provenance_payload:
-        # GitHub Attestation.
-        # TODO Check if old method (above) actually works.
-        provenance_payload = json_extract(provenance, ["bundle", "dsseEnvelope", "payload"], str)
-    if not provenance_payload:
         # PyPI Attestation.
         provenance_payload = json_extract(provenance, ["envelope", "statement"], str)
     if not provenance_payload:

--- a/src/macaron/slsa_analyzer/specs/inferred_provenance.py
+++ b/src/macaron/slsa_analyzer/specs/inferred_provenance.py
@@ -24,7 +24,7 @@ class InferredProvenance:
                 "builder": {"id": "<URI>"},
                 "buildType": "<URI>",
                 "invocation": {
-                    "configSource": {"uri": "<URI>", "digest": {"sha1": "<STING>"}, "entryPoint": "<STRING>"},
+                    "configSource": {"uri": "<URI>", "digest": {"sha1": "<STRING>"}, "entryPoint": "<STRING>"},
                     "parameters": {},
                     "environment": {},
                 },

--- a/src/macaron/slsa_analyzer/specs/pypi_certificate_predicate.py
+++ b/src/macaron/slsa_analyzer/specs/pypi_certificate_predicate.py
@@ -2,18 +2,27 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the spec for predicates derived from a PyPI attestation certificate."""
+from dataclasses import dataclass
 
 
+@dataclass(frozen=True)
 class PyPICertificatePredicate:
     """This class implements the PyPI certificate predicate."""
 
-    @staticmethod
-    def build_predicate(source_url: str, source_digest: str, build_workflow: str, invocation_url: str) -> dict:
+    source_url: str
+
+    source_digest: str
+
+    build_workflow: str
+
+    invocation_url: str
+
+    def build_predicate(self) -> dict:
         """Build a predicate using passed parameters."""
         return {
             "buildType": "pypi_certificate",
-            "sourceUri": f"{source_url}",
-            "sourceDigest": f"{source_digest}",
-            "workflow": f"{build_workflow}",
-            "invocationUrl": f"{invocation_url}",
+            "sourceUri": f"{self.source_url}",
+            "sourceDigest": f"{self.source_digest}",
+            "workflow": f"{self.build_workflow}",
+            "invocationUrl": f"{self.invocation_url}",
         }

--- a/src/macaron/slsa_analyzer/specs/pypi_certificate_predicate.py
+++ b/src/macaron/slsa_analyzer/specs/pypi_certificate_predicate.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module contains the spec for predicates derived from a PyPI attestation certificate."""
+
+
+class PyPICertificatePredicate:
+    """This class implements the PyPI certificate predicate."""
+
+    @staticmethod
+    def build_predicate(source_url: str, source_digest: str, build_workflow: str, invocation_url: str) -> dict:
+        """Build a predicate using passed parameters."""
+        return {
+            "buildType": "pypi_certificate",
+            "sourceUri": f"{source_url}",
+            "sourceDigest": f"{source_digest}",
+            "workflow": f"{build_workflow}",
+            "invocationUrl": f"{invocation_url}",
+        }

--- a/tests/integration/cases/pypi_attestation_discovery/policy.dl
+++ b/tests/integration/cases/pypi_attestation_discovery/policy.dl
@@ -1,0 +1,13 @@
+/* Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_passed(component_id, "mcn_provenance_verified_1"),
+    check_passed(component_id, "mcn_provenance_available_1"),
+    check_passed(component_id, "mcn_provenance_derived_repo_1"),
+    check_passed(component_id, "mcn_provenance_derived_commit_1").
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:pypi/ultralytics@8.3.70").

--- a/tests/integration/cases/pypi_attestation_discovery/test.yaml
+++ b/tests/integration/cases/pypi_attestation_discovery/test.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a PyPI PURL that has provenance available on the PyPI registry.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/ultralytics@8.3.70
+- name: Run macaron verify-policy to verify passed/failed checks
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/integration/cases/repo_finder_remote_calls/repo_finder.py
+++ b/tests/integration/cases/repo_finder_remote_calls/repo_finder.py
@@ -43,6 +43,13 @@ def test_repo_finder() -> int:
         defaults.add_section("git_service.gitlab")
     defaults.set("git_service.gitlab", "hostname", "gitlab.com")
 
+    if not defaults.has_section("deps_dev"):
+        defaults.add_section("deps_dev")
+    defaults.set("deps_dev", "url_netloc", "api.deps.dev")
+    defaults.set("deps_dev", "url_scheme", "https")
+    defaults.set("deps_dev", "api_endpoint", "v3alpha")
+    defaults.set("deps_dev", "purl_endpoint", "purl")
+
     # Test Java package with SCM metadata in artifact POM.
     match, outcome = find_repo(PackageURL.from_string("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.2"))
     if not match or outcome != RepoFinderInfo.FOUND:

--- a/tests/provenance/test_provenance_finder.py
+++ b/tests/provenance/test_provenance_finder.py
@@ -14,7 +14,11 @@ from packageurl import PackageURL
 from pydriller import Git
 
 from macaron.code_analyzer.call_graph import BaseNode, CallGraph
-from macaron.provenance.provenance_finder import find_gav_provenance, find_npm_provenance, find_provenance_from_ci
+from macaron.provenance.provenance_finder import (
+    find_gav_provenance,
+    find_npm_provenance,
+    find_provenance_from_ci,
+)
 from macaron.slsa_analyzer.ci_service import BaseCIService, CircleCI, GitHubActions, GitLabCI, Jenkins, Travis
 from macaron.slsa_analyzer.git_service.api_client import GhAPIClient
 from macaron.slsa_analyzer.package_registry import JFrogMavenRegistry, NPMRegistry
@@ -206,9 +210,7 @@ def test_provenance_on_supported_ci(macaron_path: Path, test_dir: Path) -> None:
         assert provenance is None
 
 
-def test_provenance_available_on_npm_registry(
-    test_dir: Path,
-) -> None:
+def test_provenance_available_on_npm_registry(test_dir: Path) -> None:
     """Test provenance published on npm registry."""
     purl = PackageURL.from_string("pkg:npm/@sigstore/mock@0.1.0")
     npm_registry = MockNPMRegistry()
@@ -220,11 +222,9 @@ def test_provenance_available_on_npm_registry(
     assert provenance
 
 
-def test_provenance_available_on_jfrog_registry(
-    test_dir: Path,
-) -> None:
+def test_provenance_available_on_jfrog_registry(test_dir: Path) -> None:
     """Test provenance published on jfrog registry."""
-    purl = PackageURL.from_string("pkg:/maven/io.micronaut/micronaut-core@4.2.3")
+    purl = PackageURL.from_string("pkg:maven/io.micronaut/micronaut-core@4.2.3")
     jfrog_registry = MockJFrogRegistry(str(test_dir))
     provenance = find_gav_provenance(purl, jfrog_registry)
 

--- a/tests/repo_finder/test_repo_finder_deps_dev.py
+++ b/tests/repo_finder/test_repo_finder_deps_dev.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module tests the deps.dev repo finder."""
+
+import pytest
+from packageurl import PackageURL
+from pytest_httpserver import HTTPServer
+
+from macaron.repo_finder.repo_finder_deps_dev import DepsDevRepoFinder
+from macaron.repo_finder.repo_finder_enums import RepoFinderInfo
+
+
+def test_find_repo_url_failure(deps_dev_service_mock: dict) -> None:
+    """Test find repo function."""
+    purl = PackageURL.from_string(f"pkg:pypi/example{deps_dev_service_mock['api']}")
+    result, outcome = DepsDevRepoFinder().find_repo(purl)
+    assert not result
+    assert outcome == RepoFinderInfo.DDEV_API_ERROR
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_outcome"),
+    [
+        ('{"foo": "bar"}', RepoFinderInfo.DDEV_JSON_INVALID),
+        ('{"links": [{"url": 1}]}', RepoFinderInfo.DDEV_NO_URLS),
+        ('{"links": [{"url": "test://test.test"}]}', RepoFinderInfo.DDEV_NO_VALID_URLS),
+    ],
+)
+def test_find_repo_links_failures(
+    httpserver: HTTPServer, deps_dev_service_mock: dict, data: str, expected_outcome: RepoFinderInfo
+) -> None:
+    """Test invalid links."""
+    purl = PackageURL.from_string("pkg:pypi/example@2")
+    target_url = (
+        f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/pkg:{purl.type}/{purl.name}@{purl.version}"
+    )
+
+    httpserver.expect_request(target_url).respond_with_data(data)
+    result, outcome = DepsDevRepoFinder().find_repo(purl)
+
+    assert not result
+    assert outcome == expected_outcome
+
+
+def test_find_repo_success(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:
+    """Test repo finder success."""
+    purl = PackageURL.from_string("pkg:pypi/example@2")
+    target_url = (
+        f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/pkg:{purl.type}/{purl.name}@{purl.version}"
+    )
+
+    httpserver.expect_request(target_url).respond_with_data('{"links": [{"url": "http://github.com/oracle/macaron"}]}')
+    result, outcome = DepsDevRepoFinder().find_repo(purl)
+
+    assert result
+    assert outcome == RepoFinderInfo.FOUND
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "server_url", "data"),
+    [
+        ("http::::://130/test", "", ""),
+        ("http://github.com/oracle/macaron", "", ""),
+        ("", "/oracle/macaron", "INVALID JSON"),
+    ],
+)
+def test_get_project_info_failures(
+    httpserver: HTTPServer, deps_dev_service_mock: dict, repo_url: str, server_url: str, data: str
+) -> None:
+    """Test get project info failures."""
+    if not repo_url:
+        repo_url = f"{deps_dev_service_mock['base_scheme']}://{deps_dev_service_mock['base_netloc']}{server_url}"
+
+    if server_url:
+        target_url = f"/{deps_dev_service_mock['api']}/projects/{deps_dev_service_mock['base_hostname']}{server_url}"
+        httpserver.expect_request(target_url).respond_with_data(data)
+
+    assert not DepsDevRepoFinder().get_project_info(repo_url)
+
+
+def test_get_project_info_success(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:
+    """Test get project info success."""
+    path = "/oracle/macaron"
+    repo_url = f"{deps_dev_service_mock['base_scheme']}://{deps_dev_service_mock['base_netloc']}{path}"
+    target_url = f"/{deps_dev_service_mock['api']}/projects/{deps_dev_service_mock['base_hostname']}{path}"
+    httpserver.expect_request(target_url).respond_with_data('{"foo": "bar"}')
+
+    assert DepsDevRepoFinder().get_project_info(repo_url)
+
+
+@pytest.mark.parametrize(
+    ("purl_string", "server_url", "data", "expected_outcome"),
+    [
+        ("pkg:pypi/test@3", False, "", RepoFinderInfo.DDEV_API_ERROR),
+        ("pkg:pypi/test@3", True, '{"foo": "bar"}', RepoFinderInfo.DDEV_JSON_INVALID),
+        ("pkg:pypi/test@3", True, '{"version": [1]}', RepoFinderInfo.DDEV_JSON_INVALID),
+    ],
+)
+def test_get_latest_version_failures(
+    httpserver: HTTPServer,
+    deps_dev_service_mock: dict,
+    purl_string: str,
+    server_url: bool,
+    data: str,
+    expected_outcome: RepoFinderInfo,
+) -> None:
+    """Test get latest version failures."""
+    purl = PackageURL.from_string(purl_string)
+
+    if server_url:
+        target_url = f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/pkg:{purl.type}/{purl.name}"
+        httpserver.expect_request(target_url).respond_with_data(data)
+
+    result, outcome = DepsDevRepoFinder().get_latest_version(purl)
+
+    assert not result
+    assert outcome == expected_outcome
+
+
+def test_get_latest_version_success(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:
+    """Test get latest version success."""
+    purl = PackageURL.from_string("pkg:pypi/test@3")
+    target_url = f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/pkg:{purl.type}/{purl.name}"
+    httpserver.expect_request(target_url).respond_with_data(
+        '{"version": [{"versionKey":{"version": "4"}, "isDefault":true}]}'
+    )
+    result, outcome = DepsDevRepoFinder().get_latest_version(purl)
+    assert result
+    assert outcome == RepoFinderInfo.FOUND_FROM_LATEST
+
+
+@pytest.mark.parametrize(
+    ("purl_string", "server_url", "data"),
+    [
+        ("pkg:pypi/test", False, ""),
+        ("pkg:pypi/test@3", False, ""),
+        ("pkg:pypi/test@3", True, '{"foo": "bar"}'),
+        ("pkg:pypi/test@3", True, '{"attestations": [1, 2]}'),
+        ("pkg:pypi/test@3", True, '{"attestations": [{"url": "*replace_url*/bad_endpoint"}]}'),
+        ("pkg:pypi/test@3", True, '{"attestations": [{"url": "*replace_url*"}]}'),
+        ("pkg:pypi/test@3", True, '{"attestations": [{"url": "*replace_url*"}], "attestation_bundles": [1,2]}'),
+        (
+            "pkg:pypi/test@3",
+            True,
+            '{"attestations": [{"url": "*replace_url*"}], "attestation_bundles": [{"attestations": [1]}]}',
+        ),
+    ],
+)
+def test_get_attestation_failures(
+    httpserver: HTTPServer, deps_dev_service_mock: dict, purl_string: str, server_url: bool, data: str
+) -> None:
+    """Test get attestation failures."""
+    purl = PackageURL.from_string(purl_string)
+
+    if server_url:
+        assert purl.version
+        target_url = (
+            f"/{deps_dev_service_mock['api']}/"
+            + f"{'/'.join(['systems', purl.type, 'packages', purl.name, 'versions', purl.version])}"
+        )
+        if "*replace_url*" in data:
+            attestation_url = (
+                f"{deps_dev_service_mock['base_scheme']}://{deps_dev_service_mock['base_netloc']}{target_url}"
+            )
+            data = data.replace("*replace_url*", attestation_url)
+
+        httpserver.expect_request(target_url).respond_with_data(data)
+
+    result, _ = DepsDevRepoFinder().get_attestation(purl)
+    assert not result
+
+
+def test_get_attestation_success(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:
+    """Test get attestation success."""
+    purl = PackageURL.from_string("pkg:pypi/test@3")
+    target_url = (
+        f"/{deps_dev_service_mock['api']}/"
+        + f"{'/'.join(['systems', purl.type, 'packages', purl.name, 'versions', purl.version or ''])}"
+    )
+    attestation_url = f"{deps_dev_service_mock['base_scheme']}://{deps_dev_service_mock['base_netloc']}{target_url}"
+    data = """
+        {
+            "attestations": [{"url": "*replace_url*", "verified": true}],
+            "attestation_bundles": [{"attestations": [{"foo": "bar"}]}]
+        }
+    """
+    data = data.replace("*replace_url*", attestation_url)
+    httpserver.expect_request(target_url).respond_with_data(data)
+    result, verified = DepsDevRepoFinder().get_attestation(purl)
+    assert result
+    assert verified

--- a/tests/repo_finder/test_repo_finder_deps_dev.py
+++ b/tests/repo_finder/test_repo_finder_deps_dev.py
@@ -63,7 +63,9 @@ def test_find_repo_success(httpserver: HTTPServer, deps_dev_service_mock: dict) 
         "http://github.com/oracle/macaron",
     ],
 )
-def test_get_project_info_invalid_url(repo_url: str) -> None:
+def test_get_project_info_invalid_url(
+    deps_dev_service_mock: dict, repo_url: str  # pylint: disable=unused-argument
+) -> None:
     """Test get project info invalid url."""
     assert not DepsDevRepoFinder().get_project_info(repo_url)
 

--- a/tests/slsa_analyzer/package_registry/test_deps_dev.py
+++ b/tests/slsa_analyzer/package_registry/test_deps_dev.py
@@ -3,66 +3,41 @@
 
 """Tests for the deps.dev service."""
 
-import os
-import urllib
-from pathlib import Path
-
 import pytest
 from pytest_httpserver import HTTPServer
-from werkzeug import Response
 
-from macaron.config.defaults import load_defaults
 from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 
 
 @pytest.mark.parametrize(
     ("purl", "data", "expected"),
     [
-        ("pkg%3Apypi%2Fultralytics%408.3.46", "", None),
-        ("pkg%3Apypi%2Fultralytics", '{"foo": "bar"}', {"foo": "bar"}),
+        ("pkg:pypi/ultralytics", '{"foo": "bar"}', {"foo": "bar"}),
     ],
 )
-def test_get_package_info(httpserver: HTTPServer, tmp_path: Path, purl: str, data: str, expected: dict | None) -> None:
+def test_get_package_info(
+    httpserver: HTTPServer, purl: str, data: str, expected: dict, deps_dev_service_mock: dict
+) -> None:
     """Test getting package info."""
-    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
-    user_config_input = f"""
-    [deps_dev]
-    url_netloc = {base_url_parsed.netloc}
-    url_scheme = {base_url_parsed.scheme}
-    """
-
-    user_config_path = os.path.join(tmp_path, "config.ini")
-    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
-        user_config_file.write(user_config_input)
-    # We don't have to worry about modifying the ``defaults`` object causing test
-    # pollution here, since we reload the ``defaults`` object before every test with the
-    # ``setup_test`` fixture.
-    load_defaults(user_config_path)
-
-    httpserver.expect_request(f"/v3alpha/purl/{purl}").respond_with_response(Response(data))
+    httpserver.expect_request(
+        f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/{purl}"
+    ).respond_with_data(data)
 
     assert DepsDevService.get_package_info(purl) == expected
 
 
-def test_get_package_info_exception(httpserver: HTTPServer, tmp_path: Path) -> None:
+def test_get_package_info_exception(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:
     """Test if the function correctly returns an exception."""
-    base_url_parsed = urllib.parse.urlparse(httpserver.url_for(""))
-    user_config_input = f"""
-    [deps_dev]
-    url_netloc = {base_url_parsed.netloc}
-    url_scheme = {base_url_parsed.scheme}
-    """
+    purl = "pkg:pypi/example"
 
-    user_config_path = os.path.join(tmp_path, "config.ini")
-    with open(user_config_path, "w", encoding="utf-8") as user_config_file:
-        user_config_file.write(user_config_input)
-    # We don't have to worry about modifying the ``defaults`` object causing test
-    # pollution here, since we reload the ``defaults`` object before every test with the
-    # ``setup_test`` fixture.
-    load_defaults(user_config_path)
+    # Return bad JSON data.
+    httpserver.expect_request(
+        f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/{purl}"
+    ).respond_with_data("Not Valid")
 
-    purl = "pkg%3Apypi%2Fexample"
-    httpserver.expect_request(f"/v3alpha/purl/{purl}").respond_with_data("Not Valid")
-
-    with pytest.raises(APIAccessError):
+    with pytest.raises(APIAccessError, match="^Failed to process"):
         DepsDevService.get_package_info(purl)
+
+    # Request an invalid resource.
+    with pytest.raises(APIAccessError, match="^No valid response"):
+        DepsDevService.get_package_info("pkg:pypi/test")

--- a/tests/slsa_analyzer/package_registry/test_deps_dev.py
+++ b/tests/slsa_analyzer/package_registry/test_deps_dev.py
@@ -4,26 +4,22 @@
 """Tests for the deps.dev service."""
 
 import pytest
+from packageurl import PackageURL
 from pytest_httpserver import HTTPServer
 
 from macaron.slsa_analyzer.package_registry.deps_dev import APIAccessError, DepsDevService
 
 
-@pytest.mark.parametrize(
-    ("purl", "data", "expected"),
-    [
-        ("pkg:pypi/ultralytics", '{"foo": "bar"}', {"foo": "bar"}),
-    ],
-)
-def test_get_package_info(
-    httpserver: HTTPServer, purl: str, data: str, expected: dict, deps_dev_service_mock: dict
-) -> None:
+def test_get_package_info(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:
     """Test getting package info."""
+    purl = "pkg:npm/@test/%:_@\"'$£!^&*()-test-example@v3.5.0-jar"
     httpserver.expect_request(
         f"/{deps_dev_service_mock['api']}/{deps_dev_service_mock['purl']}/{purl}"
-    ).respond_with_data(data)
+    ).respond_with_data('{"foo": "bar"}')
 
+    expected = {"foo": "bar"}
     assert DepsDevService.get_package_info(purl) == expected
+    assert DepsDevService.get_package_info(PackageURL.from_string(purl)) == expected
 
 
 def test_get_package_info_exception(httpserver: HTTPServer, deps_dev_service_mock: dict) -> None:


### PR DESCRIPTION
## Summary
<!-- Briefly summarize the purpose and scope of this PR. -->
This PR adds discovery of PyPI attestation. URLs to these attestation files are sought via the deps.dev API.

## Description of changes
<!-- Provide a detailed explanation of the changes made in this PR, why they were needed, and how they address the issue(s). -->

- `DepsDevRepoFinder` was updated to use the `DepsDevService`, ensuring consistent and easily configurable use of the API
- Tests were added for `DepsDevRepoFinder` functions (they were not added previously), including for the functions that PyPI attestation discovery relies upon.
- PyPI attestations do not have a predicate. The `pypi-attestation` is used to extract information from the attestation certificate. This information is coerced into a predicate for use elsewhere within Macaron.
- Addition of an integration test case using the `ultralytics` Python library as its target.

## Related issues
<!-- List any related issue(s) this PR addresses, e.g., `Closes #123`, `Fixes #456`. -->
Closes #947