### PR TITLE
ci: add actions to CodeQL languages

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,10 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-        # We enable JavaScript language to analyze JavaScript expressions in GitHub Actions.
-        language: [python, go, javascript]
+        language: [python, go, actions]
     steps:
 
     - name: Checkout repository


### PR DESCRIPTION
## Summary
This PR adds the `actions` scanner to the CodeQL configuration, which has been recently added to the supported languages.

It also removes `javascript` which was originally added for partial analysis of GitHub Actions. This is not required anymore.

See the latest set of supported languages [here](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed).