### PR TITLE
chore: address Value field issue for empty strings in dataflow analysis

### DIFF
--- a/src/macaron/code_analyzer/dataflow_analysis/bash.py
+++ b/src/macaron/code_analyzer/dataflow_analysis/bash.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2025 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Dataflow analysis implementation for analysing Bash shell scripts."""
@@ -1811,7 +1811,7 @@ def convert_shell_word_to_value(
     if dbl_quoted_parts is not None:
         return convert_shell_value_sequence_to_fact_value(dbl_quoted_parts, context), True
 
-    sgl_quoted_str = parse_sql_quoted_string(word)
+    sgl_quoted_str = parse_sgl_quoted_string(word)
     if sgl_quoted_str is not None:
         return facts.StringLiteral(sgl_quoted_str), True
 
@@ -1842,7 +1842,7 @@ def parse_dbl_quoted_string(word: bashparser_model.Word) -> list[LiteralOrEnvVar
     return None
 
 
-def parse_sql_quoted_string(word: bashparser_model.Word) -> str | None:
+def parse_sgl_quoted_string(word: bashparser_model.Word) -> str | None:
     """Parse single quoted string.
 
     If the given word is a single quoted string, return the string
@@ -1851,6 +1851,8 @@ def parse_sql_quoted_string(word: bashparser_model.Word) -> str | None:
     if len(word["Parts"]) == 1:
         part = word["Parts"][0]
         if bashparser_model.is_sgl_quoted(part):
+            if "Value" not in part:
+                return ""
             return part["Value"]
 
     return None

--- a/src/macaron/parsers/bashparser_model.py
+++ b/src/macaron/parsers/bashparser_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Type definitions for Bash AST as produced (and json-serialised) by the "mvdan.cc/sh/v3/syntax" bash parser."""
@@ -159,7 +159,7 @@ class SglQuoted(TypedDict):
     Left: Pos
     Right: Pos
     Dollar: NotRequired[bool]
-    Value: str
+    Value: NotRequired[str]
 
 
 def is_sgl_quoted(part: WordPart) -> TypeGuard[SglQuoted]:


### PR DESCRIPTION
## Summary
This patch addresses an issue in the dataflow analysis related to parsing single-quoted strings in bash scripts. Previously, for empty single-quoted strings the code incorrectly assumed that a `Value` field with an empty string would always be present. 

## Description of changes
- Updated the logic to handle cases where the `Value` field is absent, returning an empty string when appropriate.
- Corrected the typo in function naming: `parse_sql_quoted_string` is now correctly named `parse_sgl_quoted_string`.
- Adjusted the definition of the `SglQuoted` class to reflect that the Value field is not always required