### PR TITLE
chore: change rules for fake email analyzer to reduce FPs

### DIFF
--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -433,8 +433,8 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         failed({Heuristics.ONE_RELEASE.value}),
         failed({Heuristics.ANOMALOUS_VERSION.value}).
 
-    % Package has no links or repo, one release or multiple quick releases, and a suspicious maintainer who recently
-    % joined and has a fake email address.
+    % Package has no links, one release or multiple quick releases, and a suspicious maintainer who recently
+    % joined, has a fake email address, and other similarly-structured projects.
     {Confidence.MEDIUM.value}::trigger(malware_medium_confidence_3) :-
         quickUndetailed,
         failed({Heuristics.SIMILAR_PROJECTS.value}),

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -433,12 +433,18 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         failed({Heuristics.ONE_RELEASE.value}),
         failed({Heuristics.ANOMALOUS_VERSION.value}).
 
-    % Package released recently with the a maintainer email address that is not valid.
+    % Package has no links or repo, one release or multiple quick releases, and a suspicious maintainer who recently
+    % joined and has a fake email address.
     {Confidence.MEDIUM.value}::trigger(malware_medium_confidence_3) :-
         quickUndetailed,
-        failed({Heuristics.FAKE_EMAIL.value}),
-        failed({Heuristics.SIMILAR_PROJECTS.value}).
-
+        failed({Heuristics.SIMILAR_PROJECTS.value}),
+        failed({Heuristics.ONE_RELEASE.value}),
+        failed({Heuristics.FAKE_EMAIL.value}).
+    {Confidence.MEDIUM.value}::trigger(malware_medium_confidence_4) :-
+        quickUndetailed,
+        failed({Heuristics.SIMILAR_PROJECTS.value}),
+        failed({Heuristics.HIGH_RELEASE_FREQUENCY.value}),
+        failed({Heuristics.FAKE_EMAIL.value}).
     % ----- Evaluation -----
 
     % Aggregate result
@@ -446,9 +452,10 @@ class DetectMaliciousMetadataCheck(BaseCheck):
     {problog_result_access} :- trigger(malware_high_confidence_2).
     {problog_result_access} :- trigger(malware_high_confidence_3).
     {problog_result_access} :- trigger(malware_high_confidence_4).
-    {problog_result_access} :- trigger(malware_medium_confidence_3).
-    {problog_result_access} :- trigger(malware_medium_confidence_2).
     {problog_result_access} :- trigger(malware_medium_confidence_1).
+    {problog_result_access} :- trigger(malware_medium_confidence_2).
+    {problog_result_access} :- trigger(malware_medium_confidence_3).
+    {problog_result_access} :- trigger(malware_medium_confidence_4).
     query({problog_result_access}).
 
     % Explainability


### PR DESCRIPTION
## Summary
With the existing `malware_medium_confidence_3` which was introduced with the `FakeEmailAnalyzer`, some false positives were observed. This PR changes this rule by adding in further heuristics to reduce false positives. 

## Description of changes
The rationale for including the `FakeEmailAnalyzer` in a rule is to increase the confidence that a maintainer is suspicious and may have released a malicious package. To make use of this, the rule `quickUndetailed`, which looks for a non-descriptive (no links) package with a recently-joined maintainer, along with `SimilarProjects` and either `OneRelease` or `HighReleaseFrequency` have been included along with the `FakeEmailAnalyzer`. This is representative of a suspicious package, combined with indicators of a suspicious maintainer. 

This was tested against the observed false positives `smooth-operator` and `clodd`, previously being incorrectly flagged as malicious. They now are not flagged as malicious.
## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
