### PR TITLE
docs: include source code analysis subsection in malicious package tutorial

### DIFF
--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -84,6 +84,9 @@ Options
 
     Allow the analysis to attempt to verify provenance files as part of its normal operations.
 
+.. option:: --force-analyze-source
+
+    Forces PyPI sourcecode analysis to run regardless of other heuristic results.
 
 -----------
 Environment

--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -86,7 +86,11 @@ Options
 
 .. option:: --force-analyze-source
 
-    Forces PyPI sourcecode analysis to run regardless of other heuristic results.
+    Forces PyPI sourcecode analysis to run regardless of other heuristic results. Requires '--analyze-source'.
+
+.. option:: --analyze-source
+
+    For improved malware detection, analyze the source code of the (PyPI) package using a textual scan and dataflow analysis.
 
 -----------
 Environment

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -232,6 +232,21 @@ Macaron also provides a confidence score for each check result, represented as a
       is_component(component_id, purl),
       match("pkg:pypi/django@.*", purl).
 
+''''''''''''''''''''
+Source Code Analysis
+''''''''''''''''''''
+
+Macaron supports static code analysis as a malware analysis heuristic. This can be enabled by supplying the command line argument ``--analyze-source``. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Currently supported are detection of attempts to obfuscate the source code, and detection of code that exfiltrates sensitive data to a remote connection.
+
+By default, the source code analyzer is run in conjunction with the other metadata heuristics. The source code heuristic is optimised such that it is not always required to be run to ensure a package is benign, so it will not always be run as part of the heuristic analysis, even when enabled. To force it to run regardless of the result of other heuristics, the command line argument ``--force-analyze-source`` must be supplied. To analyze ``django@5.0.6`` with source code analysis enabled and enforced, the following command may be run:
+
+.. code-block:: shell
+
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --analyze-source --force-analyze-source
+
+If any suspicious patterns are triggered, this will be identified in the ``mcn_detect_malicious_metadata_1`` result for the heuristic named ``suspicious_patterns``. The output database ``output/macaron.db`` can be used to get the specific results of the analysis by querying the :class:`detect_malicious_metadata_check.result field <macaron.database>`. This will provide detailed JSON information about all data collected by the ``mcn_detect_malicious_metadata_1`` check, including, for source code analysis, any malicious code patterns detected, what Semgrep rule detected it, the file in which it was detected, and the line number for the detection.
+
+
 ***********
 Future Work
 ***********

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -126,6 +126,8 @@ Note that the ``match`` constraint applies a regex pattern and can be expanded t
 Source Code Analysis
 ''''''''''''''''''''
 
+.. note:: This is a new feature recently added to Macaron in 2025.
+
 Macaron supports static code analysis as a malware analysis heuristic. This can be enabled by supplying the command line argument ``--analyze-source``. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Example detection patterns include identifying attempts to obfuscate source code and detecting code that exfiltrates sensitive data to remote connections.
 
 By default, the source code analyzer is run in conjunction with the other metadata heuristics. The source code heuristic is optimised such that it is not always required to be run to ensure a package is benign, so it will not always be run as part of the heuristic analysis, even when enabled. To force it to run regardless of the result of other heuristics, the command line argument ``--force-analyze-source`` must be supplied. To analyze ``django@5.0.6`` with source code analysis enabled and enforced, the following command may be run:

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -126,7 +126,7 @@ Note that the ``match`` constraint applies a regex pattern and can be expanded t
 Source Code Analysis
 ''''''''''''''''''''
 
-.. note:: This is a new feature recently added to Macaron in 2025.
+.. note:: This is a new feature recently added to Macaron.
 
 Macaron supports static code analysis as a malware analysis heuristic. This can be enabled by supplying the command line argument ``--analyze-source``. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Example detection patterns include identifying attempts to obfuscate source code and detecting code that exfiltrates sensitive data to remote connections.
 

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -122,6 +122,20 @@ Note that the ``match`` constraint applies a regex pattern and can be expanded t
       is_component(component_id, purl),
       match("pkg:pypi.*", purl).
 
+''''''''''''''''''''
+Source Code Analysis
+''''''''''''''''''''
+
+Macaron supports static code analysis as a malware analysis heuristic. This can be enabled by supplying the command line argument ``--analyze-source``. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Example detection patterns include identifying attempts to obfuscate source code and detecting code that exfiltrates sensitive data to remote connections.
+
+By default, the source code analyzer is run in conjunction with the other metadata heuristics. The source code heuristic is optimised such that it is not always required to be run to ensure a package is benign, so it will not always be run as part of the heuristic analysis, even when enabled. To force it to run regardless of the result of other heuristics, the command line argument ``--force-analyze-source`` must be supplied. To analyze ``django@5.0.6`` with source code analysis enabled and enforced, the following command may be run:
+
+.. code-block:: shell
+
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --analyze-source --force-analyze-source
+
+If any suspicious patterns are triggered, this will be identified in the ``mcn_detect_malicious_metadata_1`` result for the heuristic named ``suspicious_patterns``. The output database ``output/macaron.db`` can be used to get the specific results of the analysis by querying the :class:`detect_malicious_metadata_check.result field <macaron.database>`. This will provide detailed JSON information about all data collected by the ``mcn_detect_malicious_metadata_1`` check, including, for source code analysis, any malicious code patterns detected, what Semgrep rule detected it, the file in which it was detected, and the line number for the detection.
+
 +++++++++++++++++++++++++++++++++++++++
 Verification Summary Attestation report
 +++++++++++++++++++++++++++++++++++++++
@@ -231,21 +245,6 @@ Macaron also provides a confidence score for each check result, represented as a
   apply_policy_to("check-dependencies", component_id) :-
       is_component(component_id, purl),
       match("pkg:pypi/django@.*", purl).
-
-''''''''''''''''''''
-Source Code Analysis
-''''''''''''''''''''
-
-Macaron supports static code analysis as a malware analysis heuristic. This can be enabled by supplying the command line argument ``--analyze-source``. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Currently supported are detection of attempts to obfuscate the source code, and detection of code that exfiltrates sensitive data to a remote connection.
-
-By default, the source code analyzer is run in conjunction with the other metadata heuristics. The source code heuristic is optimised such that it is not always required to be run to ensure a package is benign, so it will not always be run as part of the heuristic analysis, even when enabled. To force it to run regardless of the result of other heuristics, the command line argument ``--force-analyze-source`` must be supplied. To analyze ``django@5.0.6`` with source code analysis enabled and enforced, the following command may be run:
-
-.. code-block:: shell
-
-  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --analyze-source --force-analyze-source
-
-If any suspicious patterns are triggered, this will be identified in the ``mcn_detect_malicious_metadata_1`` result for the heuristic named ``suspicious_patterns``. The output database ``output/macaron.db`` can be used to get the specific results of the analysis by querying the :class:`detect_malicious_metadata_check.result field <macaron.database>`. This will provide detailed JSON information about all data collected by the ``mcn_detect_malicious_metadata_1`` check, including, for source code analysis, any malicious code patterns detected, what Semgrep rule detected it, the file in which it was detected, and the line number for the detection.
-
 
 ***********
 Future Work


### PR DESCRIPTION
## Summary
This PR follows on from #965 by including a write-up explanation of how to use the source code analysis component of Macaron.

## Description of changes
A source code analysis subsection has been added to `detect_malicious_package.rst` explaining at a high level how to use the source code analysis capability introduced by #965, in line with the included components into the tutorial's integration test (`tests/integration/cases/django_with_dep_resolution_virtual_env_as_input`) for source code analysis.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
