### PR TITLE
chore(deps): update slsa-verifier to v2.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ setup-go:
 	go build -o $(PACKAGE_PATH)/bin/ $(REPO_PATH)/golang/cmd/...
 setup-binaries: $(PACKAGE_PATH)/bin/slsa-verifier $(PACKAGE_PATH)/resources/mvnw $(PACKAGE_PATH)/resources/gradlew souffle gnu-sed
 $(PACKAGE_PATH)/bin/slsa-verifier:
-	git clone --depth 1 https://github.com/slsa-framework/slsa-verifier.git -b v2.6.0
+	git clone --depth 1 https://github.com/slsa-framework/slsa-verifier.git -b v2.7.1
 	cd slsa-verifier/cli/slsa-verifier && go build -o $(PACKAGE_PATH)/bin/
 	cd $(REPO_PATH) && rm -rf slsa-verifier
 $(PACKAGE_PATH)/resources/mvnw:


### PR DESCRIPTION
## Summary
This PR updates slsa-verifier to [`v2.7.1`](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.7.1).