### PR TITLE
build: change release to semgrep from pypi instead of semgrep bfs

### DIFF
--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -11,8 +11,6 @@
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle/macaron-base
 # image for this build.
 
-FROM ghcr.io/oracle/macaron-deps:latest@sha256:99526baf6596c4c3f24e4caa2b59afaf7f7c26d633ad3113ca24ba43dfad3f0f as deps_stage
-
 FROM ghcr.io/oracle/macaron-base:latest@sha256:79b3b8b03cb9b6a124c6450f4baa58f96f83ee9e37f572c88a97597b35c7bc51
 
 ENV HOME="/home/macaron"
@@ -37,17 +35,11 @@ ARG WHEEL_PATH
 # the warning of not having correct ownership of /home/macaron is not raised.
 USER macaron:macaron
 COPY --chown=macaron:macaron $WHEEL_PATH $HOME/dist/
-# Currently, the only dependency stored in the minimal image is the wheel for Semgrep, which we copy here. Since the
-# Macaron project dependencies lists Semgrep as a python dependency, we uninstall it first before using our wheel here
-# to install a trusted built-from-source version.
-COPY --chown=macaron:macaron --from=deps_stage /semgrep-*manylinux*.whl $HOME/dist/
 RUN : \
     && python3 -m venv $HOME/.venv \
     && . .venv/bin/activate \
     && pip install --no-compile --no-cache-dir --upgrade pip setuptools \
     && find $HOME/dist -depth \( -type f \( -name "macaron-*.whl" \) \) -exec pip install --no-compile --no-cache-dir '{}' \; \
-    && pip uninstall semgrep -y \
-    && find $HOME/dist -depth \( -type f \( -name "semgrep-*.whl" \) \) -exec pip install --no-compile --no-cache-dir '{}' \; \
     && rm -rf $HOME/dist \
     && deactivate
 


### PR DESCRIPTION
## Summary
Semgrep version 1.113.0 has been approved for installing using `pip`. This is an easier and more streamlined way to install the dependency and is easier to maintain. This PR updates Macaron's release artifacts to use this method of installation instead of the previously developed build from source method.

## Description of changes
The final docker file now uses Semgrep from the requirements file instead of using the dependency artifact.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
