### PR TITLE
chore: improve max download restrictions for malicious metadata tutorial

### DIFF
--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -136,6 +136,8 @@ By default, the source code analyzer is run in conjunction with the other metada
 
   ./run_macaron.sh analyze -purl pkg:pypi/django@5.0.6 --python-venv "/tmp/.django_venv" --force-analyze-source
 
+.. note:: Some packages source code, like ``django@5.0.6``, will be larger than the default download limit of 10 megabytes. This is controlled using the ``max_download_size`` configuration under ``downloads`` in ``defaults.ini``, and can be increased by either modifying that value in ``defaults.ini`` or by passing in a configuration file using ``-dp`` with this value increased.
+
 If any suspicious patterns are triggered, this will be identified in the ``mcn_detect_malicious_metadata_1`` result for the heuristic named ``suspicious_patterns``. The output database ``output/macaron.db`` can be used to get the specific results of the analysis by querying the :class:`detect_malicious_metadata_check.result field <macaron.database>`. This will provide detailed JSON information about all data collected by the ``mcn_detect_malicious_metadata_1`` check, including, for source code analysis, any malicious code patterns detected, what Semgrep rule detected it, the file in which it was detected, and the line number for the detection.
 
 +++++++++++++++++++++++++++++++++++++++

--- a/docs/source/pages/tutorials/provenance.rst
+++ b/docs/source/pages/tutorials/provenance.rst
@@ -204,7 +204,7 @@ Build Types
 File Download Limit
 *******************
 
-To prevent analyses from taking too long, Macaron imposes a configurable size limit for downloads. This includes files being downloaded for provenance verification. In cases where the limit is being reached and you wish to continue analysis regardless, you can specify a new download size in the default configuration file. This value can be found under the ``slsa.verifier`` section, listed as ``max_download_size`` with a default limit of 10 megabytes. See :ref:`How to change the default configuration <change-config>` for more details on configuring values like these.
+To prevent analyses from taking too long, Macaron imposes a configurable size limit for downloads. This includes files being downloaded for provenance verification. In cases where the limit is being reached and you wish to continue analysis regardless, you can specify a new download size in the default configuration file. This value can be found under the ``downloads`` section, listed as ``max_download_size`` with a default limit of 10 megabytes. See :ref:`How to change the default configuration <change-config>` for more details on configuring values like these.
 
 **************************************
 Run ``verify-policy`` command (semver)

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -10,6 +10,8 @@ error_retries = 5
 [downloads]
 # The default timeout in seconds for downloading assets.
 timeout = 120
+# This is the acceptable maximum size (in bytes) to download an asset.
+max_download_size = 10000000
 
 # This is the database to store Macaron's results.
 [database]
@@ -486,8 +488,6 @@ provenance_extensions =
     intoto.jsonl.gz
     intoto.jsonl.url
     intoto.jsonl.gz.url
-# This is the acceptable maximum size (in bytes) to download an asset.
-max_download_size = 10000000
 # This is the timeout (in seconds) to run the SLSA verifier.
 timeout = 120
 # The allowed hostnames for URL file links for provenance download

--- a/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/suspicious_setup.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/suspicious_setup.py
@@ -56,7 +56,7 @@ class SuspiciousSetupAnalyzer(BaseHeuristicAnalyzer):
         with tempfile.TemporaryDirectory() as temp_dir:
             source_file = os.path.join(temp_dir, file_name)
             timeout = defaults.getint("downloads", "timeout", fallback=120)
-            size_limit = defaults.getint("slsa.verifier", "max_download_size", fallback=10000000)
+            size_limit = defaults.getint("downloads", "max_download_size", fallback=10000000)
             if not download_file_with_size_limit(sourcecode_url, {}, source_file, timeout, size_limit):
                 return None
 

