### PR TITLE
build: add built-from-source github action for semgrep

### DIFF
--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+name: Build Semgrep Wheel Artifact
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  build-semgrep-wheel:
+    name: Build Semgrep wheel
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Install git   # for cloning Semgrep repository
+      run: |
+        sudo apt-get install git
+
+    - name: Clone Semgrep v1.113.0 repository
+      run: |
+        git init
+        git remote add origin https://github.com/semgrep/semgrep.git
+        git fetch --depth 1 origin 4729a05d24bf9cee8face447e8a6d418037d61d8
+        git checkout FETCH_HEAD
+        git submodule update --init --recursive --depth 1
+
+    - name: Build wheel through docker
+      run: |
+        docker build --target semgrep-wheel -t semgrep .
+        docker create --name temp semgrep
+        mkdir -p dist/
+        docker cp temp:/semgrep/cli/dist/ dist/
+        docker container rm temp
+
+    - name: Get wheel name
+      run: |
+        WHEELS=($(find ./dist -type f -name "*manylinux*.whl"))
+        if [ "${WHEELS[@]}" -ne 1]; then
+          echo "Expected a single wheel file built by semgrep dockerfile"
+          exit 1
+        fi
+        echo "WHEEL_PATH=${WHEELS[0]}" >> "$GITHUB_ENV"
+
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02    # v4.6.2
+      with:
+        name: semgrep_wheel_manylinux.whl
+        path: ${{ env.WHEEL_PATH }}
+        if-no-files-found: error
+        compression-level: 0   # don't compress the wheel file
+        retention-days: 90   # uploaded wheel valid for 90 days, before workflow must be run again

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -20,8 +20,8 @@ jobs:
 
     steps:
     # To update the semgrep version, please apply the following changes:
-    #   - change the version tag in the 'name' description
-    #   - change the 'ref' field to use the commit hash of that tag
+    #   change the version tag in the 'name' description
+    #   change the 'ref' field to use the commit hash of that tag
     - name: Check out Semgrep v1.113.0 repository
       uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       with:
@@ -39,8 +39,8 @@ jobs:
         docker cp temp:/semgrep/cli/dist/. wheels/
         docker container rm temp
 
-    # - name: Log in to GitHub Container Registry
-    #   run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+    - name: Log in to GitHub Container Registry
+      run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
     # The manylinux image will be a static binary built using musl, suitable for Oracle linux
     - name: Build and push semgrep wheel image
@@ -50,6 +50,4 @@ jobs:
         echo "FROM scratch
         COPY ${WHEEL} /semgrep_wheel.whl" >> Dockerfile.semgrep
         docker build -t ghcr.io/macaron/macaron-deps:latest -f Dockerfile.semgrep .
-
-
-    # docker push ghcr.io/macaron/macaron-deps:latest
+        docker push ghcr.io/macaron/macaron-deps:latest

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -3,7 +3,7 @@
 
 name: Build Semgrep Wheel Artifact
 
-on: [push, workflow_dispatch]
+on: workflow_dispatch
 
 permissions:
   contents: read

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -3,7 +3,7 @@
 
 name: Build Semgrep Wheel Artifact
 
-on: workflow_dispatch
+on: [push, workflow_dispatch]
 
 permissions:
   contents: read
@@ -12,44 +12,44 @@ jobs:
   build-semgrep-wheel:
     name: Build Semgrep wheel
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # to push the docker image
     defaults:
       run:
         shell: bash
 
     steps:
-    - name: Install git   # for cloning Semgrep repository
-      run: |
-        sudo apt-get install git
-
-    - name: Clone Semgrep v1.113.0 repository
-      run: |
-        git init
-        git remote add origin https://github.com/semgrep/semgrep.git
-        git fetch --depth 1 origin 4729a05d24bf9cee8face447e8a6d418037d61d8
-        git checkout FETCH_HEAD
-        git submodule update --init --recursive --depth 1
+    # To update the semgrep version, please apply the following changes:
+    #   - change the version tag in the 'name' description
+    #   - change the 'ref' field to use the commit hash of that tag
+    - name: Check out Semgrep v1.113.0 repository
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        repository: semgrep/semgrep.git
+        ref: 4729a05d24bf9cee8face447e8a6d418037d61d8 # v1.113.0
+        fetch-depth: 1 # only need most recent commits to this tag
+        submodules: recursive # semgrep uses many of their own ocaml submodules, which are required to build
 
     - name: Build wheel through docker
+      # we build to the 'semgrep-wheel' target as we don't need the performance testing, and want to extract the wheel
       run: |
         docker build --target semgrep-wheel -t semgrep .
         docker create --name temp semgrep
-        mkdir -p dist/
-        docker cp temp:/semgrep/cli/dist/ dist/
+        mkdir -p wheels/
+        docker cp temp:/semgrep/cli/dist/. wheels/
         docker container rm temp
 
-    - name: Get wheel name
-      run: |
-        WHEELS=($(find ./dist -type f -name "*manylinux*.whl"))
-        if [ "${WHEELS[@]}" -ne 1]; then
-          echo "Expected a single wheel file built by semgrep dockerfile"
-          exit 1
-        fi
-        echo "WHEEL_PATH=${WHEELS[0]}" >> "$GITHUB_ENV"
+    # - name: Log in to GitHub Container Registry
+    #   run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02    # v4.6.2
-      with:
-        name: semgrep_wheel_manylinux.whl
-        path: ${{ env.WHEEL_PATH }}
-        if-no-files-found: error
-        compression-level: 0   # don't compress the wheel file
-        retention-days: 90   # uploaded wheel valid for 90 days, before workflow must be run again
+    # The manylinux image will be a static binary built using musl, suitable for Oracle linux
+    - name: Build and push semgrep wheel image
+      run: |
+        cd wheels
+        WHEEL=$(find . -type f -name 'semgrep-*manylinux*.whl')
+        echo "FROM scratch
+        COPY ${WHEEL} /semgrep_wheel.whl" >> Dockerfile.semgrep
+        docker build -t ghcr.io/macaron/macaron-deps:latest -f Dockerfile.semgrep .
+
+
+    # docker push ghcr.io/macaron/macaron-deps:latest


### PR DESCRIPTION
## Summary
This PR adds support for building [Semgrep ](https://github.com/semgrep/semgrep) from source and including it as a Macaron dependency.

## Description of changes
This PR introduces a new manually-triggered GitHub action that clones the Semgrep GitHub repository for version 1.113.0 and builds the software as a python wheel package from source using the repository's supplied Docker file. This includes building from source the required OCaml binaries that are part of the package. This action publishes a minimal docker image under the name `macaron-deps` that only holds that build-from-source semgrep wheel with the name `semgrep_wheel.whl` in the top-level directory. The intention is for this artifact to be used in the final docker build in `Dockerfile.final` to copy the Semgrep wheel out into the Macaron image and install it.

## Checklist
- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
