### PR TITLE
chore: fix a bug in SimilarProjectAnalyzer

### DIFF
--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/similar_projects.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/similar_projects.py
@@ -24,7 +24,18 @@ class SimilarProjectAnalyzer(BaseHeuristicAnalyzer):
         super().__init__(
             name="similar_project_analyzer",
             heuristic=Heuristics.SIMILAR_PROJECTS,
-            depends_on=None,
+            depends_on=[
+                (Heuristics.EMPTY_PROJECT_LINK, HeuristicResult.FAIL),
+                (Heuristics.ONE_RELEASE, HeuristicResult.FAIL),
+                (Heuristics.HIGH_RELEASE_FREQUENCY, HeuristicResult.FAIL),
+                (Heuristics.UNCHANGED_RELEASE, HeuristicResult.FAIL),
+                (Heuristics.CLOSER_RELEASE_JOIN_DATE, HeuristicResult.FAIL),
+                (Heuristics.SUSPICIOUS_SETUP, HeuristicResult.FAIL),
+                (Heuristics.WHEEL_ABSENCE, HeuristicResult.FAIL),
+                (Heuristics.ANOMALOUS_VERSION, HeuristicResult.FAIL),
+                (Heuristics.TYPOSQUATTING_PRESENCE, HeuristicResult.FAIL),
+                (Heuristics.FAKE_EMAIL, HeuristicResult.FAIL),
+            ],
         )
 
     def analyze(self, pypi_package_json: PyPIPackageJsonAsset) -> tuple[HeuristicResult, dict[str, JsonType]]:
@@ -106,6 +117,9 @@ class SimilarProjectAnalyzer(BaseHeuristicAnalyzer):
         list[str]:
             The list of files in the package's sdist.
         """
+        # TODO: We should not download the source distributions for every package.
+        # This is very inefficient. We should find a different way to extract the package
+        # structure, e.g., the inspector service?
         sdist_url = self.get_url(package_name)
         if not sdist_url:
             logger.debug("Package %s does not have a sdist.", package_name)
@@ -117,10 +131,16 @@ class SimilarProjectAnalyzer(BaseHeuristicAnalyzer):
             return []
 
         buffer = io.BytesIO(response.content)
-        with tarfile.open(fileobj=buffer, mode="r:gz") as tf:
-            members = [
-                member.name for member in tf.getmembers() if member.name and not member.name.startswith("PAXHeaders/")
-            ]
+        try:
+            with tarfile.open(fileobj=buffer, mode="r:gz") as tf:
+                members = [
+                    member.name
+                    for member in tf.getmembers()
+                    if member.name and not member.name.startswith("PAXHeaders/")
+                ]
+        except (tarfile.TarError, OSError) as error:
+            logger.debug("Error reading source code tar file: %s", error)
+            return []
 
         return members
 


### PR DESCRIPTION
## Summary
This PR addresses a bug in the `SimilarProjectAnalyzer` where exceptions were not properly handled. Additionally, it improves efficiency by ensuring that the `SIMILAR_PROJECTS` heuristic only runs when most other heuristics have failed.

## Description of changes
The main changes in this PR are:

1. Exception handling: The bug where exceptions were not properly handled in the `SimilarProjectAnalyzer` has been fixed. See a [this CI error](https://github.com/oracle/macaron/actions/runs/16898732099/job/47873695334?pr=1145#step:8:7337).

2. Efficiency improvement: To address performance concerns, the `SIMILAR_PROJECTS` heuristic now only runs when the majority of other heuristics have failed. This is achieved by adding those heuristics to the `depends_on` list.

3. Additionally, a TODO has been added to for this known inefficiency.