### PR TITLE
chore: switch to using Central Search for Maven artifacts

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -518,7 +518,7 @@ publish_time_range = 7200
 
 [package_registry.maven_central]
 # Maven Central host name.
-search_netloc = search.maven.org
+search_netloc = central.sonatype.com
 search_scheme = https
 # The search REST API. See https://central.sonatype.org/search/rest-api-guide/
 search_endpoint = solrsearch/select

--- a/tests/slsa_analyzer/package_registry/test_maven_central_registry.py
+++ b/tests/slsa_analyzer/package_registry/test_maven_central_registry.py
@@ -30,7 +30,7 @@ def resources() -> Path:
 def maven_central_instance() -> MavenCentralRegistry:
     """Create a ``MavenCentralRegistry`` object for the following tests."""
     return MavenCentralRegistry(
-        search_netloc="search.maven.org",
+        search_netloc="central.sonatype.com",
         search_scheme="https",
         search_endpoint="solrsearch/select",
         registry_url_netloc="repo1.maven.org/maven2",


### PR DESCRIPTION
## Summary
This PR witches to use [Central Search](https://central.sonatype.com/solrsearch/select) for Maven artifacts instead of search.maven.org.

## Description of changes
Central Search appears to be more stable based on [published operational statistics](https://status.maven.org/). The Central Search API is compatible with our current integration and requires minimal changes. This PR also updates the related unit test.