### PR TITLE
refactor: run source code analysis by default

### DIFF
--- a/docs/source/pages/cli_usage/command_analyze.rst
+++ b/docs/source/pages/cli_usage/command_analyze.rst
@@ -86,11 +86,7 @@ Options
 
 .. option:: --force-analyze-source
 
-    Forces PyPI sourcecode analysis to run regardless of other heuristic results. Requires '--analyze-source'.
-
-.. option:: --analyze-source
-
-    For improved malware detection, analyze the source code of the (PyPI) package using a textual scan and dataflow analysis.
+    Forces PyPI sourcecode analysis to run regardless of other heuristic results.
 
 -----------
 Environment

--- a/docs/source/pages/developers_guide/apidoc/macaron.code_analyzer.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.code_analyzer.rst
@@ -3,8 +3,8 @@ macaron.code\_analyzer package
 
 .. automodule:: macaron.code_analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,5 +14,5 @@ macaron.code\_analyzer.call\_graph module
 
 .. automodule:: macaron.code_analyzer.call_graph
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.config.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.config.rst
@@ -3,8 +3,8 @@ macaron.config package
 
 .. automodule:: macaron.config
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,21 +14,21 @@ macaron.config.defaults module
 
 .. automodule:: macaron.config.defaults
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.config.global\_config module
 ------------------------------------
 
 .. automodule:: macaron.config.global_config
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.config.target\_config module
 ------------------------------------
 
 .. automodule:: macaron.config.target_config
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.database.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.database.rst
@@ -3,8 +3,8 @@ macaron.database package
 
 .. automodule:: macaron.database
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,29 +14,29 @@ macaron.database.database\_manager module
 
 .. automodule:: macaron.database.database_manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.database.db\_custom\_types module
 -----------------------------------------
 
 .. automodule:: macaron.database.db_custom_types
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.database.table\_definitions module
 ------------------------------------------
 
 .. automodule:: macaron.database.table_definitions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.database.views module
 -----------------------------
 
 .. automodule:: macaron.database.views
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.dependency_analyzer.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.dependency_analyzer.rst
@@ -3,8 +3,8 @@ macaron.dependency\_analyzer package
 
 .. automodule:: macaron.dependency_analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,29 +14,29 @@ macaron.dependency\_analyzer.cyclonedx module
 
 .. automodule:: macaron.dependency_analyzer.cyclonedx
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.dependency\_analyzer.cyclonedx\_gradle module
 -----------------------------------------------------
 
 .. automodule:: macaron.dependency_analyzer.cyclonedx_gradle
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.dependency\_analyzer.cyclonedx\_mvn module
 --------------------------------------------------
 
 .. automodule:: macaron.dependency_analyzer.cyclonedx_mvn
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.dependency\_analyzer.cyclonedx\_python module
 -----------------------------------------------------
 
 .. automodule:: macaron.dependency_analyzer.cyclonedx_python
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.metadata.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.metadata.rst
@@ -3,8 +3,8 @@ macaron.malware\_analyzer.pypi\_heuristics.metadata package
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,61 +14,69 @@ macaron.malware\_analyzer.pypi\_heuristics.metadata.anomalous\_version module
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.anomalous_version
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.closer\_release\_join\_date module
 --------------------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.closer_release_join_date
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.empty\_project\_link module
 -------------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.empty_project_link
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.high\_release\_frequency module
 -----------------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.high_release_frequency
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.one\_release module
 -----------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.one_release
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.source\_code\_repo module
 -----------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.source_code_repo
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
+
+macaron.malware\_analyzer.pypi\_heuristics.metadata.typosquatting\_presence module
+----------------------------------------------------------------------------------
+
+.. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.typosquatting_presence
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.unchanged\_release module
 -----------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.unchanged_release
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.metadata.wheel\_absence module
 -------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.metadata.wheel_absence
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.rst
@@ -3,8 +3,8 @@ macaron.malware\_analyzer.pypi\_heuristics package
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -23,13 +23,13 @@ macaron.malware\_analyzer.pypi\_heuristics.base\_analyzer module
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.base_analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.heuristics module
 ------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.heuristics
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.sourcecode.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.pypi_heuristics.sourcecode.rst
@@ -3,8 +3,8 @@ macaron.malware\_analyzer.pypi\_heuristics.sourcecode package
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.sourcecode
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,13 +14,13 @@ macaron.malware\_analyzer.pypi\_heuristics.sourcecode.pypi\_sourcecode\_analyzer
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.sourcecode.pypi_sourcecode_analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.malware\_analyzer.pypi\_heuristics.sourcecode.suspicious\_setup module
 ------------------------------------------------------------------------------
 
 .. automodule:: macaron.malware_analyzer.pypi_heuristics.sourcecode.suspicious_setup
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.malware_analyzer.rst
@@ -3,8 +3,8 @@ macaron.malware\_analyzer package
 
 .. automodule:: macaron.malware_analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -22,5 +22,5 @@ macaron.malware\_analyzer.datetime\_parser module
 
 .. automodule:: macaron.malware_analyzer.datetime_parser
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.output_reporter.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.output_reporter.rst
@@ -3,8 +3,8 @@ macaron.output\_reporter package
 
 .. automodule:: macaron.output_reporter
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,29 +14,29 @@ macaron.output\_reporter.jinja2\_extensions module
 
 .. automodule:: macaron.output_reporter.jinja2_extensions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.output\_reporter.reporter module
 ----------------------------------------
 
 .. automodule:: macaron.output_reporter.reporter
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.output\_reporter.results module
 ---------------------------------------
 
 .. automodule:: macaron.output_reporter.results
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.output\_reporter.scm module
 -----------------------------------
 
 .. automodule:: macaron.output_reporter.scm
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.parsers.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.parsers.rst
@@ -3,8 +3,8 @@ macaron.parsers package
 
 .. automodule:: macaron.parsers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -22,29 +22,29 @@ macaron.parsers.actionparser module
 
 .. automodule:: macaron.parsers.actionparser
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.parsers.bashparser module
 ---------------------------------
 
 .. automodule:: macaron.parsers.bashparser
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.parsers.github\_workflow\_model module
 ----------------------------------------------
 
 .. automodule:: macaron.parsers.github_workflow_model
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.parsers.pomparser module
 --------------------------------
 
 .. automodule:: macaron.parsers.pomparser
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.parsers.yaml.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.parsers.yaml.rst
@@ -3,8 +3,8 @@ macaron.parsers.yaml package
 
 .. automodule:: macaron.parsers.yaml
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,5 +14,5 @@ macaron.parsers.yaml.loader module
 
 .. automodule:: macaron.parsers.yaml.loader
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.policy_engine.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.policy_engine.rst
@@ -3,8 +3,8 @@ macaron.policy\_engine package
 
 .. automodule:: macaron.policy_engine
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,21 +14,21 @@ macaron.policy\_engine.policy\_engine module
 
 .. automodule:: macaron.policy_engine.policy_engine
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.policy\_engine.souffle module
 -------------------------------------
 
 .. automodule:: macaron.policy_engine.souffle
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.policy\_engine.souffle\_code\_generator module
 ------------------------------------------------------
 
 .. automodule:: macaron.policy_engine.souffle_code_generator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.provenance.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.provenance.rst
