### PR TITLE
ci: run Macaron as a GitHub Action to check workflows

### DIFF
--- a/.github/workflows/macaron-analysis.yaml
+++ b/.github/workflows/macaron-analysis.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+# Run Macaron's policies and generate Verification Summary Attestation reports.
+# See https://github.com/oracle/macaron
+
+name: Run Macaron to check supply chain security issues
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/**
+  pull_request:
+    paths:
+    - .github/workflows/**
+  schedule:
+  - cron: 20 15 * * 3
+permissions:
+  contents: read
+
+jobs:
+  run_macaron:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Check out repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    # Check the GitHub Actions workflows in the repository for vulnerabilities.
+    # Note: adjust the policy_purl to refer to your repository URL.
+    - name: Run Macaron action
+      id: run_macaron
+      continue-on-error: true
+      uses: oracle/macaron@fda4dda04aa7228fcaba162804891806cf5a1375 # v0.22.0
+      with:
+        repo_path: ./
+        policy_file: check-github-actions
+        policy_purl: pkg:github.com/oracle/macaron@.*
+
+    - name: Upload Macaron reports
+      if: ${{ always() }}
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: macaron-reports
+        path: |
+          output/reports/github_com/oracle/macaron/macaron.html
+          output/reports/github_com/oracle/macaron/macaron.json
+          output/macaron.db
+        if-no-files-found: warn
+        retention-days: 90
+
+    - name: Check Verification Summary Attestation check passes
+      if: ${{ always() }}
+      run: |
+        if [ ! -f output/vsa.intoto.jsonl ]; then
+          echo "The check-github-actions policy failed, therefore VSA was not generated at output/vsa.intoto.jsonl. Check the uploaded reports."
+          exit 1
+        fi

--- a/.github/workflows/test_macaron_action.yaml
+++ b/.github/workflows/test_macaron_action.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Analyzing and comparing different versions of an artifact
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5.0.0
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Run Macaron (analyze arrow@1.3.0)
       uses: ./

--- a/docs/source/pages/macaron_action.rst
+++ b/docs/source/pages/macaron_action.rst
@@ -9,7 +9,7 @@ This document describes the composite GitHub Action defined in ``action.yaml`` a
 Quick usage
 -----------
 
-When using this action you can reference the action in your workflow. Example:
+When you use this action, you can reference it directly in your workflow. For a real-world example, check out our `workflow <https://github.com/oracle/macaron/blob/main/.github/workflows/macaron-analysis.yaml>`_ (we use it for dogfooding), or follow the example below to understand how it works:
 
 .. code-block:: yaml
 
@@ -19,13 +19,14 @@ When using this action you can reference the action in your workflow. Example:
       steps:
         - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         - name: Run Macaron Security Analysis Action
-          uses: oracle/macaron@v0.22.0
+          uses: oracle/macaron@fda4dda04aa7228fcaba162804891806cf5a1375 # v0.22.0
           with:
             repo_path: 'https://github.com/example/project'
             policy_file: check-github-actions
             policy_purl: 'pkg:github.com/example/project'
             output_dir: 'macaron-output'
-            upload_attestation: true
+
+If you upload the results like in this `workflow <https://github.com/oracle/macaron/blob/main/.github/workflows/macaron-analysis.yaml>`_ check this :ref:`documentation <detect-vuln-gh-actions-results>` to see how to read and understand them.
 
 Example: policy verification only
 ----------------------------------
@@ -37,11 +38,10 @@ directory containing ``macaron.db``:
 .. code-block:: yaml
 
   - name: Verify policy
-    uses: oracle/macaron@v0.22.0
+    uses: oracle/macaron@fda4dda04aa7228fcaba162804891806cf5a1375 # v0.22.0
     with:
       policy_file: policy.dl
       output_dir: macaron-output
-      upload_attestation: true
 
 Inputs
 ------
@@ -103,7 +103,9 @@ options. Key inputs are listed below (see ``action.yaml`` for the full list):
      - ``output``
    * - ``upload_attestation``
      - When ``true``, the action will attempt to upload a generated
-       verification attestation (VSA) after policy verification.
+       verification attestation (VSA) after policy verification. The attestation will be available
+       under the ``Actions/management`` tab. This feature requires ``id-token: write`` and
+       ``attestations: write`` Job permissions in the GitHub Actions workflow.
      - ``false``
    * - ``subject_path``
      - Path to the artifact serving as the subject of the attestation.
@@ -129,7 +131,8 @@ The composite action exposes the following outputs (set by the
      - Path to the generated VSA (Verification Summary Attestation) in
        `in-toto <https://in-toto.io/>`_ JSONL format. If no VSA was produced
        during verification, the action emits the string ``"VSA Not Generated."``
-       instead of a path.
+       instead of a path. The attestation will be available
+       under the ``Actions/management`` tab.
 
 Default Policies
 ----------------

--- a/docs/source/pages/tutorials/detect_vulnerable_github_actions.rst
+++ b/docs/source/pages/tutorials/detect_vulnerable_github_actions.rst
@@ -126,6 +126,8 @@ Run the ``verify-policy`` command to verify that the check passes:
 
   ./run_macaron.sh verify-policy --database ./output/macaron.db --file ./check_github_actions_vuln.dl
 
+.. _detect-vuln-gh-actions-results:
+
 ******************
 Review the Results
 ******************

--- a/src/macaron/slsa_analyzer/checks/github_actions_vulnerability_check.py
+++ b/src/macaron/slsa_analyzer/checks/github_actions_vulnerability_check.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2025 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains the implementation of the GitHub Actions vulnerabilities check."""
@@ -144,7 +144,9 @@ class GitHubActionsVulnsCheck(BaseCheck):
         # We first send a batch query to see which GitHub Actions are potentially vulnerable.
         # OSV's querybatch returns minimal results but this allows us to only make subsequent
         # queries to get vulnerability details when needed.
-        batch_query = [{"name": k, "ecosystem": "GitHub Actions"} for k, _ in external_workflows.items()]
+        batch_query = [
+            {"package": {"name": k, "ecosystem": "GitHub Actions"}} for k, _ in external_workflows.items() if k
+        ]
         batch_vulns = []
         try:
             batch_vulns = OSVDevService.get_vulnerabilities_package_name_batch(batch_query)
@@ -152,7 +154,8 @@ class GitHubActionsVulnsCheck(BaseCheck):
             logger.debug(error)
 
         result_tables: list[CheckFacts] = []
-        for vuln_res in batch_vulns:
+        for pkg in batch_vulns:
+            vuln_res = pkg["package"]
             vulns: list = []
             workflow_name = vuln_res["name"]
             try:

--- a/src/macaron/slsa_analyzer/package_registry/osv_dev.py
+++ b/src/macaron/slsa_analyzer/package_registry/osv_dev.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2025 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module contains implementation of osv.dev service."""
@@ -102,10 +102,7 @@ class OSVDevService:
         APIAccessError
             If there is an issue with querying the OSV API or if the results do not match the expected size.
         """
-        query_data: dict[str, list] = {"queries": []}
-
-        for pkg in packages:
-            query_data["queries"].append({"package": {"ecosystem": pkg["ecosystem"], "name": pkg["name"]}})
+        query_data: dict[str, list] = {"queries": packages}
 
         # The results returned by OSV reports the vulnerabilities, preserving the order.
         osv_res = OSVDevService.call_osv_querybatch_api(query_data, len(packages))

--- a/tests/integration/cases/oracle_coherence-js-client/policy.dl
+++ b/tests/integration/cases/oracle_coherence-js-client/policy.dl
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("check-github-actions-vulnerabilities", component_id, "Check GitHub Actions vulnerabilities for coherence-js-client") :-
+    check_failed(component_id, "mcn_githubactions_vulnerabilities_1"),
+    github_actions_vulnerabilities_check(
+        _,
+        "[\"https://osv.dev/vulnerability/GHSA-69fq-xp46-6x23\", \"https://osv.dev/vulnerability/GHSA-9p44-j4g5-cfx5\"]",
+        "aquasecurity/trivy-action",
+        "0.32.0",
+        "https://github.com/oracle/coherence-js-client/blob/39166341bc31f75b663ff439dae36170fb3e99a9/.github/workflows/trivy-scan.yml"
+    ).
+
+apply_policy_to("check-github-actions-vulnerabilities", component_id) :-
+    is_component(component_id, "pkg:github.com/oracle/coherence-js-client@39166341bc31f75b663ff439dae36170fb3e99a9").

--- a/tests/integration/cases/oracle_coherence-js-client/test.yaml
+++ b/tests/integration/cases/oracle_coherence-js-client/test.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing oracle/coherence-js-client at commit 39166341bc31f75b663ff439dae36170fb3e99a9
+  and verifying that the GitHub Actions vulnerabilities check fails.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -rp
+    - https://github.com/oracle/coherence-js-client
+    - -d
+    - 39166341bc31f75b663ff439dae36170fb3e99a9
+- name: Run macaron verify-policy to verify that the GitHub Actions vulnerabilities check fails.
+  kind: verify
+  options:
+    policy: policy.dl

--- a/tests/slsa_analyzer/package_registry/test_osv_dev.py
+++ b/tests/slsa_analyzer/package_registry/test_osv_dev.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2025 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """Tests for the osv.dev service."""
@@ -222,3 +222,45 @@ def test_is_affected_version_ranges(vuln: dict, workflow: str, version: str, exp
         OSVDevService.is_version_affected(vuln=vuln, pkg_name=workflow, pkg_version=version, ecosystem="GitHub Actions")
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("packages", "osv_batch_response", "expected"),
+    [
+        pytest.param(
+            [{"package": {"ecosystem": "GitHub Actions", "name": "aquasecurity/trivy-action"}}],
+            {
+                "results": [
+                    {
+                        "vulns": [
+                            {"id": "GHSA-69fq-xp46-6x23", "modified": "2026-03-24T18:02:32.837793Z"},
+                            {"id": "GHSA-9p44-j4g5-cfx5", "modified": "2026-02-22T23:23:29.929429Z"},
+                        ]
+                    }
+                ]
+            },
+            [{"package": {"ecosystem": "GitHub Actions", "name": "aquasecurity/trivy-action"}}],
+            id="Single vulnerable package",
+        ),
+        pytest.param(
+            [{"package": {"ecosystem": "GitHub Actions", "name": ""}}],
+            {"results": [{}]},
+            [],
+            id="Empty package name",
+        ),
+    ],
+)
+def test_get_vulnerabilities_package_name_batch(
+    monkeypatch: pytest.MonkeyPatch, packages: list, osv_batch_response: dict[str, list], expected: list
+) -> None:
+    """Test filtering vulnerable packages from OSV batch query results."""
+
+    def mock_call_osv_querybatch_api(query_data: dict, expected_size: int | None = None) -> list:
+        assert query_data == {"queries": packages}
+        assert query_data["queries"][0]["package"]["name"] == packages[0]["package"]["name"]
+        assert expected_size == len(packages)
+        return osv_batch_response["results"]
+
+    monkeypatch.setattr(OSVDevService, "call_osv_querybatch_api", staticmethod(mock_call_osv_querybatch_api))
+
+    assert OSVDevService.get_vulnerabilities_package_name_batch(packages) == expected


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that runs Oracle Macaron to scan and validate our GitHub Actions workflows for supply chain security issues whenever workflow files change. It also fixes a bug in sending the query to osv.dev and adds relevant tests.

## Description of changes
- Adds a new GitHub Actions workflow that runs Macaron on workflow changes to scan/validate GitHub Actions workflows for supply chain security issues.
- Fixes a bug in the osv.dev request path/format so the correct query is sent when batching package name lookups.
- Adds a new integration test case at for the GitHub Actions detection check.
- Adds unit tests for `get_vulnerabilities_package_name_batch` function.
