### PR TITLE
chore: update get maintainers to use new JSON API field

### DIFF
--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/closer_release_join_date.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/closer_release_join_date.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Analyzer checks whether the maintainers' join date closer to latest package's release date."""
@@ -10,7 +10,7 @@ from macaron.json_tools import JsonType
 from macaron.malware_analyzer.datetime_parser import parse_datetime
 from macaron.malware_analyzer.pypi_heuristics.base_analyzer import BaseHeuristicAnalyzer
 from macaron.malware_analyzer.pypi_heuristics.heuristics import HeuristicResult, Heuristics
-from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset, PyPIRegistry
+from macaron.slsa_analyzer.package_registry.pypi_registry import PyPIPackageJsonAsset
 
 
 class CloserReleaseJoinDateAnalyzer(BaseHeuristicAnalyzer):
@@ -33,30 +33,28 @@ class CloserReleaseJoinDateAnalyzer(BaseHeuristicAnalyzer):
             return section.getint("timedelta_threshold_of_join_release", 5)
         return 5
 
-    def _get_maintainers_join_date(self, pypi_registry: PyPIRegistry, package_name: str) -> list[datetime] | None:
+    def _get_maintainers_join_date(self, pypi_package_json: PyPIPackageJsonAsset) -> list[datetime] | None:
         """Get the join date of the maintainers.
 
         Each package might have multiple maintainers.
 
         Parameters
         ----------
-        pypi_registry: PyPIRegistry
-            The PyPI registry implementation.
-        package_name: str
-            The package name.
+        pypi_package_json: PyPIPackageJsonAsset
+            The PyPI package JSON asset object.
 
         Returns
         -------
         list[datetime] | None
             The maintainers' join date.
         """
-        maintainers: list | None = pypi_registry.get_maintainers_of_package(package_name)
+        maintainers: list | None = pypi_package_json.get_maintainers_of_package()
         if maintainers is None:
             return None
 
         join_dates: list[datetime] = []
         for maintainer in maintainers:
-            maintainer_join_date = pypi_registry.get_maintainer_join_date(maintainer)
+            maintainer_join_date = pypi_package_json.pypi_registry.get_maintainer_join_date(maintainer)
             if maintainer_join_date is not None:
                 join_dates.append(maintainer_join_date)
 
@@ -94,9 +92,7 @@ class CloserReleaseJoinDateAnalyzer(BaseHeuristicAnalyzer):
         tuple[HeuristicResult, dict[str, JsonType]]:
             The result and related information collected during the analysis.
         """
