### PR TITLE
fix: sanitize version specifier and handled generator name edge case for Python builds

### DIFF
--- a/src/macaron/build_spec_generator/common_spec/pypi_spec.py
+++ b/src/macaron/build_spec_generator/common_spec/pypi_spec.py
@@ -331,6 +331,10 @@ class PyPIBuildSpec(
         '1.2.3'
         >>> spec.parse_generator_version("1.2.3")
         '1.2.3'
+        >>> spec.parse_generator_version("10.2.3")
+        '10.2.3'
+        >>> spec.parse_generator_version("(10.2.3)")
+        '10.2.3'
         >>> spec.parse_generator_version("a.b.c")
         ''
         >>> spec.parse_generator_version("1..2.3")
@@ -340,9 +344,9 @@ class PyPIBuildSpec(
         """
         # Two patterns p1 and p2 rather than just one
         # (p1)|(p2) as the latter complicates the group to return
-        pattern_plain = re.compile(r"^(\d(\.(\d)+)*)$")
+        pattern_plain = re.compile(r"^(\d+(\.(\d)+)*)$")
         plain_match = pattern_plain.match(literal_version_specification)
-        pattern_parenthesis = re.compile(r"^\((\d(\.(\d)+)*)\)$")
+        pattern_parenthesis = re.compile(r"^\((\d+(\.(\d)+)*)\)$")
         parenthesis_match = pattern_parenthesis.match(literal_version_specification)
         if plain_match:
             return plain_match.group(1)

--- a/tests/integration/cases/pypi_cachetools/expected_default.buildspec
+++ b/tests/integration/cases/pypi_cachetools/expected_default.buildspec
@@ -23,7 +23,7 @@
         ]
     ],
     "build_requires": {
-        "setuptools": "==(80.9.0)",
+        "setuptools": "==80.9.0",
         "wheel": ""
     },
     "build_backends": [

--- a/tests/integration/cases/pypi_toga/expected_default.buildspec
+++ b/tests/integration/cases/pypi_toga/expected_default.buildspec
@@ -23,7 +23,7 @@
         ]
     ],
     "build_requires": {
-        "setuptools": "==(80.3.1)",
+        "setuptools": "==80.3.1",
         "setuptools_dynamic_dependencies": "==1.0.0",
         "setuptools_scm": "==8.3.1"
     },


### PR DESCRIPTION
## Summary
Fixed logic related to parsing the "Generator: ..." line of `.dist_info`

## Description of changes
- Modified `pypi_spec.py`, specifically added `parse_generator_version` so correctly sanitize and standardize the generator's version and added logic to handle the edge case of the `bdist_wheel` build backend. It's name is not indicative of the backend to be installed: instead `wheel` must be installed.