@@ -3,8 +3,8 @@ macaron.provenance package
 
 .. automodule:: macaron.provenance
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,21 +14,21 @@ macaron.provenance.provenance\_extractor module
 
 .. automodule:: macaron.provenance.provenance_extractor
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.provenance.provenance\_finder module
 --------------------------------------------
 
 .. automodule:: macaron.provenance.provenance_finder
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.provenance.provenance\_verifier module
 ----------------------------------------------
 
 .. automodule:: macaron.provenance.provenance_verifier
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.repo_finder.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.repo_finder.rst
@@ -3,8 +3,8 @@ macaron.repo\_finder package
 
 .. automodule:: macaron.repo_finder
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,61 +14,69 @@ macaron.repo\_finder.commit\_finder module
 
 .. automodule:: macaron.repo_finder.commit_finder
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_finder module
 ----------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_finder
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_finder\_base module
 ----------------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_finder_base
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_finder\_deps\_dev module
 ---------------------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_finder_deps_dev
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_finder\_enums module
 -----------------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_finder_enums
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_finder\_java module
 ----------------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_finder_java
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
+
+macaron.repo\_finder.repo\_finder\_pypi module
+----------------------------------------------
+
+.. automodule:: macaron.repo_finder.repo_finder_pypi
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_utils module
 ---------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_utils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_finder.repo\_validator module
 -------------------------------------------
 
 .. automodule:: macaron.repo_finder.repo_validator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.repo_verifier.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.repo_verifier.rst
