### PR TITLE
test: updated test_detect_malicious_metadata to work with new package versions.

### DIFF
--- a/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
+++ b/tests/slsa_analyzer/checks/test_detect_malicious_metadata_check.py
@@ -34,7 +34,7 @@ RESOURCE_PATH = Path(__file__).parent.joinpath("resources")
         # from reaching the network.
         pytest.param("pkg:pypi/zlibxjson", CheckResultType.PASSED, False, id="test_malicious_pypi_package"),
         pytest.param("pkg:pypi/test", CheckResultType.UNKNOWN, False, id="test_unknown_pypi_package"),
-        pytest.param("pkg:maven:test/test", CheckResultType.UNKNOWN, False, id="test_non_pypi_package"),
+        pytest.param("pkg:maven/test", CheckResultType.UNKNOWN, False, id="test_non_pypi_package"),
         # TODO: including source code analysis that detects flow from a remote point to a file write may assist in resolving
         # the issue of this false negative.
         pytest.param(


### PR DESCRIPTION
## Summary
Minor fix to ensure test_detect_malicious_metadata works with the latest version of packageurl-python.

## Description of changes
- Modified `pkg:maven/test/test` to `pkg:maven/test` so that it works with the latest version of packageurl-python whilst ensuring the test still remains valid.