### PR TITLE
chore(deps): update semgrep to v1.149.0 and ignore GHSA-7gcm-g887-7qv7 temporarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # Use bash as the shell when executing a rule's recipe. For more details:
@@ -274,12 +274,13 @@ requirements.txt: pyproject.toml
 # editable mode (like the one in development here) because they may not have
 # a PyPI entry; also print out CVE description and potential fixes if audit
 # found an issue.
+# Ignoring GHSA-7gcm-g887-7qv7: remove the exception when a fix is available.
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-7gcm-g887-7qv7
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # https://flit.pypa.io/en/latest/pyproject_toml.html
@@ -37,7 +37,7 @@ dependencies = [
     "beautifulsoup4 >= 4.12.0,<5.0.0",
     "problog >= 2.2.6,<3.0.0",
     "cryptography >=44.0.0,<45.0.0",
-    "semgrep == 1.113.0",
+    "semgrep == 1.149.0",
     "email-validator >=2.2.0,<3.0.0",
     "rich >=13.5.3,<15.0.0",
     "lark >= 1.3.0,<2.0.0",


### PR DESCRIPTION
## Summary
This PR updates semgrep to v1.149.0 and temporarily ignores GHSA-7gcm-g887-7qv7 until [the fix](https://github.com/protocolbuffers/protobuf/pull/25239) is available.