### PR TITLE
chore: reduce FPs in whitespace PR by considering ; statement

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -629,12 +629,13 @@ check_deliverability = True
 # custom rulesets: this is a collection of user-provided rulesets, living inside the path provided to 'custom_semgrep_rules_path'.
 
 # disable default semgrep rulesets here (i.e. all rule IDs in a Semgrep .yaml file) using ruleset names, the name
-# without the .yaml prefix. Currently, we disable the exfiltration rulesets by default due to a high false positive rate.
-# This list may not contain duplicated elements. Macaron's default ruleset names are all unique.
+# without the .yaml prefix (e.g. "obfuscation" for "obfuscation.yaml"). Currently, we disable the exfiltration rulesets
+# by default due to a high false positive rate. This list may not contain duplicated elements. Macaron's default ruleset
+# names are all unique.
 disabled_default_rulesets = exfiltration
-# disable individual rules here (i.e. individual rule IDs inside a Semgrep .yaml file) using rule IDs. You may also
-# provide the IDs of your custom semgrep rules here too, as all Semgrep rule IDs must be unique. This list may not contain
-# duplicated elements.
+# disable individual rules here (i.e. individual rule IDs inside a Semgrep .yaml file, specified under the "rules" header in the
+# .yaml file, with each rule ID under "- id") using rule IDs. You may also provide the IDs of your custom semgrep rules here too,
+# as all Semgrep rule IDs must be unique. This list may not contain duplicated elements.
 disabled_rules =
 # absolute path to a directory where a custom set of semgrep rules for source code analysis are stored. These will be included
 # with Macaron's default rules. The path will be normalised to the OS path type.

--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -101,6 +101,15 @@ This feature is currently a work in progress, and supports detection of code obf
 - `custom_semgrep_rules`: supply to this an absolute path to a directory containing custom Semgrep `.yaml` files to be run alongside the default ones.
 - `disabled_custom_rulesets`: supply to this a comma separated list of the names of custom Semgrep rule files (excluding the `.yaml` extension) to disable all rule IDs in that file.
 
+Here, a "semgrep ruleset" refers to the name of a Semgrep `.yaml` file without the extension. For example, the name of one of the default rulesets is `obfuscation`, as the file name is `obfuscation.yaml`. To disable all rules in that `.yaml` file would look like this:
+```
+disabled_default_rulesets = obfuscation
+```
+A "semgrep rule", or "rule ID", refers to an `- id` entry under the `rules:` heading in a Semgrep `.yaml` file. For example, the name of a rule in `obfuscation.yaml` would be `obfuscation_excessive-spacing`, which is the name specified under the `- id` entry for that rule. Disabling it would look like this:
+```
+disabled_rules = obfuscation_excessive-spacing
+```
+
 ### Contributing
 
 When contributing an analyzer, it must meet the following requirements:

--- a/src/macaron/resources/pypi_malware_rules/obfuscation.yaml
+++ b/src/macaron/resources/pypi_malware_rules/obfuscation.yaml
@@ -319,6 +319,8 @@ rules:
   languages:
   - python
   severity: ERROR