@@ -3,8 +3,8 @@ macaron.repo\_verifier package
 
 .. automodule:: macaron.repo_verifier
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,29 +14,29 @@ macaron.repo\_verifier.repo\_verifier module
 
 .. automodule:: macaron.repo_verifier.repo_verifier
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_verifier.repo\_verifier\_base module
 --------------------------------------------------
 
 .. automodule:: macaron.repo_verifier.repo_verifier_base
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_verifier.repo\_verifier\_gradle module
 ----------------------------------------------------
 
 .. automodule:: macaron.repo_verifier.repo_verifier_gradle
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.repo\_verifier.repo\_verifier\_maven module
 ---------------------------------------------------
 
 .. automodule:: macaron.repo_verifier.repo_verifier_maven
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.rst
@@ -3,8 +3,8 @@ macaron package
 
 .. automodule:: macaron
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -34,29 +34,29 @@ macaron.environment\_variables module
 
 .. automodule:: macaron.environment_variables
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.errors module
 ---------------------
 
 .. automodule:: macaron.errors
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.json\_tools module
 --------------------------
 
 .. automodule:: macaron.json_tools
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.util module
 -------------------
 
 .. automodule:: macaron.util
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.asset.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.asset.rst
@@ -3,5 +3,5 @@ macaron.slsa\_analyzer.asset package
 
 .. automodule:: macaron.slsa_analyzer.asset
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.build_tool.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.build_tool.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.build\_tool package
 
 .. automodule:: macaron.slsa_analyzer.build_tool
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,77 +14,77 @@ macaron.slsa\_analyzer.build\_tool.base\_build\_tool module
 
 .. automodule:: macaron.slsa_analyzer.build_tool.base_build_tool
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.docker module
 ------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.docker
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.go module
 --------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.go
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.gradle module
 ------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.gradle
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.language module
 --------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.language
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.maven module
 -----------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.maven
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.npm module
 ---------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.npm
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.pip module
 ---------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.pip
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.poetry module
 ------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.poetry
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.build\_tool.yarn module
 ----------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.build_tool.yarn
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.checks.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.checks.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.checks package
 
 .. automodule:: macaron.slsa_analyzer.checks
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,133 +14,141 @@ macaron.slsa\_analyzer.checks.base\_check module
 
 .. automodule:: macaron.slsa_analyzer.checks.base_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.build\_as\_code\_check module
 -----------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.build_as_code_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.build\_script\_check module
 ---------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.build_script_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.build\_service\_check module
 ----------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.build_service_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.build\_tool\_check module
 -------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.build_tool_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.check\_result module
 --------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.check_result
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.detect\_malicious\_metadata\_check module
 -----------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.detect_malicious_metadata_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
