### PR TITLE
test: update log4j package version to the latest

### DIFF
--- a/.github/workflows/test_macaron_action.yaml
+++ b/.github/workflows/test_macaron_action.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2025 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 name: Test Macaron Action (tutorials)
@@ -111,7 +111,7 @@ jobs:
     - name: Run Macaron (analyze purl - log4j-core example)
       uses: ./
       with:
-        package_url: pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3
+        package_url: pkg:maven/org.apache.logging.log4j/log4j-core@2.25.3
         output_dir: macaron_output/detect_vulnerable_github_actions
 
     - name: Run Macaron (verify policy - github_actions_vulns for purl)

--- a/docs/source/pages/tutorials/detect_malicious_java_dep.rst
+++ b/docs/source/pages/tutorials/detect_malicious_java_dep.rst
@@ -25,7 +25,7 @@ dependencies:
    * - Artifact name
      - `Package URL (PURL) <https://github.com/package-url/purl-spec>`_
    * - `log4j-core <https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-core>`_
-     - ``pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3?type=jar``
+     - ``pkg:maven/org.apache.logging.log4j/log4j-core@2.25.3?type=jar``
    * - `jackson-databind <https://central.sonatype.com/artifact/io.github.behnazh-w.demo/jackson-databind>`_
      - ``pkg:maven/io.github.behnazh-w.demo/jackson-databind@1.0?type=jar``
 
@@ -110,20 +110,20 @@ As you scroll down in the HTML report, you will see a section for the dependenci
 | Macaron has found the two dependencies as expected:
 
 * ``io.github.behnazh-w.demo:jackson-databind:1.0``
-* ``org.apache.logging.log4j:log4j-core:3.0.0-beta3``
+* ``org.apache.logging.log4j:log4j-core:2.25.3``
 
-When we open the reports for each dependency, we see that ``mcn_find_artifact_pipeline_1`` is passed for ``org.apache.logging.log4j:log4j-core:3.0.0-beta3``
-and a GitHub Actions workflow run is found for publishing version ``3.0.0-beta3``. However, this check is failing for ``io.github.behnazh-w.demo:jackson-databind:1.0``.
+When we open the reports for each dependency, we see that ``mcn_find_artifact_pipeline_1`` is passed for ``org.apache.logging.log4j:log4j-core:2.25.3``
+and a GitHub Actions workflow run is found for publishing version ``2.25.3``. However, this check is failing for ``io.github.behnazh-w.demo:jackson-databind:1.0``.
 This means that ``io.github.behnazh-w.demo:jackson-databind:1.0`` could have been built and published manually to Maven Central
 and could potentially be malicious.
 
 .. _fig_find_artifact_pipeline_log4j:
 
 .. figure:: ../../_static/images/tutorial_log4j_find_pipeline.png
-   :alt: mcn_find_artifact_pipeline_1 for org.apache.logging.log4j:log4j-core:3.0.0-beta3
+   :alt: mcn_find_artifact_pipeline_1 for org.apache.logging.log4j:log4j-core:2.25.3
    :align: center
 
-   ``org.apache.logging.log4j:log4j-core:3.0.0-beta3``
+   ``org.apache.logging.log4j:log4j-core:2.25.3``
 
 .. _fig_infer_artifact_pipeline_bh_jackson_databind:
 

--- a/docs/source/pages/tutorials/detect_vulnerable_github_actions.rst
+++ b/docs/source/pages/tutorials/detect_vulnerable_github_actions.rst
@@ -107,7 +107,7 @@ Alternatively, run the ``analyze`` command with the PURL of a package:
 
 .. code-block:: shell
 
-  ./run_macaron.sh analyze -purl pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3
+  ./run_macaron.sh analyze -purl pkg:maven/org.apache.logging.log4j/log4j-core@2.25.3
 
 Then, ensure that the ``mcn_githubactions_vulnerabilities_1`` check passes for the component. You can create a similar policy to the one shown earlier and store it in a file (e.g., ``check_github_actions_vuln.dl``):
 

--- a/tests/integration/cases/org_apache_logging_log4j/policy_purl.dl
+++ b/tests/integration/cases/org_apache_logging_log4j/policy_purl.dl
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved. */
+/* Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved. */
 /* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
 
 #include "prelude.dl"
@@ -20,4 +20,4 @@ Policy("test_policy", component_id, "") :-
     is_repo_url(component_id, "https://github.com/apache/logging-log4j2").
 
 apply_policy_to("test_policy", component_id) :-
-    is_component(component_id, "pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3").
+    is_component(component_id, "pkg:maven/org.apache.logging.log4j/log4j-core@2.25.3").

--- a/tests/integration/cases/org_apache_logging_log4j/test.yaml
+++ b/tests/integration/cases/org_apache_logging_log4j/test.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
@@ -15,7 +15,7 @@ steps:
   options:
     command_args:
     - -purl
-    - pkg:maven/org.apache.logging.log4j/log4j-core@3.0.0-beta3
+    - pkg:maven/org.apache.logging.log4j/log4j-core@2.25.3
 - name: Run macaron verify-policy to verify passed/failed checks
   kind: verify
   options:


### PR DESCRIPTION
## Summary
Update the log4j package version in integration tests to the latest version, for which GitHub workflow runs are not deleted, and update the documentations.