### PR TITLE
build: add flake8-print plugin and update pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -47,10 +47,13 @@ ignore = E203,E266,E501,W503,D105,D404,PT009
 # D107: Missing docstring in __init__
 # PT004: Fixture does not return anything, add leading underscore
 # B903: Data class should either be immutable or use __slots__ to save memory
+# T201: Check for Print statements in python files.
 per-file-ignores =
     __init__.py:D104
     tests/*:D400,D200,D102,D104,D107,PT004
     src/macaron/database/views.py:B903
+    tests/schema_validation/json_schema_validate.py:T201
+    tests/integration/cases/run_macaron_sh_script_unit_test/test_run_macaron_sh.py:T201
 
 max-line-length = 120
 show-source = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
 # Commitizen enforces semantic and conventional commit messages.
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.4.1
+  rev: v4.8.3
   hooks:
   - id: commitizen
     name: Check conventional commit message
@@ -50,7 +50,7 @@ repos:
 
 # Upgrade and rewrite Python idioms.
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.19.1
+  rev: v3.20.0
   hooks:
   - id: pyupgrade
     name: Upgrade code idioms
@@ -60,13 +60,13 @@ repos:
 # Similar to pylint, with a few more/different checks. For more available
 # extensions: https://github.com/DmytroLitvinov/awesome-flake8-extensions
 - repo: https://github.com/pycqa/flake8
-  rev: 7.1.2
+  rev: 7.3.0
   hooks:
   - id: flake8
     name: Check flake8 issues
     files: ^src/macaron/|^tests/
     types: [text, python]
-    additional_dependencies: [flake8-bugbear==22.10.27, flake8-builtins==2.0.1, flake8-comprehensions==3.10.1, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.4.0, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.3.0, pep8-naming==0.13.2]
+    additional_dependencies: [flake8-bugbear==22.10.27, flake8-builtins==2.0.1, flake8-comprehensions==3.10.1, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.4.0, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.3.0, flake8-print==5.0.0, pep8-naming==0.13.2]
     exclude: ^tests/malware_analyzer/pypi/resources/sourcecode_samples.*
     args: [--config, .flake8]
 
@@ -110,7 +110,7 @@ repos:
 
 # Check for potential security issues.
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.8.3
+  rev: 1.8.6
   hooks:
   - id: bandit
     name: Check for security issues
@@ -164,7 +164,7 @@ repos:
 
 # Check and prettify the configuration files.
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.14.0
+  rev: v2.15.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -224,7 +224,7 @@ repos:
 
 # A linter for Golang
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.64.6
+  rev: v2.3.0
   hooks:
   - id: golangci-lint
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ docs = [
     "sphinx-togglebutton >=0.3.2,<1.0.0",
 ]
 hooks = [
-    "pre-commit >=4.0.0,<4.2.0",
+    "pre-commit >=4.2.0,<5.0.0",
 ]
 # Note that the `custom_exit_code` and `env` plugins may currently be unmaintained.
 test = [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -91,7 +91,7 @@ def _response_generator(target_value: int) -> Callable[[Request], Response]:
 
     def generator(request: Request) -> Response:  # pylint: disable=unused-argument
         """Add the next value as a header and adjust the status code based on the value."""
-        nonlocal value, target_value
+        nonlocal value
         value += 1
         response = Response()
         response.status_code = 403 if value <= (target_value + 1) else 200


### PR DESCRIPTION
## Summary  
Add `flake8-print` plugin to enforce detection of `print` statements in code, and update the pre-commit hooks.

## Description of changes  
This PR introduces the [`flake8-print`](https://pypi.org/project/flake8-print/) plugin to the codebase via the pre-commit configuration. This plugin flags any usage of the `print` function, which is generally discouraged in production code in favor of proper logging.

Changes:
- Added `flake8-print` to the list of pre-commit hooks.
- Updated `pre-commit` configuration to include the plugin.
- Added `per-file-ignores` for test scripts where `print` statements are used legitimately (e.g., for test output).
