### PR TITLE
chore(deps): update the base Docker image

### DIFF
--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -31,5 +31,5 @@ jobs:
     # only requires docker/Dockerfile.base. The base image will be tagged with ghcr.io/oracle/macaron-base:latest.
     - name: Build and push the base image
       run: |
-        docker build -t ghcr.io/oracle/macaron-base:test -f docker/Dockerfile.base docker/
-        docker push ghcr.io/oracle/macaron-base:test
+        docker build -t ghcr.io/oracle/macaron-base:latest -f docker/Dockerfile.base docker/
+        docker push ghcr.io/oracle/macaron-base:latest

--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -31,5 +31,5 @@ jobs:
     # only requires docker/Dockerfile.base. The base image will be tagged with ghcr.io/oracle/macaron-base:latest.
     - name: Build and push the base image
       run: |
-        docker build -t ghcr.io/oracle/macaron-base:latest -f docker/Dockerfile.base docker/
-        docker push ghcr.io/oracle/macaron-base:latest
+        docker build -t ghcr.io/oracle/macaron-base:test -f docker/Dockerfile.base docker/
+        docker push ghcr.io/oracle/macaron-base:test

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -5,25 +5,21 @@
 # to build and run the Docker image.
 # This image is based on the container-registry.oracle.com/os/oraclelinux:9-slim image and contains the following
 # components:
-#   Python3.11.4 compiled and installed from source.
-#   Oracle JDK 17 downloaded and installed from the tarball.
+#   Python3.11.13 compiled and installed from source.
 #   Souffle 2.5 compiled and installed from source.
 #   Other runtime libraries (e.g sqlite-devel) which are installed from dnf.
 
-FROM container-registry.oracle.com/os/oraclelinux:9-slim@sha256:e2aa8053b4a15f27c5f80666be1190d24aa3f403225f2dd6fdb545979f08482a
+FROM container-registry.oracle.com/os/oraclelinux:9-slim@sha256:92deb326256d4d3053d210397b00dce9a423789d1c555adb7a3b7a1f0747ea2f
 
 ENV HOME="/home/macaron" \
     # Setting Python related environment variables.
-    PYTHON3_VERSION=3.11.4 \
+    PYTHON3_VERSION=3.11.13 \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     # https://github.com/docker-library/python/blob/f568f56f28fab0fe87b34db777e2c2861cef002b/3.11/slim-buster/Dockerfile#L12
     LANG="C.UTF-8" \
     # The GPG key to verify the source tar ball following the instructions in https://www.python.org/downloads/
-    PYTHON_SOURCE_GPG="A035C8C19219BA821ECEA86B64E628F8D684696D" \
-    # Setting Java related environment variables.
-    JAVA_HOME="/opt/jdk-17.0.12" \
-    PATH=/usr/local/bin:/opt/jdk-17.0.12/bin:$PATH
+    PYTHON_SOURCE_GPG="A035C8C19219BA821ECEA86B64E628F8D684696D"
 
 # We run the installation of all components in one single RUN to minimize the final image size.
 RUN : \
@@ -173,12 +169,6 @@ enabled=1\
         ln -svT "$src" "/usr/local/bin/$dst"; \
     done \
 # ---------------------------------------------------------------------------------------------------------------------
-    # INSTALLING JAVA.
-    && mkdir -p /opt \
-    && wget -O jdk-17.0.12_linux-x64_bin.tar.gz https://download.oracle.com/java/17/archive/jdk-17.0.12_linux-x64_bin.tar.gz \
-    && tar -xvf jdk-17.0.12_linux-x64_bin.tar.gz --directory /opt/ \
-    && rm jdk-17.0.12_linux-x64_bin.tar.gz \
-# ---------------------------------------------------------------------------------------------------------------------
     # INSTALLING SOUFFLE FROM SOURCE.
     # Based on https://github.com/souffle-lang/souffle/blob/master/.github/images/oraclelinux-8/Dockerfile.
     # However, some parts are different on Oracle Linux 9.
@@ -230,8 +220,6 @@ enabled=1\
     && dnf clean all \
     && rm -rf /var/cache/yum \
     && rm -rf /var/cache/dnf \
-    && java --version \
-    && javac --version \
     && git --version
 
 CMD [ "/bin/bash" ]

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This Dockerfile is for building the base image which contains the necessary components

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -19,7 +19,8 @@ ENV HOME="/home/macaron" \
     # https://github.com/docker-library/python/blob/f568f56f28fab0fe87b34db777e2c2861cef002b/3.11/slim-buster/Dockerfile#L12
     LANG="C.UTF-8" \
     # The GPG key to verify the source tar ball following the instructions in https://www.python.org/downloads/
-    PYTHON_SOURCE_GPG="A035C8C19219BA821ECEA86B64E628F8D684696D"
+    PYTHON_SOURCE_GPG="A035C8C19219BA821ECEA86B64E628F8D684696D" \
+    PATH=/usr/local/bin:$PATH
 
 # We run the installation of all components in one single RUN to minimize the final image size.
 RUN : \

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -11,7 +11,7 @@
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle/macaron-base
 # image for this build.
 
-FROM ghcr.io/oracle/macaron-base:test@sha256:faba24cfabdcf8d5d5b23c3ffd6ec52cd02680df9239950936bad7999a540741
+FROM ghcr.io/oracle/macaron-base:latest@sha256:e7cb431d2a870999b70a9a282a84e7b278f7a9ea91e60ba2a8efdab35b4b7e71
 
 ENV HOME="/home/macaron"
 

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -11,7 +11,7 @@
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle/macaron-base
 # image for this build.
 
-FROM ghcr.io/oracle/macaron-base:latest@sha256:3b1f5ab197ee4429c598712bb8abb555a094e879f69e35439061777ac3bcb138
+FROM ghcr.io/oracle/macaron-base:test@sha256:faba24cfabdcf8d5d5b23c3ffd6ec52cd02680df9239950936bad7999a540741
 
 ENV HOME="/home/macaron"
 

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This Dockerfile is for building the final production image. It's based on ghcr.io/oracle/macaron-base and ghcr.io/oracle/maracon-deps.


### PR DESCRIPTION
## Summary
This PR updates the base Docker image to incorporate the latest dependencies that fix known vulnerabilities.

## Description of changes
- Python has been upgraded to 3.11.13 for enhanced security.
- JDK has been removed because the current version, `17.0.12` has known vulnerabilities and we don't really use Java anymore after [this PR](https://github.com/oracle/macaron/pull/1155) was merged. It can be re-added as needed for specific use cases.
- The base ol9-slim image has been updated to the latest version.