+
+macaron.slsa\_analyzer.checks.github\_actions\_vulnerability\_check module
+--------------------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.checks.github_actions_vulnerability_check
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.infer\_artifact\_pipeline\_check module
 ---------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.infer_artifact_pipeline_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.provenance\_available\_check module
 -----------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_available_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.provenance\_commit\_check module
 --------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_commit_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.provenance\_l3\_content\_check module
 -------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_l3_content_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.provenance\_repo\_check module
 ------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_repo_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.provenance\_verified\_check module
 ----------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_verified_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.provenance\_witness\_l1\_check module
 -------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.provenance_witness_l1_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.scm\_authenticity\_check module
 -------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.scm_authenticity_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.trusted\_builder\_l3\_check module
 ----------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.trusted_builder_l3_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.checks.vcs\_check module
 -----------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.checks.vcs_check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.ci_service.github_actions.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.ci_service.github_actions.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.ci\_service.github\_actions package
 
 .. automodule:: macaron.slsa_analyzer.ci_service.github_actions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,13 +14,13 @@ macaron.slsa\_analyzer.ci\_service.github\_actions.analyzer module
 
 .. automodule:: macaron.slsa_analyzer.ci_service.github_actions.analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.ci\_service.github\_actions.github\_actions\_ci module
 -----------------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.ci_service.github_actions.github_actions_ci
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.ci_service.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.ci_service.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.ci\_service package
 
 .. automodule:: macaron.slsa_analyzer.ci_service
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -22,37 +22,37 @@ macaron.slsa\_analyzer.ci\_service.base\_ci\_service module
 
 .. automodule:: macaron.slsa_analyzer.ci_service.base_ci_service
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.ci\_service.circleci module
 --------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.ci_service.circleci
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.ci\_service.gitlab\_ci module
 ----------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.ci_service.gitlab_ci
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.ci\_service.jenkins module
 -------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.ci_service.jenkins
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.ci\_service.travis module
 ------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.ci_service.travis
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.git_service.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.git_service.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.git\_service package
 
 .. automodule:: macaron.slsa_analyzer.git_service
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,45 +14,45 @@ macaron.slsa\_analyzer.git\_service.api\_client module
 
 .. automodule:: macaron.slsa_analyzer.git_service.api_client
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.git\_service.base\_git\_service module
 -------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.git_service.base_git_service
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.git\_service.bitbucket module
 ----------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.git_service.bitbucket
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.git\_service.github module
 -------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.git_service.github
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.git\_service.gitlab module
 -------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.git_service.gitlab
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.git\_service.local\_repo\_git\_service module
 --------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.git_service.local_repo_git_service
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.expectations.cue.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.expectations.cue.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.provenance.expectations.cue package
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.cue
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,5 +14,5 @@ macaron.slsa\_analyzer.provenance.expectations.cue.cue\_validator module
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.cue.cue_validator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.expectations.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.expectations.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.provenance.expectations package
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -22,13 +22,13 @@ macaron.slsa\_analyzer.provenance.expectations.expectation module
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.expectation
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.provenance.expectations.expectation\_registry module
 ---------------------------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.provenance.expectations.expectation_registry
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.intoto.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.intoto.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.provenance.intoto package
 
 .. automodule:: macaron.slsa_analyzer.provenance.intoto
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -23,5 +23,5 @@ macaron.slsa\_analyzer.provenance.intoto.errors module
 
 .. automodule:: macaron.slsa_analyzer.provenance.intoto.errors
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.intoto.v01.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.intoto.v01.rst
@@ -3,5 +3,5 @@ macaron.slsa\_analyzer.provenance.intoto.v01 package
 
 .. automodule:: macaron.slsa_analyzer.provenance.intoto.v01
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.intoto.v1.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.intoto.v1.rst
@@ -3,5 +3,5 @@ macaron.slsa\_analyzer.provenance.intoto.v1 package
 
 .. automodule:: macaron.slsa_analyzer.provenance.intoto.v1
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.provenance package
 
 .. automodule:: macaron.slsa_analyzer.provenance
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -25,13 +25,13 @@ macaron.slsa\_analyzer.provenance.loader module
 
 .. automodule:: macaron.slsa_analyzer.provenance.loader
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.provenance.provenance module
 ---------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.provenance.provenance
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.slsa.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.slsa.rst
@@ -3,5 +3,5 @@ macaron.slsa\_analyzer.provenance.slsa package
 
 .. automodule:: macaron.slsa_analyzer.provenance.slsa
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.witness.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.provenance.witness.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.provenance.witness package
 
 .. automodule:: macaron.slsa_analyzer.provenance.witness
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,5 +14,5 @@ macaron.slsa\_analyzer.provenance.witness.attestor module
 
 .. automodule:: macaron.slsa_analyzer.provenance.witness.attestor
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer package
 
 .. automodule:: macaron.slsa_analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -29,53 +29,53 @@ macaron.slsa\_analyzer.analyze\_context module
 
 .. automodule:: macaron.slsa_analyzer.analyze_context
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.analyzer module
 --------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.analyzer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.database\_store module
 ---------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.database_store
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.git\_url module
 --------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.git_url
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.levels module
 ------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.levels
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.registry module
 --------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.registry
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.slsa\_req module
 ---------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.slsa_req
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.specs.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.slsa_analyzer.specs.rst
@@ -3,8 +3,8 @@ macaron.slsa\_analyzer.specs package
 
 .. automodule:: macaron.slsa_analyzer.specs
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,29 +14,37 @@ macaron.slsa\_analyzer.specs.build\_spec module
 
 .. automodule:: macaron.slsa_analyzer.specs.build_spec
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.specs.ci\_spec module
 --------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.specs.ci_spec
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.specs.inferred\_provenance module
 --------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.specs.inferred_provenance
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 macaron.slsa\_analyzer.specs.package\_registry\_spec module
 -----------------------------------------------------------
 
 .. automodule:: macaron.slsa_analyzer.specs.package_registry_spec
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
+
+macaron.slsa\_analyzer.specs.pypi\_certificate\_predicate module
+----------------------------------------------------------------
+
+.. automodule:: macaron.slsa_analyzer.specs.pypi_certificate_predicate
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/developers_guide/apidoc/macaron.vsa.rst
+++ b/docs/source/pages/developers_guide/apidoc/macaron.vsa.rst
@@ -3,8 +3,8 @@ macaron.vsa package
 
 .. automodule:: macaron.vsa
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Submodules
 ----------
