### PR TITLE
chore: suppress pylint's cyclic import errors

### DIFF
--- a/src/macaron/code_analyzer/dataflow_analysis/bash.py
+++ b/src/macaron/code_analyzer/dataflow_analysis/bash.py
@@ -14,7 +14,14 @@ from itertools import product
 from typing import cast
 
 from macaron import MACARON_PATH
-from macaron.code_analyzer.dataflow_analysis import core, evaluation, facts, github, models, printing
+from macaron.code_analyzer.dataflow_analysis import (  # pylint: disable=cyclic-import
+    core,
+    evaluation,
+    facts,
+    github,
+    models,
+    printing,
+)
 from macaron.errors import CallGraphError, ParseError
 from macaron.parsers import bashparser, bashparser_model
 

--- a/src/macaron/code_analyzer/dataflow_analysis/github.py
+++ b/src/macaron/code_analyzer/dataflow_analysis/github.py
@@ -10,7 +10,15 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from graphlib import TopologicalSorter
 
-from macaron.code_analyzer.dataflow_analysis import bash, core, evaluation, facts, github_expr, models, printing
+from macaron.code_analyzer.dataflow_analysis import (  # pylint: disable=cyclic-import
+    bash,
+    core,
+    evaluation,
+    facts,
+    github_expr,
+    models,
+    printing,
+)
 from macaron.errors import CallGraphError
 from macaron.parsers import github_workflow_model
 


### PR DESCRIPTION
## Summary
Pylint recently started flagging a known and expected cyclic import, triggered by an unrelated [changeset](https://github.com/oracle/macaron/actions/runs/24809624558/job/72802686972). This warning does not reflect a functional issue and has been part of the existing code structure. This PR suppresses this specific Pylint cyclic import.
