### PR TITLE
feat: add support for uv build tool

### DIFF
--- a/src/macaron/build_spec_generator/common_spec/core.py
+++ b/src/macaron/build_spec_generator/common_spec/core.py
@@ -58,6 +58,7 @@ class MacaronBuildToolName(str, Enum):
     GRADLE = "gradle"
     PIP = "pip"
     POETRY = "poetry"
+    UV = "uv"
     FLIT = "flit"
     HATCH = "hatch"
     CONDA = "conda"

--- a/src/macaron/build_spec_generator/common_spec/pypi_spec.py
+++ b/src/macaron/build_spec_generator/common_spec/pypi_spec.py
@@ -56,6 +56,8 @@ class PyPIBuildSpec(
                 build_cmd_spec["command"] = "python -m build --wheel -n".split()
             case "poetry":
                 build_cmd_spec["command"] = "poetry build".split()
+            case "uv":
+                build_cmd_spec["command"] = "uv build".split()
 
             case "flit":
                 # We might also want to deal with existence flit.ini, we can do so via

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -338,6 +338,34 @@ deploy_arg =
 [builder.poetry.ci.deploy]
 github_actions = pypa/gh-action-pypi-publish
 
+# This is the spec for the uv packaging tool.
+[builder.uv]
+entry_conf =
+build_configs = pyproject.toml
+package_lock = uv.lock
+builder =
+    uv
+# build-system information.
+build_requires =
+    uv_build
+    pdm-backend
+build_backend =
+    uv_build
+    pdm.backend
+# These are the Python interpreters that may be used to load modules.
+interpreter =
+    python
+    python3
+interpreter_flag =
+    -m
+build_arg =
+    build
+deploy_arg =
+    publish
+
+[builder.uv.ci.deploy]
+github_actions = pypa/gh-action-pypi-publish
+
 # This is the spec for Flit packaging tool.
 [builder.flit]
 entry_conf =

--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -285,9 +285,9 @@ build_timeout = 600
 [builder.pip]
 entry_conf =
 build_configs =
+    pyproject.toml
     setup.py
     setup.cfg
-    pyproject.toml
 builder =
     build
 publisher =

--- a/src/macaron/slsa_analyzer/build_tool/__init__.py
+++ b/src/macaron/slsa_analyzer/build_tool/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """The build_tool package contains the supported build tools for Macaron."""
@@ -6,6 +6,7 @@
 from macaron.slsa_analyzer.build_tool.conda import Conda
 from macaron.slsa_analyzer.build_tool.flit import Flit
 from macaron.slsa_analyzer.build_tool.hatch import Hatch
+from macaron.slsa_analyzer.build_tool.uv import Uv
 
 from .base_build_tool import BaseBuildTool
 from .docker import Docker
@@ -23,6 +24,7 @@ BUILD_TOOLS: list[BaseBuildTool] = [
     Gradle(),
     Maven(),
     Poetry(),
+    Uv(),
     Flit(),
     Hatch(),
     Conda(),

--- a/src/macaron/slsa_analyzer/build_tool/pip.py
+++ b/src/macaron/slsa_analyzer/build_tool/pip.py
@@ -70,21 +70,28 @@ class Pip(BaseBuildTool):
         results: list[BuildToolConfig] = (
             []
         )
+
         confidence_score = 1.0
         for config_name in self.build_configs:
             if config_path := file_exists(repo_path, config_name, filters=self.path_filters):
-                if os.path.basename(config_path) == "pyproject.toml":
+                config_path_relative = config_path.relative_to(repo_path)
+                if os.path.basename(config_path) == "pyproject.toml" and config_path_relative:
                     # Check the build-system section. If it doesn't exist, by default setuptools should be used.
                     if pyproject.get_build_system(config_path) is None:
-                        results.append((str(config_path.relative_to(repo_path)), confidence_score, None, None))
+                        results.append((str(config_path_relative), confidence_score, None, None))
+                        continue
                     for tool in self.build_requires + self.build_backend:
                         if pyproject.build_system_contains_tool(tool, config_path):
-                            results.append((str(config_path.relative_to(repo_path)), confidence_score, None, None))
+                            results.append((str(config_path_relative), confidence_score, None, None))
                             break
+                    if not results:
+                        # If we still have not found an evidence, we add pip as build tool anyway but with a lower confidence score.
+                        results.append((str(config_path_relative), confidence_score / 2, None, None))
+
                 else:
                     # TODO: For other build configuration files, like setup.py, we need to improve the logic.
-                    results.append((str(config_path.relative_to(repo_path)), confidence_score, None, None))
-                confidence_score = confidence_score / 2
+                    # For now we assign a lower confidence score.
+                    results.append((str(config_path_relative), confidence_score / 2, None, None))
         return results
 
     def get_dep_analyzer(self) -> DependencyAnalyzer:

--- a/src/macaron/slsa_analyzer/build_tool/pip.py
+++ b/src/macaron/slsa_analyzer/build_tool/pip.py
@@ -75,7 +75,7 @@ class Pip(BaseBuildTool):
         for config_name in self.build_configs:
             if config_path := file_exists(repo_path, config_name, filters=self.path_filters):
                 config_path_relative = config_path.relative_to(repo_path)
-                if os.path.basename(config_path) == "pyproject.toml" and config_path_relative:
+                if os.path.basename(config_path) == "pyproject.toml":
                     # Check the build-system section. If it doesn't exist, by default setuptools should be used.
                     if pyproject.get_build_system(config_path) is None:
                         results.append((str(config_path_relative), confidence_score, None, None))
@@ -87,11 +87,12 @@ class Pip(BaseBuildTool):
                     if not results:
                         # If we still have not found an evidence, we add pip as build tool anyway but with a lower confidence score.
                         results.append((str(config_path_relative), confidence_score / 2, None, None))
-
-                else:
-                    # TODO: For other build configuration files, like setup.py, we need to improve the logic.
-                    # For now we assign a lower confidence score.
+                # TODO: For other build configuration files, like setup.py, we need to improve the logic.
+                # For now we assign a lower confidence score if we already have found other config paths.
+                elif results:
                     results.append((str(config_path_relative), confidence_score / 2, None, None))
+                else:
+                    results.append((str(config_path_relative), confidence_score, None, None))
         return results
 
     def get_dep_analyzer(self) -> DependencyAnalyzer:

--- a/src/macaron/slsa_analyzer/build_tool/pip.py
+++ b/src/macaron/slsa_analyzer/build_tool/pip.py
@@ -72,27 +72,29 @@ class Pip(BaseBuildTool):
         )
 
         confidence_score = 1.0
+
+        pyproject_path = file_exists(repo_path, "pyproject.toml", filters=self.path_filters)
+        if pyproject_path:
+            pyproject_path_relative = pyproject_path.relative_to(repo_path)
+            # Check the build-system section. If it doesn't exist, by default setuptools should be used.
+            if pyproject.get_build_system(pyproject_path) is None:
+                results.append((str(pyproject_path_relative), confidence_score, None, None))
+            else:
+                for tool in self.build_requires + self.build_backend:
+                    if pyproject.build_system_contains_tool(tool, pyproject_path):
+                        results.append((str(pyproject_path_relative), confidence_score, None, None))
+                        break
+            if not results:
+                # If we still have not found an evidence, we add pip as build tool anyway but with a lower confidence score.
+                results.append((str(pyproject_path_relative), confidence_score / 2, None, None))
+
         for config_name in self.build_configs:
+            if config_name == "pyproject.toml":
+                continue
             if config_path := file_exists(repo_path, config_name, filters=self.path_filters):
                 config_path_relative = config_path.relative_to(repo_path)
-                if os.path.basename(config_path) == "pyproject.toml":
-                    # Check the build-system section. If it doesn't exist, by default setuptools should be used.
-                    if pyproject.get_build_system(config_path) is None:
-                        results.append((str(config_path_relative), confidence_score, None, None))
-                        continue
-                    for tool in self.build_requires + self.build_backend:
-                        if pyproject.build_system_contains_tool(tool, config_path):
-                            results.append((str(config_path_relative), confidence_score, None, None))
-                            break
-                    if not results:
-                        # If we still have not found an evidence, we add pip as build tool anyway but with a lower confidence score.
-                        results.append((str(config_path_relative), confidence_score / 2, None, None))
-                # TODO: For other build configuration files, like setup.py, we need to improve the logic.
-                # For now we assign a lower confidence score if we already have found other config paths.
-                elif results:
-                    results.append((str(config_path_relative), confidence_score / 2, None, None))
-                else:
-                    results.append((str(config_path_relative), confidence_score, None, None))
+                confidence = confidence_score / 2 if results else confidence_score
+                results.append((str(config_path_relative), confidence, None, None))
         return results
 
     def get_dep_analyzer(self) -> DependencyAnalyzer:

--- a/src/macaron/slsa_analyzer/build_tool/uv.py
+++ b/src/macaron/slsa_analyzer/build_tool/uv.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module contains the Uv class which inherits BaseBuildTool.
+
+This module is used to work with repositories that use uv for dependency management.
+"""
+
+import logging
+import os
+
+from cyclonedx_py import __version__ as cyclonedx_version
+
+from macaron.config.defaults import defaults
+from macaron.config.global_config import global_config
+from macaron.database.table_definitions import Component
+from macaron.dependency_analyzer.cyclonedx import DependencyAnalyzer
+from macaron.dependency_analyzer.cyclonedx_python import CycloneDxPython
+from macaron.slsa_analyzer.build_tool import pyproject
+from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool, BuildToolCommand, file_exists
+from macaron.slsa_analyzer.build_tool.language import BuildLanguage
+from macaron.slsa_analyzer.checks.check_result import Confidence
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class Uv(BaseBuildTool):
+    """This class contains the information of the uv build tool."""
+
+    def __init__(self) -> None:
+        """Initialize instance."""
+        super().__init__(name="uv", language=BuildLanguage.PYTHON, purl_type="pypi")
+
+    def load_defaults(self) -> None:
+        """Load the default values from defaults.ini."""
+        super().load_defaults()
+        if "builder.uv" in defaults:
+            for item in defaults["builder.uv"]:
+                if hasattr(self, item):
+                    setattr(self, item, defaults.get_list("builder.uv", item))
+
+        if "builder.uv.ci.deploy" in defaults:
+            for item in defaults["builder.uv.ci.deploy"]:
+                if item in self.ci_deploy_kws:
+                    self.ci_deploy_kws[item] = defaults.get_list("builder.uv.ci.deploy", item)
+
+    def is_detected(self, target: Component) -> list[tuple[str, float, str | None, str | None]]:
+        """
+        Return the list of build tools and their information used in the target repo.
+
+        Parameters
+        ----------
+        target : Component
+            The target software component.
+
+        Returns
+        -------
+        list[tuple[str, float, str | None, str | None]]
+            Tuples of ``(config_path, confidence_score, build_tool_version, parent_pom)``,
+            where paths are relative to `repo_path` and `parent_pom` may be ``None``.
+        """
+        repo_path, _, _ = self.resolve_component_detection_target(target)
+        if not repo_path:
+            return []
+
+        package_lock_exists = ""
+        for file in self.package_lock:
+            if file_exists(repo_path, file, filters=self.path_filters):
+                package_lock_exists = file
+                break
+
+        results: list[tuple[str, float, str | None, str | None]] = []
+        confidence_score = 1.0
+        file_paths = (file_exists(repo_path, file, filters=self.path_filters) for file in self.build_configs)
+        for config_path in file_paths:
+            if config_path and os.path.basename(config_path) == "pyproject.toml":
+                if package_lock_exists:
+                    results.append((str(config_path.relative_to(repo_path)), confidence_score, None, None))
+                elif pyproject.contains_build_tool("uv", config_path):
+                    results.append((str(config_path.relative_to(repo_path)), confidence_score, None, None))
+                else:
+                    for tool in self.build_requires + self.build_backend:
+                        if pyproject.build_system_contains_tool(tool, config_path):
+                            results.append((str(config_path.relative_to(repo_path)), confidence_score, None, None))
+                            break
+
+                confidence_score = confidence_score / 2
+
+        return results
+
+    def get_dep_analyzer(self) -> DependencyAnalyzer:
+        """Create a DependencyAnalyzer for the build tool.
+
+        Returns
+        -------
+        DependencyAnalyzer
+            The DependencyAnalyzer object.
+        """
+        return CycloneDxPython(
+            resources_path=global_config.resources_path,
+            file_name="python_sbom.json",
+            tool_name="cyclonedx_py",
+            tool_version=cyclonedx_version,
+        )
+
+    def is_deploy_command(
+        self, cmd: BuildToolCommand, excluded_configs: list[str] | None = None, provenance_workflow: str | None = None
+    ) -> tuple[bool, Confidence]:
+        """
+        Determine if the command is a deploy command.
+
+        Parameters
+        ----------
+        cmd: BuildToolCommand
+            The build tool command object.
+        excluded_configs: list[str] | None
+            Build tool commands that are called from these configuration files are excluded.
+        provenance_workflow: str | None
+            The relative path to the root CI file that is captured in a provenance or None if provenance is not found.
+
+        Returns
+        -------
+        tuple[bool, Confidence]
+            Return True along with the inferred confidence level if the command is a deploy tool command.
+        """
+        if cmd["language"] is not self.language:
+            return False, Confidence.HIGH
+
+        build_cmd = cmd["command"]
+        cmd_program_name = os.path.basename(build_cmd[0])
+
+        deploy_tools = self.publisher if self.publisher else self.builder
+        deploy_args = self.deploy_arg
+
+        if cmd_program_name in self.interpreter and len(build_cmd) > 2 and build_cmd[1] in self.interpreter_flag:
+            build_cmd = build_cmd[2:]
+
+        if not self.match_cmd_args(cmd=build_cmd, tools=deploy_tools, args=deploy_args):
+            return False, Confidence.HIGH
+
+        if excluded_configs and os.path.basename(cmd["ci_path"]) in excluded_configs:
+            return False, Confidence.HIGH
+
+        return True, self.infer_confidence_deploy_command(cmd, provenance_workflow)
+
+    def is_package_command(
+        self, cmd: BuildToolCommand, excluded_configs: list[str] | None = None
+    ) -> tuple[bool, Confidence]:
+        """
+        Determine if the command is a packaging command.
+
+        Parameters
+        ----------
+        cmd: BuildToolCommand
+            The build tool command object.
+        excluded_configs: list[str] | None
+            Build tool commands that are called from these configuration files are excluded.
+
+        Returns
+        -------
+        tuple[bool, Confidence]
+            Return True along with the inferred confidence level if the command is a build tool command.
+        """
+        if cmd["language"] is not self.language:
+            return False, Confidence.HIGH
+
+        build_cmd = cmd["command"]
+        cmd_program_name = os.path.basename(build_cmd[0])
+        if not cmd_program_name:
+            return False, Confidence.HIGH
+
+        builder = self.packager if self.packager else self.builder
+        build_args = self.build_arg
+
+        if cmd_program_name in self.interpreter and len(build_cmd) > 2 and build_cmd[1] in self.interpreter_flag:
+            build_cmd = build_cmd[2:]
+
+        if not self.match_cmd_args(cmd=build_cmd, tools=builder, args=build_args):
+            return False, Confidence.HIGH
+
+        if excluded_configs and os.path.basename(cmd["ci_path"]) in excluded_configs:
+            return False, Confidence.HIGH
+
+        return True, Confidence.HIGH

--- a/src/macaron/slsa_analyzer/build_tool/uv.py
+++ b/src/macaron/slsa_analyzer/build_tool/uv.py
@@ -16,7 +16,12 @@ from macaron.database.table_definitions import Component
 from macaron.dependency_analyzer.cyclonedx import DependencyAnalyzer
 from macaron.dependency_analyzer.cyclonedx_python import CycloneDxPython
 from macaron.slsa_analyzer.build_tool import pyproject
-from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool, BuildToolCommand, file_exists
+from macaron.slsa_analyzer.build_tool.base_build_tool import (
+    BaseBuildTool,
+    BuildToolCommand,
+    BuildToolConfig,
+    file_exists,
+)
 from macaron.slsa_analyzer.build_tool.language import BuildLanguage
 from macaron.slsa_analyzer.checks.check_result import Confidence
 
@@ -41,7 +46,7 @@ class Uv(BaseBuildTool):
                 if item in self.ci_deploy_kws:
                     self.ci_deploy_kws[item] = defaults.get_list("builder.uv.ci.deploy", item)
 
-    def is_detected(self, target: Component) -> list[tuple[str, float, str | None, str | None]]:
+    def is_detected(self, target: Component) -> list[BuildToolConfig]:
         """
         Return the list of build tools and their information used in the target repo.
 
@@ -52,9 +57,8 @@ class Uv(BaseBuildTool):
 
         Returns
         -------
-        list[tuple[str, float, str | None, str | None]]
-            Tuples of ``(config_path, confidence_score, build_tool_version, parent_pom)``,
-            where paths are relative to `repo_path` and `parent_pom` may be ``None``.
+        list[BuildToolConfig]
+            See ``BuildToolConfig`` in ``base_build_tool.py`` for field definitions.
         """
         repo_path, _, _ = self.resolve_component_detection_target(target)
         if not repo_path:
@@ -66,7 +70,7 @@ class Uv(BaseBuildTool):
                 package_lock_exists = file
                 break
 
-        results: list[tuple[str, float, str | None, str | None]] = []
+        results: list[BuildToolConfig] = []
         confidence_score = 1.0
         file_paths = (file_exists(repo_path, file, filters=self.path_filters) for file in self.build_configs)
         for config_path in file_paths:

--- a/src/macaron/slsa_analyzer/build_tool/uv.py
+++ b/src/macaron/slsa_analyzer/build_tool/uv.py
@@ -6,7 +6,6 @@
 This module is used to work with repositories that use uv for dependency management.
 """
 
-import logging
 import os
 
 from cyclonedx_py import __version__ as cyclonedx_version
@@ -20,8 +19,6 @@ from macaron.slsa_analyzer.build_tool import pyproject
 from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool, BuildToolCommand, file_exists
 from macaron.slsa_analyzer.build_tool.language import BuildLanguage
 from macaron.slsa_analyzer.checks.check_result import Confidence
-
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 class Uv(BaseBuildTool):

--- a/tests/build_spec_generator/common_spec/test_core.py
+++ b/tests/build_spec_generator/common_spec/test_core.py
@@ -63,6 +63,18 @@ def test_compose_shell_commands(
         pytest.param(
             [
                 BuildToolFacts(
+                    language="python",
+                    build_tool_name="uv",
+                    confidence=1.0,
+                )
+            ],
+            "python",
+            ["uv"],
+            id="python_uv_supported",
+        ),
+        pytest.param(
+            [
+                BuildToolFacts(
                     language="java",
                     build_tool_name="gradle",
                     confidence=1.0,

--- a/tests/build_spec_generator/common_spec/test_pypi_spec.py
+++ b/tests/build_spec_generator/common_spec/test_pypi_spec.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""Tests for PyPI build spec defaults."""
+
+import pytest
+
+from macaron.build_spec_generator.common_spec.base_spec import BaseBuildSpecDict, SpecBuildCommandDict
+from macaron.build_spec_generator.common_spec.pypi_spec import PyPIBuildSpec
+
+
+@pytest.mark.parametrize(
+    ("build_tool", "expected_command"),
+    [
+        ("poetry", ["poetry", "build"]),
+        ("flit", ["flit", "build"]),
+        ("uv", ["uv", "build"]),
+    ],
+)
+def test_set_default_build_commands_for_pypi_tools(build_tool: str, expected_command: list[str]) -> None:
+    """Ensure known PyPI build tools map to expected default build commands."""
+    spec = PyPIBuildSpec(
+        BaseBuildSpecDict(
+            {
+                "ecosystem": "pypi",
+                "purl": "pkg:pypi/example@1.0.0",
+                "language": "python",
+                "build_tools": [build_tool],
+                "macaron_version": "test",
+                "artifact_id": "example",
+                "version": "1.0.0",
+                "language_version": [],
+                "build_commands": [],
+            }
+        )
+    )
+    build_cmd_spec = SpecBuildCommandDict(
+        build_tool=build_tool,
+        command=[],
+        build_config_path="pyproject.toml",
+        confidence_score=1.0,
+    )
+
+    spec.set_default_build_commands(build_cmd_spec)
+    assert build_cmd_spec["command"] == expected_command

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from macaron.slsa_analyzer.build_tool.maven import Maven
 from macaron.slsa_analyzer.build_tool.npm import NPM
 from macaron.slsa_analyzer.build_tool.pip import Pip
 from macaron.slsa_analyzer.build_tool.poetry import Poetry
+from macaron.slsa_analyzer.build_tool.uv import Uv
 from macaron.slsa_analyzer.build_tool.yarn import Yarn
 from macaron.slsa_analyzer.ci_service.base_ci_service import BaseCIService
 from macaron.slsa_analyzer.ci_service.circleci import CircleCI
@@ -164,6 +165,25 @@ def flit_tool(setup_test) -> Flit:  # type: ignore # pylint: disable=unused-argu
     flit = Flit()
     flit.load_defaults()
     return flit
+
+
+@pytest.fixture(autouse=True)
+def uv_tool(setup_test) -> Uv:  # type: ignore # pylint: disable=unused-argument
+    """Create a Uv tool instance.
+
+    Parameters
+    ----------
+    setup_test
+        Depends on setup_test fixture.
+
+    Returns
+    -------
+    Uv
+        The Uv instance.
+    """
+    uv = Uv()
+    uv.load_defaults()
+    return uv
 
 
 @pytest.fixture(autouse=True)
@@ -308,6 +328,7 @@ def get_build_tools(
     gradle_tool: BaseBuildTool,
     pip_tool: BaseBuildTool,
     poetry_tool: BaseBuildTool,
+    uv_tool: BaseBuildTool,
     flit_tool: BaseBuildTool,
     hatch_tool: BaseBuildTool,
     conda_tool: BaseBuildTool,
@@ -326,6 +347,7 @@ def get_build_tools(
         "gradle": gradle_tool,
         "pip": pip_tool,
         "poetry": poetry_tool,
+        "uv": uv_tool,
         "flit": flit_tool,
         "hatch": hatch_tool,
         "conda": conda_tool,

--- a/tests/integration/cases/pypi_cachetools/expected_default.buildspec
+++ b/tests/integration/cases/pypi_cachetools/expected_default.buildspec
@@ -1,5 +1,5 @@
 {
-    "macaron_version": "0.22.0",
+    "macaron_version": "0.23.0",
     "group_id": null,
     "artifact_id": "cachetools",
     "version": "6.2.1",
@@ -25,7 +25,7 @@
                 "--wheel",
                 "-n"
             ],
-            "build_config_path": "setup.py",
+            "build_config_path": "pyproject.toml",
             "confidence_score": 1.0
         }
     ],

--- a/tests/integration/cases/pypi_markdown-it-py/expected_default.buildspec
+++ b/tests/integration/cases/pypi_markdown-it-py/expected_default.buildspec
@@ -1,5 +1,5 @@
 {
-    "macaron_version": "0.22.0",
+    "macaron_version": "0.23.0",
     "group_id": null,
     "artifact_id": "markdown-it-py",
     "version": "4.0.0",
@@ -14,7 +14,8 @@
     "purl": "pkg:pypi/markdown-it-py@4.0.0",
     "language": "python",
     "build_tools": [
-        "flit"
+        "flit",
+        "pip"
     ],
     "build_commands": [
         {

--- a/tests/slsa_analyzer/build_tool/test_pip.py
+++ b/tests/slsa_analyzer/build_tool/test_pip.py
@@ -1,199 +1,69 @@
-# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """This module tests the Pip build functions."""
 
+from pathlib import Path
+
 import pytest
 
-from macaron.slsa_analyzer.build_tool.base_build_tool import BuildToolCommand
-from macaron.slsa_analyzer.build_tool.language import BuildLanguage
 from macaron.slsa_analyzer.build_tool.pip import Pip
+from tests.conftest import MockAnalyzeContext
 
 
 @pytest.mark.parametrize(
-    (
-        "command",
-        "language",
-        "language_versions",
-        "language_distributions",
-        "ci_path",
-        "reachable_secrets",
-        "events",
-        "excluded_configs",
-        "expected_result",
-    ),
+    ("build_configs", "repo_files", "expected_value"),
     [
         (
-            ["twine", "upload"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/release.yaml",
-            [{"key", "pass"}],
-            ["release"],
-            ["codeql-analysis.yaml"],
-            True,
+            ["setup.py", "pyproject.toml", "setup.cfg"],
+            {
+                "setup.py": "",
+                "pyproject.toml": "",
+            },
+            [
+                ("pyproject.toml", 1.0, None, None),
+                ("setup.py", 0.5, None, None),
+            ],
         ),
         (
-            ["flit", "publish"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/pip.yaml",
-            [{"key", "pass"}],
-            ["push"],
-            ["pip.yaml"],
-            False,
+            ["setup.py", "setup.cfg"],
+            {
+                "setup.py": "",
+                "setup.cfg": "",
+            },
+            [
+                ("setup.py", 1.0, None, None),
+                ("setup.cfg", 0.5, None, None),
+            ],
         ),
         (
-            ["python", "-m", "twine", "upload"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/release.yaml",
-            [{"key", "pass"}],
-            ["release"],
-            ["codeql-analysis.yaml"],
-            True,
-        ),
-        (
-            ["flit", "publish"],
-            BuildLanguage.JAVASCRIPT,
-            None,
-            None,
-            ".github/workflows/release.yaml",
-            [{"key", "pass"}],
-            ["push"],
-            None,
-            False,
+            ["setup.py", "setup.cfg", "pyproject.toml"],
+            {
+                "setup.py": "",
+                "setup.cfg": "",
+                "pyproject.toml": '[build-system]\nrequires = ["pdm-backend>=2.4.0"]\nbuild-backend = "pdm.backend"\n',
+            },
+            [
+                ("pyproject.toml", 0.5, None, None),
+                ("setup.py", 0.5, None, None),
+                ("setup.cfg", 0.5, None, None),
+            ],
         ),
     ],
 )
-def test_is_pip_deploy_command(
+def test_pip_build_tool_detection(
     pip_tool: Pip,
-    command: list[str],
-    language: str,
-    language_versions: list[str],
-    language_distributions: list[str],
-    ci_path: str,
-    reachable_secrets: list[str],
-    events: list[str],
-    excluded_configs: list[str] | None,
-    expected_result: bool,
+    tmp_path: Path,
+    build_configs: list[str],
+    repo_files: dict[str, str],
+    expected_value: list[tuple[str, float, str | None, str | None]],
 ) -> None:
-    """Test the deploy commend detection function."""
-    result, _ = pip_tool.is_deploy_command(
-        BuildToolCommand(
-            command=command,
-            language=language,
-            language_versions=language_versions,
-            language_distributions=language_distributions,
-            language_url=None,
-            ci_path=ci_path,
-            step_node=None,
-            reachable_secrets=reachable_secrets,
-            events=events,
-        ),
-        excluded_configs=excluded_configs,
-    )
-    assert result == expected_result
+    """Test pyproject prioritization and confidence scoring across config combinations."""
+    pip_tool.build_configs = build_configs
+    for relative_path, content in repo_files.items():
+        path = tmp_path.joinpath(relative_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
 
-
-@pytest.mark.parametrize(
-    (
-        "command",
-        "language",
-        "language_versions",
-        "language_distributions",
-        "ci_path",
-        "reachable_secrets",
-        "events",
-        "excluded_configs",
-        "expected_result",
-    ),
-    [
-        (
-            ["python", "-m", "build"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/release.yaml",
-            [{"key", "pass"}],
-            ["release"],
-            ["codeql-analysis.yaml"],
-            True,
-        ),
-        (
-            ["python", "-m", "flit", "build"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/build.yaml",
-            [{"key", "pass"}],
-            ["push"],
-            None,
-            False,
-        ),
-        (
-            ["python", "-m", "flit", "build"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/flit.yaml",
-            [{"key", "pass"}],
-            ["push"],
-            ["flit.yaml"],
-            False,
-        ),
-        (
-            ["pip", "install", "--upgrade", "pip"],
-            BuildLanguage.PYTHON,
-            None,
-            None,
-            ".github/workflows/release.yaml",
-            [{"key", "pass"}],
-            ["release"],
-            ["codeql-analysis.yaml"],
-            False,
-        ),
-        (
-            ["pip", "build"],
-            BuildLanguage.JAVA,
-            None,
-            None,
-            ".github/workflows/release.yaml",
-            [{"key", "pass"}],
-            ["push"],
-            None,
-            False,
-        ),
-    ],
-)
-def test_is_pip_package_command(
-    pip_tool: Pip,
-    command: list[str],
-    language: str,
-    language_versions: list[str],
-    language_distributions: list[str],
-    ci_path: str,
-    reachable_secrets: list[str],
-    events: list[str],
-    excluded_configs: list[str] | None,
-    expected_result: bool,
-) -> None:
-    """Test the packaging command detection function."""
-    result, _ = pip_tool.is_package_command(
-        BuildToolCommand(
-            command=command,
-            language=language,
-            language_versions=language_versions,
-            language_distributions=language_distributions,
-            language_url=None,
-            ci_path=ci_path,
-            step_node=None,
-            reachable_secrets=reachable_secrets,
-            events=events,
-        ),
-        excluded_configs=excluded_configs,
-    )
-    assert result == expected_result
+    ctx = MockAnalyzeContext(macaron_path="", output_dir="", fs_path=str(tmp_path))
+    assert pip_tool.is_detected(ctx.component) == expected_value

--- a/tests/slsa_analyzer/build_tool/test_uv.py
+++ b/tests/slsa_analyzer/build_tool/test_uv.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""This module tests the Uv build functions."""
+
+from pathlib import Path
+
+import pytest
+
+from macaron.slsa_analyzer.build_tool.uv import Uv
+from tests.conftest import MockAnalyzeContext
+
+
+@pytest.mark.parametrize(
+    ("repo_files", "expected_value"),
+    [
+        (
+            {
+                "pyproject.toml": '[project]\nname = "sample"\nversion = "0.1.0"\n[tool.uv]\n',
+                "uv.lock": "version = 1\n",
+            },
+            [("pyproject.toml", 1.0, None, None)],
+        ),
+        (
+            {
+                "pyproject.toml": (
+                    '[build-system]\nrequires = ["uv_build>=0.9.5,<0.10.0"]\nbuild-backend = "uv_build"\n'
+                ),
+            },
+            [("pyproject.toml", 1.0, None, None)],
+        ),
+        (
+            {
+                "pyproject.toml": (
+                    '[build-system]\nrequires = ["pdm-backend>=2.4.0"]\nbuild-backend = "pdm.backend"\n'
+                ),
+            },
+            [("pyproject.toml", 1.0, None, None)],
+        ),
+        (
+            {
+                "pyproject.toml": '[project]\nname = "sample"\nversion = "0.1.0"\n',
+            },
+            [],
+        ),
+    ],
+)
+def test_uv_build_tool_with_pyproject_detection(
+    uv_tool: Uv,
+    tmp_path: Path,
+    repo_files: dict[str, str],
+    expected_value: list[tuple[str, float, str | None, str | None]],
+) -> None:
+    """Test uv detection with lock file, tool section, and build-system metadata."""
+    for relative_path, content in repo_files.items():
+        path = tmp_path.joinpath(relative_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    ctx = MockAnalyzeContext(macaron_path="", output_dir="", fs_path=str(tmp_path))
+    assert uv_tool.is_detected(ctx.component) == expected_value


### PR DESCRIPTION
## Summary
This PR adds support for detecting uv as a Python build tool and improves Python build-tool reporting reliability.

## Description of changes
- Added build-tool detection support for uv in Python projects.
- Improved pip detection behavior:
  - pip is now always reported for Python projects when relevant Python config files are present.
  - Detection confidence for pip is now adjusted to better reflect inferred vs explicit signals.
- Updated detection logic to better handle multi-tool Python environments where tools can coexist.

## Related issues
Closes https://github.com/oracle/macaron/issues/1083