### PR TITLE
build: skip the generated Simple Index folder as an artifact, and use only individual distribution files

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -128,14 +128,18 @@ jobs:
         echo "Digest of artifacts is $DIGEST."
         echo "artifacts-sha256=$DIGEST" >> "$GITHUB_OUTPUT"
 
-    # For now only generate artifacts for the specified OS and Python version in env variables.
-    # Currently reusable workflows do not support setting strategy property from the caller workflow.
+    # For now only generate artifacts for the specified OS and Python version in env
+    # variables. Currently reusable workflows do not support setting strategy property
+    # from the caller workflow. Furthermore, add only top-level files as artifacts;
+    # do not copy the generated simple-index/ folder.
     - name: Upload the package artifact for debugging and release
       if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: artifact-${{ matrix.os }}-python-${{ matrix.python }}
-        path: dist
+        path: |
+          dist/*.*
+          !dist/simple-index
         if-no-files-found: error
         retention-days: 7
 


### PR DESCRIPTION
## Summary

The change fixes [this failing release job](https://github.com/oracle/macaron/actions/runs/24877228519/job/72845840345).

## Description of changes

The `gh release create …` command does not handle folders, thus do not add the generated `dist/simple-index/` folder as a release artifact.

## Related issues

Original breaking change/regression is PR https://github.com/oracle/macaron/pull/1377.

## Checklist

- [X] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [X] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [X] My commits include the "Signed-off-by" line.
- [X] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [ ] I have updated the relevant documentation, if applicable.
- [ ] I have tested my changes and verified they work as expected.
