### PR TITLE
fix: added check for missing release information for anomalous version

### DIFF
--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/anomalous_version.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/anomalous_version.py
@@ -132,10 +132,10 @@ class AnomalousVersionAnalyzer(BaseHeuristicAnalyzer):
             logger.debug(error_msg)
             raise HeuristicAnalyzerValueError(error_msg) from release_error
 
-        try:
-            version = parse(release)
-        except InvalidVersion:
-            return HeuristicResult.SKIP, {self.DETAIL_INFO_KEY: Versioning.INVALID.value}
+        if not release_metadata:
+            error_msg = "Release is missing metadata information"
+            logger.debug(error_msg)
+            raise HeuristicAnalyzerValueError(error_msg)
 
         years = []
         months = []
@@ -160,6 +160,11 @@ class AnomalousVersionAnalyzer(BaseHeuristicAnalyzer):
             publish_days.append(parsed_time.day)
 
         days = list(range(min(publish_days) - self.day_publish_error, max(publish_days) + self.day_publish_error + 1))
+
+        try:
+            version = parse(release)
+        except InvalidVersion:
+            return HeuristicResult.SKIP, {self.DETAIL_INFO_KEY: Versioning.INVALID.value}
 
         calendar = False
         calendar_semantic = False

--- a/tests/malware_analyzer/pypi/test_anomalous_version.py
+++ b/tests/malware_analyzer/pypi/test_anomalous_version.py
@@ -21,6 +21,65 @@ def test_analyze_no_information(pypi_package_json: MagicMock) -> None:
         analyzer.analyze(pypi_package_json)
 
 
+def test_analyze_no_releases(pypi_package_json: MagicMock) -> None:
+    """Test for when there are no release entries, so error."""
+    analyzer = AnomalousVersionAnalyzer()
+
+    pypi_package_json.get_releases.return_value = {}
+    pypi_package_json.get_latest_version.return_value = None
+
+    with pytest.raises(HeuristicAnalyzerValueError):
+        analyzer.analyze(pypi_package_json)
+
+
+def test_analyze_missing_release(pypi_package_json: MagicMock) -> None:
+    """Test for when there is a release entry, but no actual release information, so error."""
+    analyzer = AnomalousVersionAnalyzer()
+    version = "1.1"
+
+    pypi_package_json.get_releases.return_value = {version: []}
+    pypi_package_json.get_latest_version.return_value = version
+
+    with pytest.raises(HeuristicAnalyzerValueError):
+        analyzer.analyze(pypi_package_json)
+
+
+def test_analyze_missing_time(pypi_package_json: MagicMock) -> None:
+    """Test for when the supplied upload time does not conform with PEP 440, so error."""
+    analyzer = AnomalousVersionAnalyzer()
+    version = "1.1"
+    release = {
+        version: [
+            {
+                "comment_text": "",
+                "digests": {
+                    "blake2b_256": "defa2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3",
+                    "md5": "9203bbb130f8ddb38269f4861c170d04",
+                    "sha256": "168bcccbf5106132e90b85659297700194369b8f6b3e5a03769614f0d200e370",
+                },
+                "downloads": -1,
+                "filename": "ttttttttest_nester.py-0.1.0.tar.gz",
+                "has_sig": False,
+                "md5_digest": "9203bbb130f8ddb38269f4861c170d04",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": None,
+                "size": 546,
+                "url": "https://files.pythonhosted.org/packages/de/fa/"
+                + "2fbcebaeeb909511139ce28dac4a77ab2452ba72b49a22b12981b2f375b3/ttttttttest_nester.py-0.1.0.tar.gz",
+                "yanked": False,
+                "yanked_reason": None,
+            }
+        ]
+    }
+
+    pypi_package_json.get_releases.return_value = release
+    pypi_package_json.get_latest_version.return_value = version
+
+    with pytest.raises(HeuristicAnalyzerValueError):
+        analyzer.analyze(pypi_package_json)
+
+
 def test_analyze_invalid_time(pypi_package_json: MagicMock) -> None:
     """Test for when the supplied upload time does not conform with PEP 440, so error."""
     analyzer = AnomalousVersionAnalyzer()


### PR DESCRIPTION
## Summary
Fixing #1231, this PR introduces a check for when there exists an entry for a release, but no actual information inside that release. 

## Description of changes
A check for a non-empty `release_metadata` field (i.e. there exists information about the release) has been added to `anomalous_version.py`. The version extraction was moved under the publish days, years, and months parsing so that all `HeuristicAnalyzerValueErrors` are raised before results are considered. Additional unit tests were added to `test_anomalous_version.py` to reflect the bug and expected behaviour.

## Related issues
Closes #1231.

## Checklist

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
