### PR TITLE
feat: validate buildspec dockerfile

### DIFF
--- a/src/macaron/build_spec_generator/common_spec/base_spec.py
+++ b/src/macaron/build_spec_generator/common_spec/base_spec.py
@@ -85,7 +85,7 @@ class BaseBuildSpecDict(TypedDict, total=False):
     has_binaries: NotRequired[bool]
 
     #: The artifacts that were analyzed in generating the build specification.
-    upstream_artifacts: dict[str, str]
+    upstream_artifacts: dict[str, list[str]]
 
 
 class BaseBuildSpec(ABC):

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -708,7 +708,7 @@ class PyPIPackageJsonAsset:
     sdist_url: str = field(init=False)
 
     #: URL of the wheel file.
-    wheel_url: str = field(init=False)
+    wheel_urls: list[str] = field(init=False)
 
     #: The wheel temporary location name.
     wheel_path: str = field(init=False)
@@ -899,7 +899,7 @@ class PyPIPackageJsonAsset:
                         fragment="",
                     ).geturl()
                     logger.debug("Found wheel URL: %s", configured_wheel_url)
-                    self.wheel_url = configured_wheel_url
+                    self.wheel_urls = [configured_wheel_url]
                     return configured_wheel_url
         return None
 

--- a/tests/build_spec_generator/dockerfile/__snapshots__/test_pypi_dockerfile_output.ambr
+++ b/tests/build_spec_generator/dockerfile/__snapshots__/test_pypi_dockerfile_output.ambr
@@ -71,20 +71,23 @@
   
   # Validate script
   RUN cat <<'EOF' >/validate
+      [ -n "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl" ] || { echo "No upstream artifact to validate against."; exit 1; }
       # Capture artifacts generated