-  patterns:
-  - pattern-regex: '[\s]{50,}(\S)+' # The 50 here is the threshold for excessive spacing , more than that is considered obfuscation
-  - pattern-not-regex: '"""[\s\S]*"""'
+  pattern-either: # The 50 here is the threshold for excessive spacing , more than that is considered obfuscation
+    # there is excessive spacing after a ";", marking the end of a statement, then additional code.
+  - pattern-regex: ;[\s]{50,}(\S)+
+    # there is excessive spacing before a ";", and any amount of whitespace before additional code.
+  - pattern-regex: '[\s]{50,};[\s]*(\S)+'

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/obfuscation/excessive_spacing.py
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/obfuscation/excessive_spacing.py
@@ -20,6 +20,7 @@ def test_function():
     """
     sys.exit()
 
-    # excessive spacing obfuscation
-    def excessive_spacing_flow():
-                                                                                                                                                                                                                                                       print("Hello world!")
+    # excessive spacing obfuscation. The second line here will trigger two detections, which is expected since it matches both patterns.
+    print("hello");                                                                                                                                                         __import__('os')
+    print("hi")                                                                                         ;                                                                   __import__('base64')
+    print("things")                                                                                                                                                         ;__import__('zlib')

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/obfuscation/expected_results.json
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/obfuscation/expected_results.json
@@ -54,6 +54,21 @@
                     "end": 44
                 },
                 {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 24,
+                    "end": 24
+                },
+                {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 25,
+                    "end": 25
+                },
+                {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 26,
+                    "end": 26
+                },
+                {
                     "file": "obfuscation/inline_imports.py",
                     "start": 23,
                     "end": 23
@@ -102,6 +117,36 @@
                     "file": "obfuscation/obfuscation_tools.py",
                     "start": 69,
                     "end": 69
+                }
+            ]
+        },
+        "src.macaron.resources.pypi_malware_rules.obfuscation_excessive-spacing": {
+            "message": "Hidden code after excessive spacing",
+            "detections": [
+                {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 24,
+                    "end": 24
+                },
+                {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 25,
+                    "end": 25
+                },
+                {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 25,
+                    "end": 25
+                },
+                {
+                    "file": "obfuscation/excessive_spacing.py",
+                    "start": 26,
+                    "end": 26
+                },
+                {
+                    "file": "obfuscation/inline_imports.py",
+                    "start": 27,
+                    "end": 27
                 }
             ]
         },
@@ -227,21 +272,6 @@
                     "file": "obfuscation/obfuscation_tools.py",
                     "start": 68,
                     "end": 68
-                }
-            ]
-        },
-        "src.macaron.resources.pypi_malware_rules.obfuscation_excessive-spacing": {
-            "message": "Hidden code after excessive spacing",
-            "detections": [
-                {
-                    "file": "obfuscation/excessive_spacing.py",
-                    "start": 24,
-                    "end": 25
-                },
-                {
-                   "file": "obfuscation/inline_imports.py",
-                    "start": 27,
-                    "end": 27
                 }
             ]
         }


### PR DESCRIPTION
## Summary
Many false positives were being triggered from the introduction of the excessive whitespace obfuscation rule in #1086. This is due to a lack of specificity in the rule. This PR resolves that change by considering the key syntax of using `;` that is the primary malicious indicator for this method of obfuscation.

## Description of changes
The rule originally considered any amount of excessive spacing (50 or more) before encountering code. Whitespaces here includes newline characters, and with Semgrep running regex pattern matching in multiline matching mode, this would trigger against code lines where a long line of code was broken across multiple lines like:
```
<indentation>                                             foo(arg1, another_foo(arg_2), 
                                                                                   arg3_on_other_line)
```
Due to differences in formatting in code files, it would sometimes also simply detect vertical spacing between lines. 

The key malicious indicator white rules aims to detect is when a benign (syntactically valid) code statement is used at the start of the code line, and then the `;` character is used to finish that statement, and start a new, malicious one out of the view of the general IDE (unless wrapped text was turned on, though this is often off by default). This is syntactically valid when there is excessive spacing:
- After the benign code statement, before inserting a `;` and then writing a malicious statement
- After the benign code statement, before inserting a `;`, then further excessive spacing and a malicious statement
- After a `;` inserted immediately after the benign code statement, and writing a malicious statement

The updated `excessive_spacing.py` showcases each of these examples. The new `obfuscation.yaml` file has been rewritten to include regex that reflects this. It has been tested on recently detected false positives `logit-graph-0.1.0`, `kryon-ai-1.2.0`, and `cispark-0.1.0`, as well as the integration test case `django-5.0.6`. It was run against the Backstabbers dataset, which confirmed it was able to detect this malicious behaviour, and on popular and trusted packages from the ICSE25-AE-Evaluation dataset, for which it did not trigger.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
