### PR TITLE
test: improve deploy spec for pip and add integration test

### DIFF
--- a/docs/source/pages/tutorials/index.rst
+++ b/docs/source/pages/tutorials/index.rst
@@ -17,6 +17,7 @@ For the full list of supported technologies, such as CI services, registries, an
 .. toctree::
    :maxdepth: 1
 
+   source_finder
    commit_finder
    detect_malicious_package
    rebuild_third_party_artifacts
@@ -27,4 +28,3 @@ For the full list of supported technologies, such as CI services, registries, an
    generate_verification_summary_attestation
    use_verification_summary_attestation
    exclude_include_checks
-   source_finder

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -293,6 +293,7 @@ packager =
     build
 publisher =
     twine
+    tox
 # build-system information.
 build_requires =
     setuptools

--- a/tests/integration/cases/pypi_arrow/policy.dl
+++ b/tests/integration/cases/pypi_arrow/policy.dl
@@ -1,0 +1,11 @@
+/* Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("has-hosted-build", component_id, "Require a hosted build and publishing service.") :-
+    check_passed(component_id, "mcn_build_as_code_1").
+
+apply_policy_to("has-hosted-build", component_id) :-
+    is_component(component_id, purl),
+    match("pkg:pypi/arrow.*", purl).

--- a/tests/integration/cases/pypi_arrow/policy_report.json
+++ b/tests/integration/cases/pypi_arrow/policy_report.json
@@ -1,0 +1,22 @@
+{
+    "passed_policies": [],
+    "component_satisfies_policy": [
+        [
+            "2",
+            "pkg:pypi/arrow@1.3.0",
+            "has-hosted-build"
+        ]
+    ],
+    "failed_policies": [
+        [
+            "has-hosted-build"
+        ]
+    ],
+    "component_violates_policy": [
+        [
+            "1",
+            "pkg:pypi/arrow@0.15.0",
+            "has-hosted-build"
+        ]
+    ]
+}

--- a/tests/integration/cases/pypi_arrow/test.yaml
+++ b/tests/integration/cases/pypi_arrow/test.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing two versions of a PyPI package to show the usefulness of being able to analyze a repository at multiple stages,
+  thereby allowing for a more accurate analysis when investigating artifacts that are, or use, outdated libraries.
+
+tags:
+- macaron-python-package
+- tutorial
+
+steps:
+- name: Run macaron analyze on an old version of arrow.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/arrow@0.15.0
+- name: Run macaron analyze on a more recent version of arrow.
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/arrow@1.3.0
+- name: Run macaron verify-policy.
+  kind: verify
+  options:
+    policy: policy.dl
+  expect_fail: true
+- name: Compare verify policy result
+  kind: compare
+  options:
+    kind: policy_report
+    result: output/policy_report.json
+    expected: policy_report.json


### PR DESCRIPTION
## Summary
Improves the deployment specification for pip build tool and adds an integration test to validate the deployment workflow.

## Description of changes

- Deployment spec update: Adds `tox` as a tool often used for Python packages to manage build and publishing.
- Integration test: Adds a dedicated integration test that exercises the updated deployment workflow for `arrow` and makes sure the corresponding tutorial and policy is valid

## Related issues
Fixes https://github.com/oracle/macaron/issues/1249