### PR TITLE
chore: remove consideration of line break characters to reduce whitespace false positives

### DIFF
--- a/src/macaron/resources/pypi_malware_rules/obfuscation.yaml
+++ b/src/macaron/resources/pypi_malware_rules/obfuscation.yaml
@@ -323,4 +323,4 @@ rules:
     # there is excessive spacing after a ";", marking the end of a statement, then additional code.
   - pattern-regex: ;[\t ]{50,}(\S)+
     # there is excessive spacing before a ";", and any amount of whitespace before additional code.
-  - pattern-regex: '[\t ]{50,};[\s]*(\S)+'
+  - pattern-regex: '[\t ]{50,};[\t ]*(\S)+'


### PR DESCRIPTION
## Summary
This PR includes a small fix to the whitespace rule due to observed false positives on multiline statements by removing consideration of line break characters. 

## Description of changes
Multiline statements such as :
```
<some code>;

<some code>
```
were being triggered by the whitespace obfuscation rule. This is because `\s` includes `\f`, `\v`, `\r`, and `\n`, all of which are line break characters. The regex would then match line breaks after the `;`, and the subsequent code line. To avoid this, the whitespace now only includes the space character and `\t`.
## Checklist

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
