### PR TITLE
chore: add a new Makefile target `simple-index` which builds all distribution artifacts and then creates a PEP-503 compatible Simple Index in the dist/ folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,19 @@ docs-api:
 .PHONY: docs-full
 docs-full: docs-api docs
 
+# Build a PEP-503 compatible Simple Repository directory inside of dist/. For details on
+# the layout of that directory and the normalized project name, see: https://peps.python.org/pep-0503/
+# The directory can then be used to install (hashed) artifacts by using `pip` and
+# its `--extra-index-url` argument: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url
+PROJECT_NAME := $(shell python -c $$'import re; print(re.sub(r"[-_.]+", "-", "$(PACKAGE_NAME)").lower());')
+.PHONY: simple-index
+simple-index: dist/$(PACKAGE_WHEEL_DIST_NAME).whl dist/$(PACKAGE_SDIST_NAME).tar.gz
+	mkdir -p dist/simple-index/$(PROJECT_NAME)
+	echo -e "<!-- https://peps.python.org/pep-0503/ -->\n<!DOCTYPE html><html lang='en'><head><meta name='pypi:repository-version' content='1.3'><title>Simple Index</title></head><body><a href='$(PACKAGE_NAME)/index.html'>$(PACKAGE_NAME)</a></body></html>" > dist/simple-index/index.html
+	echo -e "<!-- https://peps.python.org/pep-0503/ -->\n<!DOCTYPE html><html lang='en'><head><meta name='pypi:repository-version' content='1.3'><title>Simple Index: $(PROJECT_NAME)</title></head><body><ul><li><a href='$(PACKAGE_WHEEL_DIST_NAME).whl#sha256="$$(python -c "with open('dist/$(PACKAGE_WHEEL_DIST_NAME).whl', 'rb') as f: import hashlib; print(hashlib.sha256(f.read()).hexdigest());")"'>$(PACKAGE_WHEEL_DIST_NAME).whl</a></li><li><a href='$(PACKAGE_SDIST_NAME).tar.gz#sha256="$$(python -c "with open('dist/$(PACKAGE_SDIST_NAME).tar.gz', 'rb') as f: import hashlib; print(hashlib.sha256(f.read()).hexdigest());")"'>$(PACKAGE_SDIST_NAME).tar.gz</a></li></ul></body></html>" > dist/simple-index/$(PROJECT_NAME)/index.html
+	cp -f dist/$(PACKAGE_WHEEL_DIST_NAME).whl dist/simple-index/$(PROJECT_NAME)/
+	cp -f dist/$(PACKAGE_SDIST_NAME).tar.gz dist/simple-index/$(PROJECT_NAME)/
+
 # Build the Docker image. The image name and tag are read from IMAGE_NAME and RELEASE_TAG
 # environment variables, respectively. By default "test" is used as the image tag.
 .PHONY: build-docker


### PR DESCRIPTION
## Summary

Add a new Makefile target `simple-index` which builds all distribution artifacts and then creates a PEP-503 compatible Simple Index in the dist/ folder.

## Description of changes

The Simple Index structure is defined in [PEP 503](https://peps.python.org/pep-0503/) and this change works as follows:
```bash
~ > mkdir /tmp/macaron-index/
~ > cd /tmp/macaron-index/
/tmp/macaron-index > python -m venv .venv  # Create a new virtual environment and activate it.
/tmp/macaron-index > . .venv/bin/activate
/tmp/macaron-index > pip install --extra-index-url file:///path/to/macaron/dist/simple-index/ macaron  # Install the Macaron package.
Looking in indexes: https://pypi.org/simple, file:///path/to/macaron/dist/simple-index/
Processing /path/to/macaron/dist/simple-index/macaron/macaron-0.23.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
WARNING: Location '/path/to/macaron/dist/simple-index/requests/' is ignored: it is either a non-existing path or lacks a specific scheme.
Collecting requests<3.0.0,>=2.32.3 (from macaron)
  Using cached requests-2.33.1-py3-none-any.whl.metadata (4.8 kB)
```
We can ignore the warnings because the Simple Index contains only the Macaron package; all other packages fall back to the global PyPI default index.

## Related issues

No related issue, but the changes are cherry-picked from PR https://github.com/oracle/macaron/pull/1355.

## Checklist

- [X] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [X] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [X] My commits include the "Signed-off-by" line.
- [X] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [ ] I have updated the relevant documentation, if applicable.
- [ ] I have tested my changes and verified they work as expected.
