### PR TITLE
chore: fix heuristic dependency handling temporarily

### DIFF
--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -100,10 +100,14 @@ class DetectMaliciousMetadataCheck(BaseCheck):
             Returns True if any result of the dependency heuristic does not match the expected result.
             Otherwise, returns False.
         """
+        mapped_h: dict[Heuristics, list[HeuristicResult]] = {}
         for heuristic, expected_result in depends_on:
-            dep_heuristic_result: HeuristicResult = results[heuristic]
-            if dep_heuristic_result is not expected_result:
-                return True
+            mapped_h.setdefault(heuristic, []).append(expected_result)
+
+            for heuristic, exp_results in mapped_h.items():
+                dep_heuristic_result = results.get(heuristic)
+                if dep_heuristic_result not in exp_results:
+                    return True
         return False
 
     def analyze_source(


### PR DESCRIPTION
## Summary
This is a PR to handle issues experience with malware heuristic dependencies (i.e. the `depends_on` functionality), which #1133 is attempting to handle. This PR temporarily solves these issues whilst that PR is still in development.

## Description of changes
Modified the `_should_skip` method of `DetectMaliciousMetadataCheck` so that multiple entries in `depends_on` are handled as expected.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
