### PR TITLE
fix: gen-build-spec maven/gradle cli parsers failed to parse valid command lines with intermixed positional args and options

### DIFF
--- a/src/macaron/build_spec_generator/cli_command_parser/gradle_cli_parser.py
+++ b/src/macaron/build_spec_generator/cli_command_parser/gradle_cli_parser.py
@@ -534,7 +534,7 @@ class GradleCLICommandParser:
         # TODO: because our parser is not completed for all cases, should we be more relaxed and use
         # parse_unknown_options?
         try:
-            parsed_opts = self.arg_parser.parse_args(options)
+            parsed_opts = self.arg_parser.parse_intermixed_args(options)
         except argparse.ArgumentError as error:
             raise CommandLineParseError(f"Failed to parse {' '.join(options)}.") from error
         # Even though we have set `exit_on_error`, argparse still exits unexpectedly in some

--- a/src/macaron/build_spec_generator/cli_command_parser/maven_cli_parser.py
+++ b/src/macaron/build_spec_generator/cli_command_parser/maven_cli_parser.py
@@ -436,7 +436,7 @@ class MavenCLICommandParser:
         # TODO: because our parser is not completed for all cases, should we be more relaxed and use
         # parse_unknown_options?
         try:
-            parsed_opts = self.arg_parser.parse_args(options)
+            parsed_opts = self.arg_parser.parse_intermixed_args(options)
         except argparse.ArgumentError as error:
             raise CommandLineParseError(f"Failed to parse command {' '.join(options)}.") from error
         # Even though we have set `exit_on_error`, argparse still exits unexpectedly in some

--- a/tests/build_spec_generator/cli_command_parser/test_gradle_cli_command.py
+++ b/tests/build_spec_generator/cli_command_parser/test_gradle_cli_command.py
@@ -38,6 +38,11 @@ from macaron.build_spec_generator.cli_command_parser.gradle_cli_parser import Gr
             "gradlew clean build -x test -x boo",
             id="test_excluded_tasks",
         ),
+        pytest.param(
+            "gradlew clean -x test -x boo build",
+            "gradlew clean build -x test -x boo",
+            id="test_intermixed_args",
+        ),
     ],
 )
 def test_comparing_gradle_cli_command_equal(

--- a/tests/build_spec_generator/cli_command_parser/test_maven_cli_command.py
+++ b/tests/build_spec_generator/cli_command_parser/test_maven_cli_command.py
@@ -27,6 +27,11 @@ from macaron.build_spec_generator.cli_command_parser.maven_cli_parser import Mav
             "mvn clean package -Dmaven.skip.test",
             id="test_default_value_for_system_property",
         ),
+        pytest.param(
+            "mvn clean package -Dmaven.skip.test=true",
+            "mvn clean -Dmaven.skip.test=true package",
+            id="test_intermixed_args",
+        ),
     ],
 )
 def test_comparing_maven_cli_command_equal(


### PR DESCRIPTION
## Summary
The maven and gradle cli parsers used by the gen-build-spec command fail to parse valid command lines with intermixed positional args and options. This change fixes that limitation.

## Description of changes
Use `argparse.ArgumentParser.parse_intermixed_args` instead of `argparse.ArgumentParser.parse_args` to enable handling of intermixed args, and add a unit test case for the maven parser and for the gradle parser.


## Checklist
- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
