### PR TITLE
fix: handle all tarfile extract errors

### DIFF
--- a/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
+++ b/src/macaron/slsa_analyzer/checks/detect_malicious_metadata_check.py
@@ -157,9 +157,8 @@ class DetectMaliciousMetadataCheck(BaseCheck):
                 return {analyzer.heuristic: result}, detail_info
 
         except SourceCodeError as error:
-            error_msg = f"Unable to perform source code analysis: {error}"
-            logger.debug(error_msg)
-            raise HeuristicAnalyzerValueError(error_msg) from error
+            logger.debug("Unable to perform source code analysis: %s", error)
+            return {analyzer.heuristic: HeuristicResult.SKIP}, {}
 
     def evaluate_heuristic_results(
         self, heuristic_results: dict[Heuristics, HeuristicResult]

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -268,8 +268,10 @@ class PyPIRegistry(PackageRegistry):
         try:
             with tarfile.open(source_file, "r:gz") as sourcecode_tar:
                 sourcecode_tar.extractall(temp_dir, filter="data")
-        except tarfile.ReadError as read_error:
-            self.cleanup_sourcecode_directory(temp_dir, f"Error reading source code tar file: {read_error}", read_error)
+        except tarfile.TarError as tar_error:
+            self.cleanup_sourcecode_directory(
+                temp_dir, f"Error extracting source code tar file: {tar_error}", tar_error
+            )
 
         os.remove(source_file)
 


### PR DESCRIPTION
## Summary
Addressing #1202, which occurred due to a `tarfile.SpecialFileError`, this case happened as the provided package had uploaded what linux classes as a character file (like a device file). Instead of handling specifically `tarfile.ReadError`, the `download_package_sourcecode` function how handles all `tarfile` errors using `tarfile.TarError`, the base error class.

## Description of changes
In addition to those changes mentioned above, also included in this PR is modifying `DetectMaliciousMetadataCheck.analyze_source` to return `SKIP` instead of raising a `HeuristicAnalyzerValueError` from a `SourceCodeError`. This means that the result of the metadata analysis is still preserved and the analysis result does not result in `UNKNOWN`.

## Related issues
Closes #1202.

## Checklist

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
