### PR TITLE
docs: fix links and improve contributions guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Please see the [README for the malware analyzer](./src/macaron/malware_analyzer/
 
 ### Prerequisites
 
-- Python 3.11
+- Python 3.11.13
 - Go 1.23
 - JDK 17
 
@@ -229,7 +229,7 @@ $ make integration-test
 
 ## Generating documentation
 
-As mentioned above, all package code should make use of [Python docstrings](https://www.python.org/dev/peps/pep-0257/) in [reStructured text format](https://www.python.org/dev/peps/pep-0287/) following [numpydoc style](https://numpydoc.readthedocs.io/en/latest/format.html) (with some exceptions - see our [style guide](https://oracle.github.io/pages/developers_guide/style_guide.html#docstrings)). Using these docstrings and the documentation template in the `docs/source/` folder, you can then generate proper documentation in different formats using the [Sphinx](https://github.com/sphinx-doc/sphinx/) tool:
+As mentioned above, all package code should make use of [Python docstrings](https://www.python.org/dev/peps/pep-0257/) in [reStructured text format](https://www.python.org/dev/peps/pep-0287/) following [numpydoc style](https://numpydoc.readthedocs.io/en/latest/format.html) (with some exceptions - see our [style guide](https://oracle.github.io/macaron/pages/developers_guide/style_guide.html#docstrings)). Using these docstrings and the documentation template in the `docs/source/` folder, you can then generate proper documentation in different formats using the [Sphinx](https://github.com/sphinx-doc/sphinx/) tool:
 
 ```bash
 make docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ python -m http.server -d docs/_build/html
 
 ## Extend the API reference
 
-We use the [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html) tool to generate API reference automatically from Python docstrings. See the [Docstring section in the Macaron Style Guide](https://oracle.github.io/pages/developers_guide/style_guide.html#docstrings) for how to write docstrings in Macaron.
+We use the [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html) tool to generate API reference automatically from Python docstrings. See the [Docstring section in the Macaron Style Guide](https://oracle.github.io/macaron/pages/developers_guide/style_guide.html#docstrings) for how to write docstrings in Macaron.
 
 If you make a code change, make sure to regenerate the API reference by running (with the dev environment activated):
 


### PR DESCRIPTION
## Summary
This PR addresses two documentation issues: 

- Fixes broken links in the documentation.
- Explicitly asks contributors to use Python 3.11.13 (rather than any 3.11.x version) to prevent compatibility issues.
     