### PR TITLE
build: fix the Semgrep Docker image path

### DIFF
--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -49,5 +49,5 @@ jobs:
         WHEEL=$(find . -type f -name 'semgrep-*manylinux*.whl')
         echo "FROM scratch
         COPY ${WHEEL} /semgrep_wheel.whl" >> Dockerfile.semgrep
-        docker build -t ghcr.io/macaron/macaron-deps:latest -f Dockerfile.semgrep .
-        docker push ghcr.io/macaron/macaron-deps:latest
+        docker build -t ghcr.io/oracle/macaron-deps:latest -f Dockerfile.semgrep .
+        docker push ghcr.io/oracle/macaron-deps:latest


### PR DESCRIPTION
## Summary
This PR fixes the Docker image path used for building the Semgrep dependency. The previous image references were incorrect.