### PR TITLE
chore: improve pure wheel check

### DIFF
--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -987,9 +987,6 @@ class PyPIPackageJsonAsset:
             try:
                 _, _, _, tags = parse_wheel_filename(file_name)
                 # Check if none and any are in the tags (i.e. the wheel is pure)
-                # Technically a wheel can have multiple tag sets. Our condition for
-                # a pure wheel is that it has only one tag set with abi "none" and
-                # platform "any"
                 if all(tag.abi == "none" and tag.platform == "any" for tag in tags):
                     return True
             except InvalidWheelFilename:


### PR DESCRIPTION
## Summary
Pure wheel check was too strong earlier, and it would not recognize that `astunparse-1.6.3-py2.py3-none-any.whl` was a pure wheel, as the `py2.py3` technically splits it into multiple tags.

## Description of changes
Removed `len(tags) == 1` in `has_pure_wheel` function.