### PR TITLE
chore(deps): exclude GHSA-vfmq-68hx-4jfw temporarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,14 +299,17 @@ requirements.txt: pyproject.toml
 # Audit the currently installed packages. Skip packages that are installed in
 # editable mode (like the one in development here) because they may not have
 # a PyPI entry; also print out CVE description and potential fixes if audit
-# found an issue.
-# Remove GHSA-5239-wwwm-4pmq from the ignore list when it is patched.
+# found an issue. If an advisory needs to be ignored, use the --ignore-vuln option.
+#
+# Remove GHSA-vfmq-68hx-4jfw when the following issue is resolved to be able to
+# install the latest version of lxml.
+# https://github.com/semgrep/semgrep/issues/11630
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-5239-wwwm-4pmq
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-vfmq-68hx-4jfw
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "beautifulsoup4 >=4.12.0,<5.0.0",
     "problog >=2.2.6,<3.0.0",
     "cryptography >=46.0.5,<47.0.0",
-    "semgrep ==1.151.0",
+    "semgrep ==1.160.0",
     "email-validator >=2.2.0,<3.0.0",
     "rich >=13.5.3,<15.0.0",
     "lark >=1.3.0,<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "beautifulsoup4 >=4.12.0,<5.0.0",
     "problog >=2.2.6,<3.0.0",
     "cryptography >=46.0.5,<47.0.0",
-    "semgrep ==1.160.0",
+    "semgrep == 1.151.0",
     "email-validator >=2.2.0,<3.0.0",
     "rich >=13.5.3,<15.0.0",
     "lark >=1.3.0,<2.0.0",

--- a/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/test.yaml
+++ b/tests/integration/cases/django_with_dep_resolution_virtual_env_as_input/test.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 description: |
@@ -87,7 +87,7 @@ steps:
   kind: verify
   options:
     policy: policy-sourcecode.dl
-- name: Query the output database to verify the suspicious_patterns rull passed.
+- name: Query the output database to verify the suspicious_patterns rule passed.
   kind: shell
   options:
     cmd: ./check_sourcecode_patterns.sh


### PR DESCRIPTION
## Summary
Suppress `GHSA-vfmq-68hx-4jfw` for now until https://github.com/semgrep/semgrep/issues/11630 is resolved and we can upgrade our dependencies to use the latest version of `lxml`.