### PR TITLE
build: make the Docker image building reproducible by using Macaron’s pinned and hashed requirements.txt

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This is a trusted builder implemented as a reusable workflow that can be called by other
@@ -115,12 +115,13 @@ jobs:
         set -euo pipefail
         TARBALL_PATH=$(find dist/ -type f -name "*.tar.gz")
         WHEEL_PATH=$(find dist/ -type f -name "*.whl")
+        SIMPLE_INDEX_PATH=$(find dist/ -type f -name "*-simple-index.tar")
         REQUIREMENTS_PATH=$(find dist/ -type f -name "*-requirements.txt")
         SBOM_PATH=$(find dist/ -type f -name "*-sbom.json")
         SBOM_GO_PATH=$(find dist/ -type f -name "*-sbom-go.json")
         HTML_DOCS_PATH=$(find dist/ -type f -name "*-docs-html.zip")
         BUILD_EPOCH_PATH=$(find dist/ -type f -name "*-build-epoch.txt")
-        DIGEST=$(sha256sum "$TARBALL_PATH" "$WHEEL_PATH" "$REQUIREMENTS_PATH" "$SBOM_PATH" \
+        DIGEST=$(sha256sum "$TARBALL_PATH" "$WHEEL_PATH" "$SIMPLE_INDEX_PATH" "$REQUIREMENTS_PATH" "$SBOM_PATH" \
           "$SBOM_GO_PATH" "$HTML_DOCS_PATH" "$BUILD_EPOCH_PATH" | base64 -w0)
         echo "Digest of artifacts is $DIGEST."
         echo "artifacts-sha256=$DIGEST" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -107,7 +107,8 @@ jobs:
 
     # Find the paths to the artifact files that will be included in the release, compute
     # the SHA digest for all the release files and encode them using Base64, and export it
-    # from this job.
+    # from this job. Note that using -maxdepth 1 prevents searching through the generated
+    # Simple Index, which contains duplicated sdist and wheel files.
     - name: Compute package hash
       if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
       id: compute-hash
@@ -116,12 +117,12 @@ jobs:
         set -euo pipefail
         TARBALL_PATH=$(find dist/ -maxdepth 1 -type f -name "*.tar.gz")
         WHEEL_PATH=$(find dist/ -maxdepth 1 -type f -name "*.whl")
-        SIMPLE_INDEX_PATH=$(find dist/ -type f -name "*-simple-index.tar")
-        REQUIREMENTS_PATH=$(find dist/ -type f -name "*-requirements.txt")
-        SBOM_PATH=$(find dist/ -type f -name "*-sbom.json")
-        SBOM_GO_PATH=$(find dist/ -type f -name "*-sbom-go.json")
-        HTML_DOCS_PATH=$(find dist/ -type f -name "*-docs-html.zip")
-        BUILD_EPOCH_PATH=$(find dist/ -type f -name "*-build-epoch.txt")
+        SIMPLE_INDEX_PATH=$(find dist/ -maxdepth 1 -type f -name "*-simple-index.tar")
+        REQUIREMENTS_PATH=$(find dist/ -maxdepth 1 -type f -name "*-requirements.txt")
+        SBOM_PATH=$(find dist/ -maxdepth 1 -type f -name "*-sbom.json")
+        SBOM_GO_PATH=$(find dist/ -maxdepth 1 -type f -name "*-sbom-go.json")
+        HTML_DOCS_PATH=$(find dist/ -maxdepth 1 -type f -name "*-docs-html.zip")
+        BUILD_EPOCH_PATH=$(find dist/ -maxdepth 1 -type f -name "*-build-epoch.txt")
         DIGEST=$(sha256sum "$TARBALL_PATH" "$WHEEL_PATH" "$SIMPLE_INDEX_PATH" "$REQUIREMENTS_PATH" "$SBOM_PATH" \
           "$SBOM_GO_PATH" "$HTML_DOCS_PATH" "$BUILD_EPOCH_PATH" | base64 -w0)
         echo "Digest of artifacts is $DIGEST."

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -114,8 +114,8 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-        TARBALL_PATH=$(find dist/ -type f -name "*.tar.gz")
-        WHEEL_PATH=$(find dist/ -type f -name "*.whl")
+        TARBALL_PATH=$(find dist/ -maxdepth 1 -type f -name "*.tar.gz")
+        WHEEL_PATH=$(find dist/ -maxdepth 1 -type f -name "*.whl")
         SIMPLE_INDEX_PATH=$(find dist/ -type f -name "*-simple-index.tar")
         REQUIREMENTS_PATH=$(find dist/ -type f -name "*-requirements.txt")
         SBOM_PATH=$(find dist/ -type f -name "*-sbom.json")

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -82,11 +82,12 @@ jobs:
     - name: Audit installed packages
       run: make audit
 
-    # Build the sdist and wheel distribution of the package and docs as a zip file.
-    # We don't need to check and test the package separately because `make dist` runs
-    # those targets first and only builds the package if they succeed.
+    # Build the sdist and wheel distribution of the package and docs as a zip file,
+    # as well as a PEP-503 simple index and its archives. We don't need to check and
+    # test the package separately because `make dist` runs those targets first and
+    # only builds the packages and index if they succeed.
     - name: Build the package
-      run: make dist
+      run: make dist simple-index
       env:
         GITHUB_TOKEN: ${{ github.token }}
 

--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,8 @@ simple-index: dist/$(PACKAGE_WHEEL_DIST_NAME).whl dist/$(PACKAGE_SDIST_NAME).tar
 	echo -e "<!-- https://peps.python.org/pep-0503/ -->\n<!DOCTYPE html><html lang='en'><head><meta name='pypi:repository-version' content='1.3'><title>Simple Index: $(PROJECT_NAME)</title></head><body><ul><li><a href='$(PACKAGE_WHEEL_DIST_NAME).whl#sha256="$$(python -c "with open('dist/$(PACKAGE_WHEEL_DIST_NAME).whl', 'rb') as f: import hashlib; print(hashlib.sha256(f.read()).hexdigest());")"'>$(PACKAGE_WHEEL_DIST_NAME).whl</a></li><li><a href='$(PACKAGE_SDIST_NAME).tar.gz#sha256="$$(python -c "with open('dist/$(PACKAGE_SDIST_NAME).tar.gz', 'rb') as f: import hashlib; print(hashlib.sha256(f.read()).hexdigest());")"'>$(PACKAGE_SDIST_NAME).tar.gz</a></li></ul></body></html>" > dist/simple-index/$(PROJECT_NAME)/index.html
 	cp -f dist/$(PACKAGE_WHEEL_DIST_NAME).whl dist/simple-index/$(PROJECT_NAME)/
 	cp -f dist/$(PACKAGE_SDIST_NAME).tar.gz dist/simple-index/$(PROJECT_NAME)/
+	python -m zipfile --create dist/$(PACKAGE_SDIST_NAME)-pep503-simple-index.zip dist/simple-index/
+	python -m tarfile --create dist/$(PACKAGE_SDIST_NAME)-pep503-simple-index.tar dist/simple-index/
 
 # Build the Docker image. The image name and tag are read from IMAGE_NAME and RELEASE_TAG
 # environment variables, respectively. By default "test" is used as the image tag.

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,6 @@ simple-index: dist/$(PACKAGE_WHEEL_DIST_NAME).whl dist/$(PACKAGE_SDIST_NAME).tar
 	echo -e "<!-- https://peps.python.org/pep-0503/ -->\n<!DOCTYPE html><html lang='en'><head><meta name='pypi:repository-version' content='1.3'><title>Simple Index: $(PROJECT_NAME)</title></head><body><ul><li><a href='$(PACKAGE_WHEEL_DIST_NAME).whl#sha256="$$(python -c "with open('dist/$(PACKAGE_WHEEL_DIST_NAME).whl', 'rb') as f: import hashlib; print(hashlib.sha256(f.read()).hexdigest());")"'>$(PACKAGE_WHEEL_DIST_NAME).whl</a></li><li><a href='$(PACKAGE_SDIST_NAME).tar.gz#sha256="$$(python -c "with open('dist/$(PACKAGE_SDIST_NAME).tar.gz', 'rb') as f: import hashlib; print(hashlib.sha256(f.read()).hexdigest());")"'>$(PACKAGE_SDIST_NAME).tar.gz</a></li></ul></body></html>" > dist/simple-index/$(PROJECT_NAME)/index.html
 	cp -f dist/$(PACKAGE_WHEEL_DIST_NAME).whl dist/simple-index/$(PROJECT_NAME)/
 	cp -f dist/$(PACKAGE_SDIST_NAME).tar.gz dist/simple-index/$(PROJECT_NAME)/
-	python -m zipfile --create dist/$(PACKAGE_SDIST_NAME)-pep503-simple-index.zip dist/simple-index/
 	python -m tarfile --create dist/$(PACKAGE_SDIST_NAME)-pep503-simple-index.tar dist/simple-index/
 
 # Build the Docker image. The image name and tag are read from IMAGE_NAME and RELEASE_TAG

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -37,9 +37,9 @@ USER macaron:macaron
 COPY --chown=macaron:macaron $SIMPLE_INDEX_PATH $HOME/dist/macaron-simple-index.tar
 COPY --chown=macaron:macaron $REQUIREMENTS_PATH $HOME/dist/macaron-requirements.txt
 RUN : \
-    && tar --extract --directory $HOME/ --file $HOME/dist/macaron-simple-index.tar \
     && python3 -m venv $HOME/.venv \
     && . .venv/bin/activate \
+    && python3 -m tarfile --extract $HOME/dist/macaron-simple-index.tar $HOME/ \
     && python3 -m pip install --no-compile --no-cache-dir --upgrade pip setuptools \
     && python3 -m pip install --no-compile --no-cache-dir --no-deps --extra-index-url file://$HOME/dist/simple-index/ --requirement $HOME/dist/macaron-requirements.txt \
     && rm -rf $HOME/dist \

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -15,8 +15,6 @@ FROM ghcr.io/oracle/macaron-base:latest@sha256:6d1d300d32060a75deffd2e6fce00e9f6
 
 ENV HOME="/home/macaron"
 
-ENV PACKAGE_PATH=$HOME/.venv/lib/python3.11/site-packages/macaron
-
 # Create the macaron user and group with arbitrary UID and GID.
 # The macaron GID and UID in this image will be modified by the
 # user.sh script on startup to get the UID and GID of the user who started
@@ -27,19 +25,23 @@ RUN : \
 
 WORKDIR $HOME
 
-# Build time ARG. This argument specifies the path of the wheel file from the host machine.
-ARG WHEEL_PATH
+# Build time ARGs. These arguments specify the path of Macaron's PEP-503 simple index
+# archive and its requirements.txt from the host.
+ARG SIMPLE_INDEX_PATH
+ARG REQUIREMENTS_PATH
 
 # Installing the Python dependencies in the Python virtual environment.
 # We switch to user macaron so that when we install the dependencies using pip,
 # the warning of not having correct ownership of /home/macaron is not raised.
 USER macaron:macaron
-COPY --chown=macaron:macaron $WHEEL_PATH $HOME/dist/
+COPY --chown=macaron:macaron $SIMPLE_INDEX_PATH $HOME/dist/macaron-simple-index.tar
+COPY --chown=macaron:macaron $REQUIREMENTS_PATH $HOME/dist/macaron-requirements.txt
 RUN : \
+    && tar --extract --directory $HOME/ --file $HOME/dist/macaron-simple-index.tar \
     && python3 -m venv $HOME/.venv \
     && . .venv/bin/activate \
-    && pip install --no-compile --no-cache-dir --upgrade pip setuptools \
-    && find $HOME/dist -depth \( -type f \( -name "macaron-*.whl" \) \) -exec pip install --no-compile --no-cache-dir '{}' \; \
+    && python3 -m pip install --no-compile --no-cache-dir --upgrade pip setuptools \
+    && python3 -m pip install --no-compile --no-cache-dir --no-deps --extra-index-url file://$HOME/dist/simple-index/ --requirement $HOME/dist/macaron-requirements.txt \
     && rm -rf $HOME/dist \
     && deactivate
 

--- a/scripts/dev_scripts/build_docker.sh
+++ b/scripts/dev_scripts/build_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 # This script is used to build the Docker image. The built image will always be tagged with `latest`.
@@ -10,6 +10,10 @@
 #   $ RELEASE_TAG: The additionally release tag to tag the final built image. If it's empty, the built image
 #       will be additionally tagged with `test`.
 
+if [ "$#" -ne 3 ];
+then
+    echo "Illegal number of parameters" && exit 1
+fi
 IMAGE_NAME=$1
 WORKSPACE=$2
 RELEASE_TAG=$3
@@ -17,29 +21,33 @@ RELEASE_TAG=$3
 DIST_PATH="${WORKSPACE}/dist"
 REPO_PATH="${WORKSPACE}"
 
-WHEEL_PATH=$(find "$DIST_PATH" -depth -type f -name 'macaron-*.whl' | head -n 1)
-if [[ -z "${WHEEL_PATH}" ]];
-then
-    echo "Unable to find Macaron wheel file in ${DIST_PATH}."
+SIMPLE_INDEX_PATH=$(find "$DIST_PATH" -depth -type f -name 'macaron-*-pep503-simple-index.tar' | head -n 1)
+if [[ -z "${SIMPLE_INDEX_PATH}" ]]; then
+    echo "Unable to find Macaron Simple Index in ${DIST_PATH}."
     exit 1
 fi
 
-# We need to use the relative path so that it works in the docker context.
-WHEEL_PATH=$(realpath --relative-to="$REPO_PATH" "$WHEEL_PATH")
+REQUIREMENTS_PATH=$(find "$DIST_PATH" -depth -type f -name 'macaron-*-requirements.txt' | head -n 1)
+if [[ -z "${REQUIREMENTS_PATH}" ]]; then
+    echo "Unable to find Macaron requirements.txt in ${DIST_PATH}."
+    exit 1
+fi
 
 if [[ -z "${RELEASE_TAG}" ]];
 then
     docker build \
-        -t "${IMAGE_NAME}:latest" \
-        -t "${IMAGE_NAME}:test" \
-        --build-arg WHEEL_PATH="${WHEEL_PATH}" \
-        -f "${REPO_PATH}/docker/Dockerfile.final" "${REPO_PATH}"
+        --tag "${IMAGE_NAME}:latest" \
+        --tag "${IMAGE_NAME}:test" \
+        --build-arg SIMPLE_INDEX_PATH="${SIMPLE_INDEX_PATH}" \
+        --build-arg REQUIREMENTS_PATH="${REQUIREMENTS_PATH}" \
+        --file "${REPO_PATH}/docker/Dockerfile.final" "${REPO_PATH}"
 else
     docker build \
-        -t "${IMAGE_NAME}:latest" \
-        -t "${IMAGE_NAME}:${RELEASE_TAG}" \
-        --build-arg WHEEL_PATH="${WHEEL_PATH}" \
-        -f "${REPO_PATH}/docker/Dockerfile.final" "$REPO_PATH"
+        --tag "${IMAGE_NAME}:latest" \
+        --tag "${IMAGE_NAME}:${RELEASE_TAG}" \
+        --build-arg SIMPLE_INDEX_PATH="${SIMPLE_INDEX_PATH}" \
+        --build-arg REQUIREMENTS_PATH="${REQUIREMENTS_PATH}" \
+        --file "${REPO_PATH}/docker/Dockerfile.final" "$REPO_PATH"
 fi
 
 exit 0

--- a/scripts/dev_scripts/build_docker.sh
+++ b/scripts/dev_scripts/build_docker.sh
@@ -12,7 +12,7 @@
 
 if [ "$#" -ne 3 ];
 then
-    echo "Illegal number of parameters" && exit 1
+    echo "Required arguments are missing" && exit 1
 fi
 IMAGE_NAME=$1
 WORKSPACE=$2
@@ -21,17 +21,19 @@ RELEASE_TAG=$3
 DIST_PATH="${WORKSPACE}/dist"
 REPO_PATH="${WORKSPACE}"
 
-SIMPLE_INDEX_PATH=$(find "$DIST_PATH" -depth -type f -name 'macaron-*-pep503-simple-index.tar' | head -n 1)
+SIMPLE_INDEX_PATH=$(find "${DIST_PATH}" -depth -type f -name 'macaron-*-pep503-simple-index.tar' | head -n 1)
 if [[ -z "${SIMPLE_INDEX_PATH}" ]]; then
     echo "Unable to find Macaron Simple Index in ${DIST_PATH}."
     exit 1
 fi
+SIMPLE_INDEX_PATH=$(realpath --relative-to "${REPO_PATH}" "${SIMPLE_INDEX_PATH}")
 
-REQUIREMENTS_PATH=$(find "$DIST_PATH" -depth -type f -name 'macaron-*-requirements.txt' | head -n 1)
+REQUIREMENTS_PATH=$(find "${DIST_PATH}" -depth -type f -name 'macaron-*-requirements.txt' | head -n 1)
 if [[ -z "${REQUIREMENTS_PATH}" ]]; then
     echo "Unable to find Macaron requirements.txt in ${DIST_PATH}."
     exit 1
 fi
+REQUIREMENTS_PATH=$(realpath --relative-to "${REPO_PATH}" "${REQUIREMENTS_PATH}")
 
 if [[ -z "${RELEASE_TAG}" ]];
 then


### PR DESCRIPTION
## Summary

Following up on comment https://github.com/oracle/macaron/pull/1358#issuecomment-4234829139, this change makes the Docker image building reproducible by using Macaron’s pinned and hashed requirements.txt.

## Description of changes

Building on the Simple Index artifact (see PR https://github.com/oracle/macaron/pull/1358) this change uses that local index and Macaron’s own generated requirements.txt to install Macaron into the Docker container using only the pinned and hashed dependencies.

## Related issues

Issues: n/a
Pulls: https://github.com/oracle/macaron/pull/1358

## Checklist

- [X] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [X] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [X] My commits include the "Signed-off-by" line.
- [X] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [ ] I have updated the relevant documentation, if applicable.
- [ ] I have tested my changes and verified they work as expected.
