### PR TITLE
fix: include inspector links with information on if they are reachable.

### DIFF
--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/wheel_absence.py
@@ -70,7 +70,8 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
                 logger.debug(error_msg)
                 raise HeuristicAnalyzerValueError(error_msg)
 
-        inspector_links: list[JsonType] = []
+        # Contains a boolean field identifying if the link is reachable by this Macaron instance or not.
+        inspector_links: dict[str, JsonType] = {}
         wheel_present: bool = False
 
         release_distributions = json_extract(releases, [version], list)
@@ -120,10 +121,9 @@ class WheelAbsenceAnalyzer(BaseHeuristicAnalyzer):
             )
 
             # use a head request because we don't care about the response contents
-            if send_head_http_raw(inspector_link) is None:
-                inspector_links.append(None)
-            else:
-                inspector_links.append(inspector_link)
+            inspector_links[inspector_link] = False
+            if send_head_http_raw(inspector_link):
+                inspector_links[inspector_link] = True  # link was reachable
 
         detail_info: dict[str, JsonType] = {
             "inspector_links": inspector_links,

--- a/tests/malware_analyzer/pypi/test_wheel_absence.py
+++ b/tests/malware_analyzer/pypi/test_wheel_absence.py
@@ -75,7 +75,7 @@ def test_analyze_tar_present(mock_send_head_http_raw: MagicMock, pypi_package_js
     mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
 
     expected_detail_info = {
-        "inspector_links": [inspector_link_expected],
+        "inspector_links": {inspector_link_expected: True},
     }
 
     expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.FAIL, expected_detail_info)
@@ -134,7 +134,7 @@ def test_analyze_whl_present(mock_send_head_http_raw: MagicMock, pypi_package_js
     mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
 
     expected_detail_info = {
-        "inspector_links": [inspector_link_expected],
+        "inspector_links": {inspector_link_expected: True},
     }
 
     expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.PASS, expected_detail_info)
@@ -222,7 +222,7 @@ def test_analyze_both_present(mock_send_head_http_raw: MagicMock, pypi_package_j
     mock_send_head_http_raw.return_value = MagicMock()  # assume valid URL for testing purposes
 
     expected_detail_info = {
-        "inspector_links": [wheel_link_expected, tar_link_expected],
+        "inspector_links": {wheel_link_expected: True, tar_link_expected: True},
     }
 
     expected_result: tuple[HeuristicResult, dict] = (HeuristicResult.PASS, expected_detail_info)


### PR DESCRIPTION
## Summary
`wheel_absence.py` now include inspector links regardless of if they are reachable or not in its detail information, along with a boolean for each identifying if it is reachable.

## Description of changes
Recently team members have had some troubles accessing PyPI inspector, and as a result observing that after running Macaron analysis, the inspector links are not provided in the output. To ensure the links are still available in the results, this PR now changes the detail information returned by `wheel_absence.py` to include the inspector links regardless of whether they are reachable or not. It also then include a boolean value identifying if it was reachable by that Macaron instance.

## Checklist

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
