### PR TITLE
docs: update Macaron Action version

### DIFF
--- a/.github/workflows/macaron-analysis.yaml
+++ b/.github/workflows/macaron-analysis.yaml
@@ -35,7 +35,7 @@ jobs:
     # Note: adjust the policy_purl to refer to your repository URL.
     - name: Run Macaron action
       id: run_macaron
-      uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+      uses: oracle/macaron@4ddb55e3c9ef2c77b548be55c557078c4476fd9c # v0.24.0
       with:
         repo_path: ./
         policy_file: check-github-actions

--- a/Makefile
+++ b/Makefile
@@ -304,12 +304,15 @@ requirements.txt: pyproject.toml
 # Remove GHSA-vfmq-68hx-4jfw when the following issue is resolved to be able to
 # install the latest version of lxml.
 # https://github.com/semgrep/semgrep/issues/11630
+#
+# Remove GHSA-58qw-9mgm-455v once a patch is available.
+# https://github.com/advisories/GHSA-58qw-9mgm-455v
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-vfmq-68hx-4jfw
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-vfmq-68hx-4jfw --ignore-vuln GHSA-58qw-9mgm-455v
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy check-go check-actionlint

--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Use Macaron as a GitHub Action
 To use the Macaron GitHub Action, add the following step to your workflow (adjust the version as needed). In this example, we use an example policy. For detailed instructions and a comprehensive list of available options, please refer to the [Macaron GitHub Action documentation](https://oracle.github.io/macaron/pages/macaron_action.html).
 
 ```yaml
-- uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+- uses: oracle/macaron@4ddb55e3c9ef2c77b548be55c557078c4476fd9c # v0.24.0
   with:
-    repo_path: 'https://github.com/example/project'
+    repo_path: ./
     policy_file: check-github-actions
     policy_purl: 'pkg:github.com/example/project@.*'
     output_dir: 'macaron-output'
-    upload_attestation: true
 ```
 
 For detailed instructions and a comprehensive list of available options, please refer to the [Macaron GitHub Action documentation](https://oracle.github.io/macaron/pages/macaron_action.html).

--- a/docs/source/pages/macaron_action.rst
+++ b/docs/source/pages/macaron_action.rst
@@ -24,7 +24,7 @@ When you use this action, you can reference it directly in your workflow. For a 
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         - name: Run Macaron Security Analysis Action
-          uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+          uses: oracle/macaron@4ddb55e3c9ef2c77b548be55c557078c4476fd9c # v0.24.0
           with:
             repo_path: ./
             policy_file: check-github-actions


### PR DESCRIPTION
## Summary
Bumps Macaron GitHub Action to v0.24.0 and update the docs. We also ignore https://github.com/advisories/GHSA-58qw-9mgm-455v for now until a patch is available.