@@ -14,5 +14,5 @@ macaron.vsa.vsa module
 
 .. automodule:: macaron.vsa.vsa
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -128,13 +128,13 @@ Source Code Analysis
 
 .. note:: This is a new feature recently added to Macaron.
 
-Macaron supports static code analysis as a malware analysis heuristic. This can be enabled by supplying the command line argument ``--analyze-source``. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Example detection patterns include identifying attempts to obfuscate source code and detecting code that exfiltrates sensitive data to remote connections.
+Macaron supports static code analysis as a malware analysis heuristic. Macaron uses the open-source static code analysis tool Semgrep to analyse the source code of a python package, looking for malicious code patterns defined in Macaron's own Semgrep rules. Example detection patterns include identifying attempts to obfuscate source code and detecting code that exfiltrates sensitive data to remote connections.
 
 By default, the source code analyzer is run in conjunction with the other metadata heuristics. The source code heuristic is optimised such that it is not always required to be run to ensure a package is benign, so it will not always be run as part of the heuristic analysis, even when enabled. To force it to run regardless of the result of other heuristics, the command line argument ``--force-analyze-source`` must be supplied. To analyze ``django@5.0.6`` with source code analysis enabled and enforced, the following command may be run:
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --analyze-source --force-analyze-source
+  ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --force-analyze-source
 
 If any suspicious patterns are triggered, this will be identified in the ``mcn_detect_malicious_metadata_1`` result for the heuristic named ``suspicious_patterns``. The output database ``output/macaron.db`` can be used to get the specific results of the analysis by querying the :class:`detect_malicious_metadata_check.result field <macaron.database>`. This will provide detailed JSON information about all data collected by the ``mcn_detect_malicious_metadata_1`` check, including, for source code analysis, any malicious code patterns detected, what Semgrep rule detected it, the file in which it was detected, and the line number for the detection.
 

--- a/src/macaron/__main__.py
+++ b/src/macaron/__main__.py
@@ -96,10 +96,6 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
 
         global_config.local_maven_repo = user_provided_local_maven_repo
 
-    if analyzer_single_args.force_analyze_source and not analyzer_single_args.analyze_source:
-        logger.error("'--force-analyze-source' requires '--analyze-source'.")
-        sys.exit(os.EX_USAGE)
-
     analyzer = Analyzer(global_config.output_path, global_config.build_log_path)
 
     # Initiate reporters.
@@ -177,7 +173,6 @@ def analyze_slsa_levels_single(analyzer_single_args: argparse.Namespace) -> None
         deps_depth,
         provenance_payload=prov_payload,
         verify_provenance=analyzer_single_args.verify_provenance,
-        analyze_source=analyzer_single_args.analyze_source,
         force_analyze_source=analyzer_single_args.force_analyze_source,
     )
     sys.exit(status_code)