-        maintainers_join_date: list[datetime] | None = self._get_maintainers_join_date(
-            pypi_package_json.pypi_registry, pypi_package_json.component_name
-        )
+        maintainers_join_date: list[datetime] | None = self._get_maintainers_join_date(pypi_package_json)
         latest_release_date: datetime | None = self._get_latest_release_date(pypi_package_json)
         detail_info: dict[str, JsonType] = {
             "maintainers_join_date": (

--- a/src/macaron/malware_analyzer/pypi_heuristics/metadata/similar_projects.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/metadata/similar_projects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This analyzer checks if the package has a similar structure to other packages maintained by the same user."""
@@ -50,7 +50,7 @@ class SimilarProjectAnalyzer(BaseHeuristicAnalyzer):
         similar_projects: list[str] = []
         result: HeuristicResult = HeuristicResult.PASS
 
-        maintainers = pypi_package_json.pypi_registry.get_maintainers_of_package(pypi_package_json.component_name)
+        maintainers = pypi_package_json.get_maintainers_of_package()
         if not maintainers:
             # NOTE: This would ideally raise an error, identifying malformed package information, but issues with
             # obtaining maintainer information from the HTML page means this will remains as a SKIP for now.

--- a/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
+++ b/src/macaron/slsa_analyzer/package_registry/pypi_registry.py
@@ -397,26 +397,6 @@ class PyPIRegistry(PackageRegistry):
             return html_snippets
         return None
 
-    def get_maintainers_of_package(self, package_name: str) -> list | None:
-        """Implement custom API to get all maintainers of the package.
-
-        Parameters
-        ----------
-        package_name: str
-            The package name.
-
-        Returns
-        -------
-        list | None
-            The list of maintainers.
-        """
-        package_page: str | None = self.get_package_page(package_name)
-        if package_page is None:
-            return None
-        soup = BeautifulSoup(package_page, "html.parser")
-        maintainers = soup.find_all("span", class_="sidebar-section__user-gravatar-text")
-        return list({maintainer.get_text(strip=True) for maintainer in maintainers})
-
     def get_maintainer_profile_page(self, username: str) -> str | None:
         """Implement custom API to get maintainer's profile page.
 
@@ -771,6 +751,25 @@ class PyPIPackageJsonAsset:
             Version to metadata.
         """
         return json_extract(self.package_json, ["releases"], dict)
+
+    def get_maintainers_of_package(self) -> list | None:
+        """Return the names of all maintainers of this package.
+
+        Returns
+        -------
+        list | None
+            The list of maintainers.
+        """
+        maintainers: list[str] = []
+        maintainer_roles = json_extract(self.package_json, ["ownership", "roles"], list)
+        if maintainer_roles is None:
+            return None
+
+        for maintainer_with_role in maintainer_roles:
+            if (maintainer := maintainer_with_role.get("user", None)) is not None:
+                maintainers.append(maintainer)
+
+        return maintainers
 
     def get_project_links(self) -> dict | None:
         """Retrieve the project links from the base metadata.

--- a/tests/malware_analyzer/pypi/test_closer_release_join_date.py
+++ b/tests/malware_analyzer/pypi/test_closer_release_join_date.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for closer release join date heuristic."""
@@ -14,7 +14,7 @@ def test_analyze_pass(pypi_package_json: MagicMock) -> None:
     analyzer = CloserReleaseJoinDateAnalyzer()
 
     # Set up mock return values.
-    pypi_package_json.pypi_registry.get_maintainers_of_package.return_value = ["maintainer1", "maintainer2"]
+    pypi_package_json.get_maintainers_of_package.return_value = ["maintainer1", "maintainer2"]
     pypi_package_json.pypi_registry.get_maintainer_join_date.side_effect = [datetime(2018, 1, 1), datetime(2019, 1, 1)]
     pypi_package_json.get_latest_release_upload_time.return_value = "2022-06-20T12:00:00"
     pypi_package_json.component_name = "mock1"
@@ -33,7 +33,7 @@ def test_analyze_process(pypi_package_json: MagicMock) -> None:
     analyzer = CloserReleaseJoinDateAnalyzer()
 
     # Set up mock return values.
-    pypi_package_json.pypi_registry.get_maintainers_of_package.return_value = ["maintainer1"]
+    pypi_package_json.get_maintainers_of_package.return_value = ["maintainer1"]
     pypi_package_json.pypi_registry.get_maintainer_join_date.side_effect = [datetime(2022, 6, 18)]
     pypi_package_json.get_latest_release_upload_time.return_value = "2022-06-20T12:00:00"
     pypi_package_json.component_name = "mock1"
@@ -52,7 +52,7 @@ def test_analyze_skip(pypi_package_json: MagicMock) -> None:
     analyzer = CloserReleaseJoinDateAnalyzer()
 
     # Set up mock return values.
-    pypi_package_json.pypi_registry.get_maintainers_of_package.return_value = None
+    pypi_package_json.get_maintainers_of_package.return_value = None
     pypi_package_json.get_latest_release_upload_time.return_value = "2022-06-20T12:00:00"
     pypi_package_json.component_name = "mock1"
 


### PR DESCRIPTION
## Summary
The updated [PyPI JSON API](https://docs.pypi.org/api/json/) now includes a field `"ownership"` that containers the maintainers of the package in the JSON result. This PR updates the PyPI Registry code to use this instead of parsing the package HTML page.

## Description of changes
The `"ownership"` field containers the organization associated with a package, and then each user and role. For example, `black@26.1.0` has this:
```
"ownership": {
        "organization": null,
        "roles": [
            {
                "role": "Owner",
                "user": "JelleZijlstra"
            },
            {
                "role": "Owner",
                "user": "ambv"
            },
            {
                "role": "Owner",
                "user": "cooperlees"
            },
            {
                "role": "Owner",
                "user": "willingc"
            },
            {
                "role": "Owner",
                "user": "zsolzsol"
            }
        ]
    }
```
It is much neater and reliable to use this as opposed to parsing the HTML page of a PyPI package. This PR updates the `PyPIPackageJsonAsset` to have the `get_maintainers_of_package` function as part of it instead of the `PyPIRegistry` object, since it is part of the JSON. It then updates all references and uses accordingly.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
