### PR TITLE
build: include semgrep in final docker image

### DIFF
--- a/.github/workflows/_build_docker.yaml
+++ b/.github/workflows/_build_docker.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This is a reuseable workflow to build and test the Docker image. Note that this workflow does not
@@ -52,6 +52,10 @@ jobs:
         set -euo pipefail
         echo "Hash of package should be $ARTIFACT_HASH."
         echo "$ARTIFACT_HASH" | base64 --decode | sha256sum --strict --check --status || exit 1
+
+    # Login so the docker build has access to the internal dependencies image
+    - name: Log in to GitHub Container Registry
+      run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
     # Build the Docker image without pushing it.
     - name: Build the Docker image

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
+# This is a manually-triggered workflow to build the minimal macaron dependencies image that stores the built-from-source
+# Semgrep wheel file. Note that this workflow DOES push the built image.
+
 name: Build Semgrep Wheel Artifact
 
 on: workflow_dispatch

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -3,7 +3,7 @@
 
 name: Build Semgrep Wheel Artifact
 
-on: [push, workflow_dispatch]
+on: workflow_dispatch
 
 permissions:
   contents: read

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -3,7 +3,7 @@
 
 name: Build Semgrep Wheel Artifact
 
-on: workflow_dispatch
+on: [push, workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/build_semgrep_wheel.yaml
+++ b/.github/workflows/build_semgrep_wheel.yaml
@@ -48,6 +48,6 @@ jobs:
         cd wheels
         WHEEL=$(find . -type f -name 'semgrep-*manylinux*.whl')
         echo "FROM scratch
-        COPY ${WHEEL} /semgrep_wheel.whl" >> Dockerfile.semgrep
+        COPY ${WHEEL} /" >> Dockerfile.semgrep
         docker build -t ghcr.io/oracle/macaron-deps:latest -f Dockerfile.semgrep .
         docker push ghcr.io/oracle/macaron-deps:latest

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -10,7 +10,7 @@
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle/macaron-base
 # image for this build.
 
-FROM ghcr.io/oracle/macaron-deps:latest@sha256:245faf84b0f8e57eaf6032c98eed905ffbd41aea19d312a02b646888b32274d4 as wheel_stage
+FROM ghcr.io/oracle/macaron-deps:latest@sha256:99526baf6596c4c3f24e4caa2b59afaf7f7c26d633ad3113ca24ba43dfad3f0f as wheel_stage
 
 FROM ghcr.io/oracle/macaron-base:latest@sha256:79b3b8b03cb9b6a124c6450f4baa58f96f83ee9e37f572c88a97597b35c7bc51
 
@@ -36,14 +36,14 @@ ARG WHEEL_PATH
 # the warning of not having correct ownership of /home/macaron is not raised.
 USER macaron:macaron
 COPY --chown=macaron:macaron $WHEEL_PATH $HOME/dist/
-COPY --chown=macaron:macaron --from=wheel_stage /semgrep_wheel.whl $HOME/dist/semgrep_wheel.whl
+COPY --chown=macaron:macaron --from=wheel_stage /semgrep-*manylinux*.whl $HOME/dist/
 RUN : \
     && python3 -m venv $HOME/.venv \
     && . .venv/bin/activate \
     && pip install --no-compile --no-cache-dir --upgrade pip setuptools \
     && find $HOME/dist -depth \( -type f \( -name "macaron-*.whl" \) \) -exec pip install --no-compile --no-cache-dir '{}' \; \
     && pip uninstall semgrep \
-    && pip install --no-compile --no-cache-dir $HOME/dist/semgrep_wheel.whl \; \
+    && find $HOME/dist -depth \( -type f \( -name "semgrep-*.whl" \) \) -exec pip install --no-compile --no-cache-dir '{}' \; \
     && rm -rf $HOME/dist \
     && deactivate
 

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -10,6 +10,8 @@
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle/macaron-base
 # image for this build.
 
+FROM ghcr.io/oracle/macaron-deps:latest@sha256:245faf84b0f8e57eaf6032c98eed905ffbd41aea19d312a02b646888b32274d4 as wheel_stage
+
 FROM ghcr.io/oracle/macaron-base:latest@sha256:79b3b8b03cb9b6a124c6450f4baa58f96f83ee9e37f572c88a97597b35c7bc51
 
 ENV HOME="/home/macaron"
@@ -34,11 +36,14 @@ ARG WHEEL_PATH
 # the warning of not having correct ownership of /home/macaron is not raised.
 USER macaron:macaron
 COPY --chown=macaron:macaron $WHEEL_PATH $HOME/dist/
+COPY --chown=macaron:macaron --from=wheel_stage /semgrep_wheel.whl $HOME/dist/semgrep_wheel.whl
 RUN : \
     && python3 -m venv $HOME/.venv \
     && . .venv/bin/activate \
     && pip install --no-compile --no-cache-dir --upgrade pip setuptools \
     && find $HOME/dist -depth \( -type f \( -name "macaron-*.whl" \) \) -exec pip install --no-compile --no-cache-dir '{}' \; \
+    && pip uninstall semgrep \
+    && pip install --no-compile --no-cache-dir $HOME/dist/semgrep_wheel.whl \; \
     && rm -rf $HOME/dist \
     && deactivate
 

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -1,16 +1,17 @@
 # Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
-# This Dockerfile is for building the final production image. It's based on ghcr.io/oracle/macaron-base.
-# For the build, two files will be copied into the image:
+# This Dockerfile is for building the final production image. It's based on ghcr.io/oracle/macaron-base and ghcr.io/oracle/maracon-deps.
+# For the build, three files will be copied into the image:
 #   - Macaron wheel file (its path must be provided to the build argument WHEEL_PATH)
+#   - Macaron dependency files, copied from the macaron-deps image.
 #   - user.sh for the entrypoint of the final image.
 # For example, using Docker, we could build the image using:
 #   docker build --build-arg WHEEL_PATH=<path_to_wheel> -t ghcr.io/oracle/macaron -f docker/Dockerfile.final ./
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle/macaron-base
 # image for this build.
 
-FROM ghcr.io/oracle/macaron-deps:latest@sha256:99526baf6596c4c3f24e4caa2b59afaf7f7c26d633ad3113ca24ba43dfad3f0f as wheel_stage
+FROM ghcr.io/oracle/macaron-deps:latest@sha256:99526baf6596c4c3f24e4caa2b59afaf7f7c26d633ad3113ca24ba43dfad3f0f as deps_stage
 
 FROM ghcr.io/oracle/macaron-base:latest@sha256:79b3b8b03cb9b6a124c6450f4baa58f96f83ee9e37f572c88a97597b35c7bc51
 
@@ -36,7 +37,10 @@ ARG WHEEL_PATH
 # the warning of not having correct ownership of /home/macaron is not raised.
 USER macaron:macaron
 COPY --chown=macaron:macaron $WHEEL_PATH $HOME/dist/
-COPY --chown=macaron:macaron --from=wheel_stage /semgrep-*manylinux*.whl $HOME/dist/
+# Currently, the only dependency stored in the minimal image is the wheel for Semgrep, which we copy here. Since the
+# Macaron project dependencies lists Semgrep as a python dependency, we uninstall it first before using our wheel here
+# to install a trusted built-from-source version.
+COPY --chown=macaron:macaron --from=deps_stage /semgrep-*manylinux*.whl $HOME/dist/
 RUN : \
     && python3 -m venv $HOME/.venv \
     && . .venv/bin/activate \


### PR DESCRIPTION
## Summary
Include the built-from-source Semgrep wheel stored in `macaron-deps` in the final docker image for macaron.

## Description of changes
The minimal image `macaron-deps` that was created in #1073 (fixed in #1078) stores the python `.whl` package for Semgrep, built from source in a new GitHub action. After now confirming the image has been published successfully, this PR now uses this image to include the built-from-source Semgrep wheel in the final docker image for Macaron using multistage Docker builds.

There were some necessary changes to the Semgrep image made in this PR. The name of the `.whl` file must be maintained from the build inside the docker container for `pip` to use it properly, so this was updated and changed. 

Inside the final docker build, `Dockerfile.final`, this wheel is now copied into the image and used to install Semgrep. Note that, since Semgrep is part of Macaron's python dependencies, we uninstall the version that is installed by default into the image, which I have confirmed removes the binaries. 

## Checklist
- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