-      ARTIFACTS=(/src/dist/*)
-      # Ensure we only have one artefact
-      [ ${#ARTIFACTS[@]} -eq 1 ] || { echo "Unexpected artifacts prodced!"; exit 1; }
-      # BUILT_WHEEL is the artefact we built
-      BUILT_WHEEL=${ARTIFACTS[0]}
+      WHEELS=(/src/dist/*.whl)
+      # Ensure we only have one artifact
+      [ ${#WHEELS[@]} -eq 1 ] || { echo "Unexpected artifacts produced!"; exit 1; }
+      # BUILT_WHEEL is the artifact we built
+      BUILT_WHEEL=${WHEELS[0]}
+      # Ensure the artifact produced is not the literal returned by the glob
+      [ -e $BUILT_WHEEL ] || { echo "No wheels found!"; exit 1; }
       # Download the wheel
       wget -q https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl
       # Compare wheel names
       [ $(basename $BUILT_WHEEL) == "cachetools-6.2.1-py3-none-any.whl" ] || { echo "Wheel name does not match!"; exit 1; }
       # Compare file tree
       (unzip -Z1 $BUILT_WHEEL | grep -v '\.dist-info' | sort) > built.tree
-      (unzip -Z1 "cachetools-6.2.1-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artefact.tree
-      diff -u built.tree pypi_artefact.tree || { echo "File trees do not match!"; exit 1; }
+      (unzip -Z1 "cachetools-6.2.1-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artifact.tree
+      diff -u built.tree pypi_artifact.tree || { echo "File trees do not match!"; exit 1; }
       echo "Success!"
   EOF
   

--- a/tests/build_spec_generator/dockerfile/test_pypi_dockerfile_output.py
+++ b/tests/build_spec_generator/dockerfile/test_pypi_dockerfile_output.py
@@ -33,10 +33,14 @@ def fixture_base_build_spec() -> BaseBuildSpecDict:
             "build_requires": {"setuptools": "==80.9.0", "wheel": ""},
             "build_backends": ["setuptools.build_meta"],
             "upstream_artifacts": {
-                "wheel": "https://files.pythonhosted.org/packages/96/c5/"
-                "1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl",
-                "sdist": "https://files.pythonhosted.org/packages/cc/7e/"
-                "b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz",
+                "wheels": [
+                    "https://files.pythonhosted.org/packages/96/c5/"
+                    "1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl"
+                ],
+                "sdist": [
+                    "https://files.pythonhosted.org/packages/cc/7e/"
+                    "b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz"
+                ],
             },
         }
     )

--- a/tests/integration/cases/pypi_cachetools/expected_default.buildspec
+++ b/tests/integration/cases/pypi_cachetools/expected_default.buildspec
@@ -33,7 +33,11 @@
         "setuptools.build_meta"
     ],
     "upstream_artifacts": {
-        "wheel": "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl",
-        "sdist": "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz"
+        "wheels": [
+            "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl"
+        ],
+        "sdist": [
+            "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz"
+        ]
     }
 }

--- a/tests/integration/cases/pypi_cachetools/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_cachetools/expected_dockerfile.buildspec
@@ -68,20 +68,23 @@ RUN source /deps/bin/activate &&  python -m build --wheel -n
 
 # Validate script
 RUN cat <<'EOF' >/validate
+    [ -n "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl" ] || { echo "No upstream artifact to validate against."; exit 1; }
     # Capture artifacts generated
-    ARTIFACTS=(/src/dist/*)
-    # Ensure we only have one artefact
-    [ ${#ARTIFACTS[@]} -eq 1 ] || { echo "Unexpected artifacts prodced!"; exit 1; }
-    # BUILT_WHEEL is the artefact we built
-    BUILT_WHEEL=${ARTIFACTS[0]}
+    WHEELS=(/src/dist/*.whl)
+    # Ensure we only have one artifact
+    [ ${#WHEELS[@]} -eq 1 ] || { echo "Unexpected artifacts produced!"; exit 1; }
+    # BUILT_WHEEL is the artifact we built
+    BUILT_WHEEL=${WHEELS[0]}
+    # Ensure the artifact produced is not the literal returned by the glob
+    [ -e $BUILT_WHEEL ] || { echo "No wheels found!"; exit 1; }
     # Download the wheel
     wget -q https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl
     # Compare wheel names
     [ $(basename $BUILT_WHEEL) == "cachetools-6.2.1-py3-none-any.whl" ] || { echo "Wheel name does not match!"; exit 1; }
     # Compare file tree
     (unzip -Z1 $BUILT_WHEEL | grep -v '\.dist-info' | sort) > built.tree
-    (unzip -Z1 "cachetools-6.2.1-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artefact.tree
-    diff -u built.tree pypi_artefact.tree || { echo "File trees do not match!"; exit 1; }
+    (unzip -Z1 "cachetools-6.2.1-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artifact.tree
+    diff -u built.tree pypi_artifact.tree || { echo "File trees do not match!"; exit 1; }
     echo "Success!"
 EOF
 

--- a/tests/integration/cases/pypi_markdown-it-py/expected_default.buildspec
+++ b/tests/integration/cases/pypi_markdown-it-py/expected_default.buildspec
@@ -31,7 +31,11 @@
         "flit_core.buildapi"
     ],
     "upstream_artifacts": {
-        "wheel": "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl",
-        "sdist": "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz"
+        "wheels": [
+            "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl"
+        ],
+        "sdist": [
+            "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz"
+        ]
     }
 }

--- a/tests/integration/cases/pypi_markdown-it-py/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_markdown-it-py/expected_dockerfile.buildspec
@@ -68,20 +68,23 @@ RUN source /deps/bin/activate &&  pip install flit && if test -f "flit.ini"; the
 
 # Validate script
 RUN cat <<'EOF' >/validate
+    [ -n "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl" ] || { echo "No upstream artifact to validate against."; exit 1; }
     # Capture artifacts generated
-    ARTIFACTS=(/src/dist/*)
-    # Ensure we only have one artefact
-    [ ${#ARTIFACTS[@]} -eq 1 ] || { echo "Unexpected artifacts prodced!"; exit 1; }
-    # BUILT_WHEEL is the artefact we built
-    BUILT_WHEEL=${ARTIFACTS[0]}
+    WHEELS=(/src/dist/*.whl)
+    # Ensure we only have one artifact
+    [ ${#WHEELS[@]} -eq 1 ] || { echo "Unexpected artifacts produced!"; exit 1; }
+    # BUILT_WHEEL is the artifact we built
+    BUILT_WHEEL=${WHEELS[0]}
+    # Ensure the artifact produced is not the literal returned by the glob
+    [ -e $BUILT_WHEEL ] || { echo "No wheels found!"; exit 1; }
     # Download the wheel
     wget -q https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
     # Compare wheel names
     [ $(basename $BUILT_WHEEL) == "markdown_it_py-4.0.0-py3-none-any.whl" ] || { echo "Wheel name does not match!"; exit 1; }
     # Compare file tree
     (unzip -Z1 $BUILT_WHEEL | grep -v '\.dist-info' | sort) > built.tree
-    (unzip -Z1 "markdown_it_py-4.0.0-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artefact.tree
-    diff -u built.tree pypi_artefact.tree || { echo "File trees do not match!"; exit 1; }
+    (unzip -Z1 "markdown_it_py-4.0.0-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artifact.tree
+    diff -u built.tree pypi_artifact.tree || { echo "File trees do not match!"; exit 1; }
     echo "Success!"
 EOF
 

--- a/tests/integration/cases/pypi_toga/expected_default.buildspec
+++ b/tests/integration/cases/pypi_toga/expected_default.buildspec
@@ -35,7 +35,11 @@
         "setuptools.build_meta"
     ],
     "upstream_artifacts": {
-        "wheel": "https://files.pythonhosted.org/packages/2b/1a/6a9c8230ad30e819f0965bbd596c736a03e16003d27b0363c632c84d4861/toga-0.5.1-py3-none-any.whl",
-        "sdist": "https://files.pythonhosted.org/packages/17/e7/0924150329474d61e9f40f8bba1056d640cba22438e05355924019111b46/toga-0.5.1.tar.gz"
+        "wheels": [
+            "https://files.pythonhosted.org/packages/2b/1a/6a9c8230ad30e819f0965bbd596c736a03e16003d27b0363c632c84d4861/toga-0.5.1-py3-none-any.whl"
+        ],
+        "sdist": [
+            "https://files.pythonhosted.org/packages/17/e7/0924150329474d61e9f40f8bba1056d640cba22438e05355924019111b46/toga-0.5.1.tar.gz"
+        ]
     }
 }

--- a/tests/integration/cases/pypi_toga/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_toga/expected_dockerfile.buildspec
@@ -68,20 +68,23 @@ RUN source /deps/bin/activate &&  python -m build --wheel -n
 
 # Validate script
 RUN cat <<'EOF' >/validate
+    [ -n "https://files.pythonhosted.org/packages/2b/1a/6a9c8230ad30e819f0965bbd596c736a03e16003d27b0363c632c84d4861/toga-0.5.1-py3-none-any.whl" ] || { echo "No upstream artifact to validate against."; exit 1; }
     # Capture artifacts generated
-    ARTIFACTS=(/src/dist/*)
-    # Ensure we only have one artefact
-    [ ${#ARTIFACTS[@]} -eq 1 ] || { echo "Unexpected artifacts prodced!"; exit 1; }
-    # BUILT_WHEEL is the artefact we built
-    BUILT_WHEEL=${ARTIFACTS[0]}
+    WHEELS=(/src/dist/*.whl)
+    # Ensure we only have one artifact
+    [ ${#WHEELS[@]} -eq 1 ] || { echo "Unexpected artifacts produced!"; exit 1; }
+    # BUILT_WHEEL is the artifact we built
+    BUILT_WHEEL=${WHEELS[0]}
+    # Ensure the artifact produced is not the literal returned by the glob
+    [ -e $BUILT_WHEEL ] || { echo "No wheels found!"; exit 1; }
     # Download the wheel
     wget -q https://files.pythonhosted.org/packages/2b/1a/6a9c8230ad30e819f0965bbd596c736a03e16003d27b0363c632c84d4861/toga-0.5.1-py3-none-any.whl
     # Compare wheel names
     [ $(basename $BUILT_WHEEL) == "toga-0.5.1-py3-none-any.whl" ] || { echo "Wheel name does not match!"; exit 1; }
     # Compare file tree
     (unzip -Z1 $BUILT_WHEEL | grep -v '\.dist-info' | sort) > built.tree
-    (unzip -Z1 "toga-0.5.1-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artefact.tree
-    diff -u built.tree pypi_artefact.tree || { echo "File trees do not match!"; exit 1; }
+    (unzip -Z1 "toga-0.5.1-py3-none-any.whl" | grep -v '\.dist-info' | sort ) > pypi_artifact.tree
+    diff -u built.tree pypi_artifact.tree || { echo "File trees do not match!"; exit 1; }
     echo "Success!"
 EOF
 

--- a/tests/integration/cases/pypi_tree-sitter/expected_default.buildspec
+++ b/tests/integration/cases/pypi_tree-sitter/expected_default.buildspec
@@ -24,6 +24,6 @@
         "setuptools.build_meta"
     ],
     "upstream_artifacts": {
-        "sdist": "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz"
+        "sdist": ["https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz"]
     }
 }

--- a/tests/integration/cases/pypi_tree-sitter/test.yaml
+++ b/tests/integration/cases/pypi_tree-sitter/test.yaml
@@ -33,6 +33,6 @@ steps:
   options:
     command_args:
     - -purl
-    - pkg:pypi/markdown-it-py@0.25.2
+    - pkg:pypi/tree-sitter@0.25.2
     - --output-format
     - dockerfile


### PR DESCRIPTION
## Summary
The generated dockerfile now has a small validation script that compares the wheel names and file trees. The validation script is set to be the entrypoint when the built dockerfile is run.

## Description of changes
1. Added field `upstream_artifacts` to `BaseBuildSpecDict`.
2. Using this, we generate the validation script and set it to run when the dockerfile is run.