### PR TITLE
fix(pypi): update get_maintainers_of_package to avoid request blocking

### DIFF
--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -320,11 +320,10 @@ class PyPIRegistry(PackageRegistry):
         str | None
             The package main page.
         """
-        url = os.path.join(self.registry_url, "project", package_name)
+        url = f"https://pypi.org/project/{package_name}/"
         response = send_get_http_raw(url)
         if response:
-            html_snippets = response.content.decode("utf-8")
-            return html_snippets
+            return response.text
         return None
 
     def get_maintainers_of_package(self, package_name: str) -> list | None:

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -320,10 +320,12 @@ class PyPIRegistry(PackageRegistry):
         str | None
             The package main page.
         """
-        url = f"https://pypi.org/project/{package_name}/"
+        # Important: trailing '/' avoids JS-based redirect; ensures Macaron can access the page directly
+        url = urllib.parse.urljoin(self.registry_url, f"project/{package_name}/")
         response = send_get_http_raw(url)
         if response:
-            return response.text
+            html_snippets = response.content.decode("utf-8")
+            return html_snippets
         return None
 
     def get_maintainers_of_package(self, package_name: str) -> list | None:
@@ -359,7 +361,8 @@ class PyPIRegistry(PackageRegistry):
         str | None
             The profile page.
         """
-        url = os.path.join(self.registry_url, "user", username)
+        # Important: trailing '/' avoids JS-based redirect; ensures Macaron can access the page directly
+        url = urllib.parse.urljoin(self.registry_url, f"user/{username}/")
         response = send_get_http_raw(url, headers=None)
         if response:
             html_snippets = response.content.decode("utf-8")


### PR DESCRIPTION
## Summary
<!-- Briefly summarize the purpose and scope of this PR. -->
This PR improves the functionality of the pypi_registry.py by enhancing the reliability of requests made to the PyPI registry.

## Description of changes
<!-- Provide a detailed explanation of the changes made in this PR, why they were needed, and how they address the issue(s). -->
- Replaced the dynamic URL construction with a hardcoded PyPI project URL to avoid issues with incorrect joins and ensure consistent access

## Related issues
<!-- List any related issue(s) this PR addresses, e.g., `Closes #123`, `Fixes #456`. -->

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [X] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [X] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [X] My commits include the "Signed-off-by" line.
- [X] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [X] I have updated the relevant documentation, if applicable.
- [X] I have tested my changes and verified they work as expected.