@@ -482,22 +477,10 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     single_analyze_parser.add_argument(
-        "--analyze-source",
-        required=False,
-        action="store_true",
-        help=(
-            "For improved malware detection, analyze the source code of the"
-            + " (PyPI) package using a textual scan and dataflow analysis."
-        ),
-    )
-
-    single_analyze_parser.add_argument(
         "--force-analyze-source",
         required=False,
         action="store_true",
-        help=(
-            "Forces PyPI sourcecode analysis to run regardless of other heuristic results. Requires '--analyze-source'."
-        ),
+        help=("Forces PyPI sourcecode analysis to run regardless of other heuristic results."),
     )
 
     single_analyze_parser.add_argument(

--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -57,13 +57,10 @@ When a heuristic fails, with `HeuristicResult.FAIL`, then that is an indicator b
     - **Rule**: Return `HeuristicResult.FAIL` if the similarity ratio between the package name and any popular package name meets or exceeds a defined threshold; otherwise, return `HeuristicResult.PASS`.
     - **Dependency**: None.
 ### Source Code Analysis with Semgrep
-
-The following analyzer has been included as an optional feature, available by supplying `--analyze-source` in the CLI to `macaron analyze`:
-
 **PyPI Source Code Analyzer**
 - **Description**: Uses Semgrep, with default rules written in `src/macaron/resources/pypi_malware_rules` and custom rules available by supplying a path to `custom_semgrep_rules` in `defaults.ini`, to scan the package `.tar` source code.
 - **Rule**: If any Semgrep rule is triggered, the heuristic fails with `HeuristicResult.FAIL` and subsequently fails the package with `CheckResultType.FAILED`. If no rule is triggered, the heuristic passes with `HeuristicResult.PASS` and the `CheckResultType` result from the combination of all other heuristics is maintained.
-- **Dependency**: Will be run if the Source Code Repo fails. This dependency can be bypassed by suppying `--force-analyze-source` in the CLI, along with `--analyze-source`.
+- **Dependency**: Will be run if the Source Code Repo fails. This dependency can be bypassed by suppying `--force-analyze-source` in the CLI.
 
 This feature is currently a work in progress, and supports detection of code obfuscation techniques and remote exfiltration behaviors. It uses Semgrep OSS for detection. `defaults.ini` may be used to provide custom rules and exclude them:
 - `disabled_default_rulesets`: supply to this a comma separated list of the names of default Semgrep rule files (excluding the `.yaml` extension) to disable all rule IDs in that file.

--- a/src/macaron/slsa_analyzer/analyze_context.py
+++ b/src/macaron/slsa_analyzer/analyze_context.py
@@ -51,8 +51,6 @@ class ChecksOutputs(TypedDict):
     """The provenance and related information."""
     local_artifact_paths: list[str]
     """The local artifact absolute paths."""
-    analyze_source: bool
-    """True when PyPI source code analysis has been enabled."""
     force_analyze_source: bool
     """When True, enforces running source code analysis, regardless of other heuristic results."""
 
@@ -108,7 +106,6 @@ class AnalyzeContext:
             expectation=None,
             provenance_info=None,
             local_artifact_paths=[],
-            analyze_source=False,
             force_analyze_source=False,
         )
 

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -148,7 +148,6 @@ class Analyzer:
         deps_depth: int = 0,
         provenance_payload: InTotoPayload | None = None,
         verify_provenance: bool = False,
-        analyze_source: bool = False,
         force_analyze_source: bool = False,
     ) -> int:
         """Run the analysis and write results to the output path.
@@ -168,8 +167,6 @@ class Analyzer:
             The provenance intoto payload for the main software component.
         verify_provenance: bool
             Enable provenance verification if True.
-        analyze_source : bool
-            When true, triggers source code analysis for PyPI packages. Defaults to False.
         force_analyze_source : bool
             When true, enforces running source code analysis regardless of other heuristic results. Defaults to False.
 
@@ -205,7 +202,6 @@ class Analyzer:
                     analysis,
                     provenance_payload=provenance_payload,
                     verify_provenance=verify_provenance,
-                    analyze_source=analyze_source,
                     force_analyze_source=force_analyze_source,
                 )
 
@@ -325,7 +321,6 @@ class Analyzer:
         existing_records: dict[str, Record] | None = None,
         provenance_payload: InTotoPayload | None = None,
         verify_provenance: bool = False,
-        analyze_source: bool = False,
         force_analyze_source: bool = False,
     ) -> Record:
         """Run the checks for a single repository target.
