### PR TITLE
chore: updated semgrep error outputs to include stdout and stderr

### DIFF
--- a/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/pypi_sourcecode_analyzer.py
+++ b/src/macaron/malware_analyzer/pypi_heuristics/sourcecode/pypi_sourcecode_analyzer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """
@@ -301,15 +301,24 @@ class PyPISourcecodeAnalyzer(BaseHeuristicAnalyzer):
 
         with tempfile.NamedTemporaryFile(mode="w+", delete=True) as output_json_file:
             semgrep_commands.append(f"--json-output={output_json_file.name}")
-            logger.debug("executing: %s.", semgrep_commands)
+            print_command = " ".join(semgrep_commands)
+            logger.debug("executing: %s.", print_command)
             try:
                 process = subprocess.run(semgrep_commands, check=True, capture_output=True)  # nosec B603
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as semgrep_error:
-                error_msg = (
-                    f"Unable to run semgrep on {source_code_path} with argument(s) {semgrep_commands}: {semgrep_error}"
-                )
+            except subprocess.CalledProcessError as semgrep_error:
+                error_msg = f"""Unable to run {print_command} on {source_code_path}: {semgrep_error}
+                Return code: {semgrep_error.returncode}
+                stdout: {semgrep_error.stdout.decode() if semgrep_error.stdout else ""}
+                stderr: {semgrep_error.stderr.decode() if semgrep_error.stderr else ""}
+                """
                 logger.debug(error_msg)
                 raise HeuristicAnalyzerValueError(error_msg) from semgrep_error
+            except subprocess.TimeoutExpired as timeout_error:
+                error_msg = f"""
+                Subprocess timeout running {print_command} on {source_code_path}: {timeout_error}
+                """
+                logger.debug(error_msg)
+                raise HeuristicAnalyzerValueError(error_msg) from timeout_error
 
             if process.returncode != 0:
                 error_msg = f"Error running semgrep on {source_code_path} with argument(s)" f" {process.args}"


### PR DESCRIPTION
## Summary
This is a quick PR that just includes the standard output and error of Semgrep when it fails to run.

## Description of changes
This PR includes Semgrep `stderr` and `stdout`, which makes it easier to determine what caused Semgrep to fail, e.g.:
```
│ [INFO] 06:36:37 2026-04-23 06:36:37,891  Unable to run semgrep scan --metrics off --disable-version-check --oss-only --disable-nosem --config                                                                                     │
│ /scratch/cflottma/python-malware-dev/macaron/src/macaron/resources/pypi_malware_rules /tmp/Django-5.0.6_qvu0216_/Django-5.0.6 --json-output=/tmp/tmpusseunzu on /tmp/Django-5.0.6_qvu0216_/Django-5.0.6: Command '['semgrep',     │
│ 'scan', '--metrics', 'off', '--disable-version-check', '--oss-only', '--disable-nosem', '--config', '/scratch/cflottma/python-malware-dev/macaron/src/macaron/resources/pypi_malware_rules',                                      │
│ '/tmp/Django-5.0.6_qvu0216_/Django-5.0.6', '--json-output=/tmp/tmpusseunzu']' returned non-zero exit status 2.                                                                                                                    │
│                 Return code: 2                                                                                                                                                                                                    │
│                 stdout:                                                                                                                                                                                                           │
│                 stderr: Failed to find semgrep-core in PATH or in the semgrep package.
```

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
