### PR TITLE
chore: add small fixes

### DIFF
--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -55,6 +55,12 @@ class DepsDevRepoFinder(BaseRepoFinder):
         tuple[str, RepoFinderOutcome] :
             A tuple of the found URL (or an empty string), and the outcome of the Repo Finder.
         """
+        if not purl.version:
+            latest_purl, outcome = self.get_latest_version(purl)
+            if not latest_purl:
+                return "", outcome
+            purl = latest_purl
+
         try:
             json_data = DepsDevService.get_package_info(str(purl))
         except APIAccessError:

--- a/src/macaron/repo_finder/repo_finder_deps_dev.py
+++ b/src/macaron/repo_finder/repo_finder_deps_dev.py
@@ -189,7 +189,7 @@ class DepsDevRepoFinder(BaseRepoFinder):
 
         # Example of a PURL endpoint for deps.dev with '/' encoded as '%2F':
         # https://api.deps.dev/v3alpha/purl/pkg:npm%2F@sigstore%2Fmock@0.7.5
-        purl_endpoint = DepsDevService().get_purl_endpoint(purl)
+        purl_endpoint = DepsDevService.get_purl_endpoint(purl)
         target_url = urllib.parse.urlunsplit(purl_endpoint)
 
         result = send_get_http(target_url, headers={})

--- a/src/macaron/repo_finder/repo_finder_pypi.py
+++ b/src/macaron/repo_finder/repo_finder_pypi.py
@@ -61,7 +61,7 @@ def find_repo(
             if not isinstance(existing_asset, PyPIPackageJsonAsset):
                 continue
 
-            if existing_asset.component_name == purl.name and existing_asset.component_version == purl.version:
+            if existing_asset.component_name == purl.name:
                 pypi_asset = existing_asset
                 from_metadata = True
                 break


### PR DESCRIPTION
## Summary
<!-- Briefly summarize the purpose and scope of this PR. -->
This PR includes some small fixes found during a set of recent experiments.

## Description of changes
<!-- Provide a detailed explanation of the changes made in this PR, why they were needed, and how they address the issue(s). -->
Fixes:

- Assets stored within the PyPI registry metadata should only be compared via name, not version as well
- The deps.dev purl endpoint function does not need the class to be instantiated first
- The deps.dev repo finder should retrieve the latest version for purls with no version