@@ -345,8 +340,6 @@ class Analyzer:
             The provenance intoto payload for the analyzed software component.
         verify_provenance: bool
             Enable provenance verification if True.
-        analyze_source : bool
-            When true, triggers source code analysis for PyPI packages. Defaults to False.
         force_analyze_source : bool
             When true, enforces running source code analysis regardless of other heuristic results. Defaults to False.
 
@@ -583,7 +576,6 @@ class Analyzer:
                 # TODO Add release digest.
             )
 
-        analyze_ctx.dynamic_data["analyze_source"] = analyze_source
         analyze_ctx.dynamic_data["force_analyze_source"] = force_analyze_source
 
         if local_artifact_dirs:

--- a/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/test.yaml
+++ b/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/test.yaml
@@ -79,7 +79,6 @@ steps:
     - pkg:pypi/django@5.0.6
     - --python-venv
     - ./django_venv
-    - --analyze-source
     - --force-analyze-source
 - name: Run macaron verify-policy to check the package was not marked as malicious.
   kind: verify

--- a/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
+++ b/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
@@ -26,7 +26,7 @@ RESOURCE_PATH = Path(__file__).parent.joinpath("resources")
 
 @patch("macaron.malware_analyzer.pypi_heuristics.sourcecode.pypi_sourcecode_analyzer.global_config")
 @pytest.mark.parametrize(
-    ("purl", "expected", "sourcecode_analysis"),
+    ("purl", "expected", "force_analyze_source"),
     [
         # TODO: This check is expected to FAIL for pkg:pypi/zlibxjson. However, after introducing the wheel presence
         # heuristic, a false negative has been introduced. Note that if the unit test were allowed to access the OSV
@@ -38,7 +38,10 @@ RESOURCE_PATH = Path(__file__).parent.joinpath("resources")
         # TODO: including source code analysis that detects flow from a remote point to a file write may assist in resolving
         # the issue of this false negative.
         pytest.param(
-            "pkg:pypi/zlibxjson", CheckResultType.PASSED, True, id="test_sourcecode_analysis_malicious_pypi_package"
+            "pkg:pypi/zlibxjson",
+            CheckResultType.PASSED,
+            True,
+            id="test_force_sourcecode_analysis_malicious_pypi_package",
         ),
     ],
 )
@@ -49,7 +52,7 @@ def test_detect_malicious_metadata(
     macaron_path: Path,
     purl: str,
     expected: str,
-    sourcecode_analysis: bool,
+    force_analyze_source: bool,
 ) -> None:
     """Test that the check handles repositories correctly."""
     check = DetectMaliciousMetadataCheck()
@@ -58,8 +61,7 @@ def test_detect_malicious_metadata(
     ctx = MockAnalyzeContext(macaron_path=macaron_path, output_dir="", purl=purl)
     pypi_registry = PyPIRegistry()
     ctx.dynamic_data["package_registries"] = [PackageRegistryInfo("pip", "pypi", pypi_registry)]
-    if sourcecode_analysis:
-        ctx.dynamic_data["force_analyze_source"] = True
+    ctx.dynamic_data["force_analyze_source"] = force_analyze_source
 
     mock_global_config.resources_path = os.path.join(MACARON_PATH, "resources")
 

--- a/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
+++ b/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
@@ -59,7 +59,7 @@ def test_detect_malicious_metadata(
     pypi_registry = PyPIRegistry()
     ctx.dynamic_data["package_registries"] = [PackageRegistryInfo("pip", "pypi", pypi_registry)]
     if sourcecode_analysis:
-        ctx.dynamic_data["analyze_source"] = True
+        ctx.dynamic_data["force_analyze_source"] = True
 
     mock_global_config.resources_path = os.path.join(MACARON_PATH, "resources")
 


### PR DESCRIPTION
## Summary
This PR removes the requirement for source code analysis to have `--analyze-source` to be enabled, making it a feature enabled by default. The `--force-analyze-source` option still exists and functions as expected.

## Description of changes
Modifications to the relevant files handling command line options have been made to remove `--analyze-source` as an option, and the `detect_malicious_metadata_check.py` has been rewritten to include the source code analysis feature by default. The test `test_detect_malicious_metadata_check.py` has been updated to reflect this.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