--- a/src/macaron/provenance/provenance_finder.py
+++ b/src/macaron/provenance/provenance_finder.py
@@ -255,7 +255,7 @@ def find_gav_provenance(purl: PackageURL, registry: JFrogMavenRegistry) -> list[
         return []
 
     max_valid_provenance_size = defaults.getint(
-        "slsa.verifier",
+        "downloads",
         "max_download_size",
         fallback=1000000,
     )
@@ -458,7 +458,7 @@ def download_provenances_from_ci_service(ci_info: CIInfo, download_path: str) ->
         for prov_asset in prov_assets:
             # Check the size before downloading.
             if prov_asset.size_in_bytes > defaults.getint(
-                "slsa.verifier",
+                "downloads",
                 "max_download_size",
                 fallback=1000000,
             ):

--- a/src/macaron/provenance/provenance_verifier.py
+++ b/src/macaron/provenance/provenance_verifier.py
@@ -190,7 +190,7 @@ def verify_ci_provenance(analyze_ctx: AnalyzeContext, ci_info: CIInfo, download_
                 return False
             if not Path(download_path, sub_asset["name"]).is_file():
                 if "size" in sub_asset and sub_asset["size"] > defaults.getint(
-                    "slsa.verifier", "max_download_size", fallback=1000000
+                    "downloads", "max_download_size", fallback=1000000
                 ):
                     logger.debug("Sub asset too large to verify: %s", sub_asset["name"])
                     return False

--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -148,6 +148,10 @@ class DetectMaliciousMetadataCheck(BaseCheck):
         if not force and analyzer.depends_on and self._should_skip(results, analyzer.depends_on):
             return {analyzer.heuristic: HeuristicResult.SKIP}, {}
 
+        if not pypi_package_json.can_download_sourcecode():
+            logger.debug("Source code will exceed download limits. Please increase the download size limit to analyze.")
+            return {analyzer.heuristic: HeuristicResult.SKIP}, {}
+
         try:
             with pypi_package_json.sourcecode():
                 result, detail_info = analyzer.analyze(pypi_package_json)

--- a/src/macaron/slsa_analyzer/git_service/api_client.py
+++ b/src/macaron/slsa_analyzer/git_service/api_client.py
@@ -643,7 +643,7 @@ class GhAPIClient(BaseAPIClient):
         logger.debug("Download assets from %s at %s.", url, download_path)
 
         timeout = defaults.getint("downloads", "timeout", fallback=120)
-        size_limit = defaults.getint("slsa.verifier", "max_download_size", fallback=10000000)
+        size_limit = defaults.getint("downloads", "max_download_size", fallback=10000000)
         headers = {"Accept": "application/octet-stream", "Authorization": self.headers["Authorization"]}
 
         return download_file_with_size_limit(url, headers, download_path, timeout, size_limit)

--- a/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/maven_central_registry.py
@@ -286,7 +286,7 @@ class MavenCentralRegistry(PackageRegistry):
 
         hash_algorithm = hashlib.sha256()
         timeout = defaults.getint("downloads", "timeout", fallback=120)
-        size_limit = defaults.getint("slsa.verifier", "max_download_size", fallback=10000000)
+        size_limit = defaults.getint("downloads", "max_download_size", fallback=10000000)
         if not stream_file_with_size_limit(artifact_url, {}, hash_algorithm.update, timeout, size_limit):
             return None
 

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -257,7 +257,7 @@ class PyPIRegistry(PackageRegistry):
         temp_dir = tempfile.mkdtemp(prefix=f"{package_name}_")
         source_file = os.path.join(temp_dir, file_name)
         timeout = defaults.getint("downloads", "timeout", fallback=120)
-        size_limit = defaults.getint("slsa.verifier", "max_download_size", fallback=10000000)
+        size_limit = defaults.getint("downloads", "max_download_size", fallback=10000000)
         if not download_file_with_size_limit(url, {}, source_file, timeout, size_limit):
             self.cleanup_sourcecode_directory(temp_dir, "Could not download the file.")
 
@@ -295,7 +295,7 @@ class PyPIRegistry(PackageRegistry):
         """
         hash_algorithm = hashlib.sha256()
         timeout = defaults.getint("downloads", "timeout", fallback=120)
-        size_limit = defaults.getint("slsa.verifier", "max_download_size", fallback=10000000)
+        size_limit = defaults.getint("downloads", "max_download_size", fallback=10000000)
         if not stream_file_with_size_limit(artifact_url, {}, hash_algorithm.update, timeout, size_limit):
             return None
 

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -227,7 +227,7 @@ class PyPIRegistry(PackageRegistry):
         bool
             True if it can be downloaded within the size limits, otherwise False.
         """
-        size_limit = defaults.getint("slsa.verifier", "max_download_size", fallback=10000000)
+        size_limit = defaults.getint("downloads", "max_download_size", fallback=10000000)
         timeout = defaults.getint("downloads", "timeout", fallback=120)
         return can_download_file(url, size_limit, timeout=timeout)
 

--- a/src/macaron/util.py
+++ b/src/macaron/util.py
@@ -286,6 +286,35 @@ class StreamWriteDownloader:
         self.file.write(chunk)
 
 
+def can_download_file(url: str, size_limit: int, timeout: int | None = None) -> bool:
+    """Send a head request to check if the file provided at url can be downloaded within the size limit.
+
+    It expects a URL to a file, and checks the "Content-Length" field of the response.
+
+    Parameters
+    ----------
+    url: str
+        The target of the request.
+    size_limit: int
+        The size limit in bytes of the file.
+    timeout: int | None
+        The request timeout (optional).
+
+    Returns
+    -------
+    bool
+        True if the file can be downloaded within the size limit, False otherwise.
+    """
+    response = send_head_http_raw(url, timeout=timeout, allow_redirects=True)
+    if not response:
+        return False
+
+    size = response.headers.get("Content-Length")
+    if size and int(size) <= size_limit:
+        return True
+    return False
+
+
 def download_file_with_size_limit(
     url: str, headers: dict, file_path: str, timeout: int = 40, size_limit: int = 0
 ) -> bool:

--- a/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/config.ini
+++ b/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/config.ini
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
-[slsa.verifier]
+[downloads]
 max_download_size = 15000000

--- a/tests/integration/cases/ossf_scorecard/config.ini
+++ b/tests/integration/cases/ossf_scorecard/config.ini
@@ -1,12 +1,12 @@
 # Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
+[downloads]
+max_download_size = 15000000
+
 [analysis.checks]
 exclude =
 include =
     mcn_provenance_expectation_1
     mcn_provenance_verified_1
     mcn_trusted_builder_level_three_1
-
-[slsa.verifier]
-max_download_size = 15000000


### PR DESCRIPTION
## Summary
Changes the behaviour and way `max_download_size` is accessed with respect to package source code analysis.

## Description of changes
This PR makes two main changes. It moves the `max_download_size` configuration from `slsa.verifier` to `downloads` in `defaults.ini`, and adds a new function `can_download_file` that is used to check first if the source code of a package can be downloaded before acting upon this information. This is useful in `DetectMaliciousMetadataCheck.analyze_source` to ensure that a `HeuristicAnalyzerValueError` is not raised, and a subsequent `UNKNOWN` result is not returned if the file limit stops the source code from being downloaded.

This PR also updates the tutorial documentation to describe the changes needed to ensure some larger packages are downloaded when analyzing the source code.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
