### PR TITLE
fix: ensure Python 3.11.13 is used to address GHSA-4xh5-x5gv-qwph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,12 +257,15 @@ requirements.txt: pyproject.toml
 # editable mode (like the one in development here) because they may not have
 # a PyPI entry; also print out CVE description and potential fixes if audit
 # found an issue.
+# Ignore GHSA-4xh5-x5gv-qwph since we are using Python >=3.11.13, which is not vulnerable to this
+# CVE. Remove this once a new version of pip that fixes the CVE is released.
+# See https://github.com/pypa/pip/issues/13607
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-4xh5-x5gv-qwph
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -62,7 +62,7 @@ enabled=1\
         # Exceptions (not installed):
         #   mcpp - The package mcpp is not available in Oracle Linux 9. However, we don't use Souffle's feature
         #       that needs it.
-        #   python3 - We use the installed Python3.11.2 for this.
+        #   python3 - We use the installed Python3.11.13 for this.
         gcc-c++         \
         libffi          \
         libffi-devel    \

--- a/docs/source/pages/supported_technologies/index.rst
+++ b/docs/source/pages/supported_technologies/index.rst
@@ -115,7 +115,7 @@ Automatic dependency resolution
 
 Currently, we support the following type of project for automatic dependency resolution.
 
-* Python (with a Python virtual environment created and packages installed using Python3.11, see :ref:`providing Python virtual environment <python-venv-deps>`.)
+* Python (with a Python virtual environment created and packages installed using Python3.11.13, see :ref:`providing Python virtual environment <python-venv-deps>`.)
 
 --------
 See also

--- a/docs/source/pages/tutorials/detect_malicious_package.rst
+++ b/docs/source/pages/tutorials/detect_malicious_package.rst
@@ -190,7 +190,7 @@ Macaron supports analyzing a package's dependencies and performs the same set of
 
 Let's assume ``/tmp/.django_venv`` is the virtual environment where ``django@5.0.6`` is installed.
 
-.. note:: If you want Macaron to analyze the virtual environment directly to identify the dependencies, we require Python 3.11 to be used to install the package. Alternatively, you can generate the SBOM as instructed :ref:`here <python-sbom>` and pass it to Macaron as input.
+.. note:: If you want Macaron to analyze the virtual environment directly to identify the dependencies, we require Python 3.11.13 to be used to install the package. Alternatively, you can generate the SBOM as instructed :ref:`here <python-sbom>` and pass it to Macaron as input.
 
 Run Macaron as follows to analyze ``django`` and its direct dependencies.
 

--- a/docs/source/pages/using.rst
+++ b/docs/source/pages/using.rst
@@ -374,7 +374,7 @@ Where ``--python-venv`` is the path to virtual environment.
 
 Alternatively, you can create an SBOM for the python package and provide it to Macaron as input as explained :ref:`here <with-sbom>`.
 
-.. note:: We only support Python 3.11 for this feature of Macaron. Please make sure to install the package using this version of Python.
+.. note:: We only support Python 3.11.13 for this feature of Macaron. Please make sure to install the package using this version of Python.
 
 
 -----------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "macaron"
-requires-python = ">=3.11"
+requires-python = ">=3.11.13"
 authors = [
     {"name" = "Trong Nhan Mai", "email" = "trong.nhan.mai@oracle.com"},
     {"name" = "Behnaz Hassanshahi", "email" = "behnaz.hassanshahi@oracle.com"},


### PR DESCRIPTION
## Summary
This PR ensures Python `3.11.13` is used to mitigate the vulnerability identified in [GHSA-4xh5-x5gv-qwph](https://github.com/advisories/GHSA-4xh5-x5gv-qwph), as this version is not affected by the CVE.

## Description of changes

- Explicitly ensure Python `3.11.13` is used to avoid the vulnerability associated with `GHSA-4xh5-x5gv-qwph`. Since Python `3.11.13` is not vulnerable, the changes are intended to avoid unnecessary issues related to the advisory.
- A comment has been added to ignore the GHSA advisory for now, with a note to remove this once a new version of pip is released to address the CVE.

Related links:
- https://github.com/pypa/pip/issues/13607
- Our CI failed run: https://github.com/oracle/macaron/actions/runs/18145715888/job/51646824227