### PR TITLE
feat: new malware sourcecode detection for anti-analysis behaviour

### DIFF
--- a/src/macaron/config/defaults.ini
+++ b/src/macaron/config/defaults.ini
@@ -742,7 +742,7 @@ disabled_default_rulesets = exfiltration
 # disable individual rules here (i.e. individual rule IDs inside a Semgrep .yaml file, specified under the "rules" header in the
 # .yaml file, with each rule ID under "- id") using rule IDs. You may also provide the IDs of your custom semgrep rules here too,
 # as all Semgrep rule IDs must be unique. This list may not contain duplicated elements.
-disabled_rules =
+disabled_rules = anti_analysis-ip-checkers
 # absolute path to a directory where a custom set of semgrep rules for source code analysis are stored. These will be included
 # with Macaron's default rules. The path will be normalised to the OS path type.
 custom_semgrep_rules_path =

--- a/src/macaron/malware_analyzer/README.md
+++ b/src/macaron/malware_analyzer/README.md
@@ -95,7 +95,7 @@ When a heuristic fails, with `HeuristicResult.FAIL`, then that is an indicator b
 - **Rule**: If any Semgrep rule is triggered, the heuristic fails with `HeuristicResult.FAIL` and subsequently fails the package with `CheckResultType.FAILED`. If no rule is triggered, the heuristic passes with `HeuristicResult.PASS` and the `CheckResultType` result from the combination of all other heuristics is maintained.
 - **Dependency**: Will be run if the Source Code Repo fails. This dependency can be bypassed by supplying `--force-analyze-source` in the CLI.
 
-This feature is currently a work in progress, and supports detection of code obfuscation techniques and remote exfiltration behaviors. It uses Semgrep OSS for detection. `defaults.ini` may be used to provide custom rules and exclude them:
+This feature is currently a work in progress, and supports detection of code obfuscation techniques, remote exfiltration behaviors, and anti-analysis behaviours. It uses Semgrep OSS for detection. `defaults.ini` may be used to provide custom rules and exclude them:
 - `disabled_default_rulesets`: supply to this a comma separated list of the names of default Semgrep rule files (excluding the `.yaml` extension) to disable all rule IDs in that file.
 - `disabled_rules`: supply to this a comma separated list of individual rule IDs to disable (from both the default and custom list).
 - `custom_semgrep_rules`: supply to this an absolute path to a directory containing custom Semgrep `.yaml` files to be run alongside the default ones.

--- a/src/macaron/resources/pypi_malware_rules/anti_analysis.yaml
+++ b/src/macaron/resources/pypi_malware_rules/anti_analysis.yaml
@@ -9,15 +9,15 @@ rules:
   languages:
   - python
   severity: ERROR
-  pattern-either:   # format usually either has no delimiter, or uses ":", ".", or "-"
-      # VMware virtualisation associated OUIs
+  pattern-either:     # format usually either has no delimiter, or uses ":", ".", or "-"
+        # VMware virtualisation associated OUIs
   - pattern-regex: (?i)00[\.:-]?0C[\.:-]?29[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w
   - pattern-regex: 00[\.:-]?50[\.:-]?56[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w
-      # Virtualbox virtualisation associated OUIs
-  - pattern-regex: 08[\.:-]?00[\.:-]?27[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w       # Oracle Virtualbox
-  - pattern-regex: 52[\.:-]?54[\.:-]?00[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w       # Oracle Virtualbox/Vagrant
-      # Microsoft virtualisation associated OUIs
-  - pattern-regex: (?i)00[\.:-]?15[\.:-]?5D[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w       # Hyper-V Virtual Machines
+        # Virtualbox virtualisation associated OUIs
+  - pattern-regex: 08[\.:-]?00[\.:-]?27[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w         # Oracle Virtualbox
+  - pattern-regex: 52[\.:-]?54[\.:-]?00[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w         # Oracle Virtualbox/Vagrant
+        # Microsoft virtualisation associated OUIs
+  - pattern-regex: (?i)00[\.:-]?15[\.:-]?5D[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w         # Hyper-V Virtual Machines
 
 - id: anti_analysis-defender-evasion
   metadata:
@@ -27,69 +27,42 @@ rules:
   - python
   severity: ERROR
   pattern-either:
-       # Windows Defender Application Guard (WDAG) system account name
+        # Windows Defender Application Guard (WDAG) system account name
   - pattern-regex: WDAGUtilityAccount
-      # PowerShell commands
-  - pattern-regex: Add-MpPreference       # modifies defender settings
-  - pattern-regex: Remove-MpPreference       # removes default actions/exclusions
-  - pattern-regex: Set-MpPreference       # modifies scans and updates
-  - pattern-regex: Get-MpComputerStatus       # gets status of Defender
-  - pattern-regex: Remove-MpThreat       # remove active threats (potentially yourself)
-      # Switches in MpCmdRun.exe
+        # PowerShell commands
+  - pattern-regex: Add-MpPreference         # modifies defender settings
+  - pattern-regex: Remove-MpPreference         # removes default actions/exclusions
+  - pattern-regex: Set-MpPreference           # modifies defender settings
+    # - pattern-regex: Set-MpPreference       # modifies scans and updates
+  - pattern-regex: Get-MpComputerStatus         # gets status of Defender
+  - pattern-regex: Remove-MpThreat         # remove active threats (potentially yourself)
+        # Switches in MpCmdRun.exe
   - pattern-regex: -RemoveDefinitions
   - pattern-regex: -RemoveDynamicSignature
-
-      # Registry modification
-      # HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Paths
-      # HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Processes
-      # HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Extensions
-      # DisableAntiSpyware key
-      # DisableAntivirus key
+    # usually HKLM\Software\Policies\Microsoft\Windows Defender or HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender
+    # Some key values under these like HideExclusionsFromLocalAdmins, DisableAntiSpyware, DisableAntivirus
+    # typically modified with the winreg package
+  - pattern-regex: (?i)Software.+Policies.+Microsoft.+Windows.*Defender
+    # Common Information Model (CIM) classes
+  - pattern-regex: MSFT_MpPreference   # change things about defender
+  - pattern-regex: AntiVirusProduct   # get information about AVs on the system
+    # Windows Management Instrumentation (WMI)
+    # Many of these operations require admin privileges, which can be requested by:
+  - pattern: ctypes.windll.shell32.ShellExecuteW(..., 'runas', ...)
 
   # NOTE: Currently not yet suitable, need more strict that just detecting the URL
-  # - id: anti_analysis-ip-checkers
-  #   metadata:
-  #     description: Matches against common services used to check your current IP and other system information
-  #   message: Found use of a common IP-checker service
-  #   languages:
-  #   - python
-  #   severity: ERROR
-  #   pattern-either:
-  #     - pattern-regex: 'api\.ipify\.org'
-  #     - pattern-regex: 'ip-api\.com'
-  #     - pattern-regex: 'geolocation-db\.com/jsonp'
-  #     - pattern-regex: 'ip\.wtf'
-  #     - pattern-regex: 'ifconfig\.me'
-  #     - pattern-regex: 'geolocation\.com'
-  #     - pattern-regex: 'checkip\.amazonaws\.com'
-
-  # - id: anti_analysis-something
-  #   metadata:
-  #     description: blank
-  #   message: blank
-  #   languages:
-  #   - python
-  #   severity: ERROR
-  #   pattern-either:
-  #     # video card names used by virtualisation software
-  #     - pattern: virtualbox
-  #     - pattern: vmware
-  #     # registry values used in SYSTEM\CurrentControlSet\Services\Disk\Enum
-  #     - pattern: vmware
-  #     - pattern: qemu
-  #     - pattern: virtio
-  #     - pattern: vbox
-  #     - pattern: xen
-  #     - pattern: VMW
-  #     - pattern: Virtual
-
-  # - id: anti_analysis-known-debugging-processes
-  #   metadata:
-  #     description: blank
-  #   message: blank
-  #   languages:
-  #   - python
-  #   severity: ERROR
-  #   pattern-either:
-  #     - pattern: ollydbg
-  #     - pattern: taskmgr
+#   - id: anti_analysis-ip-checkers
+#     metadata:
+#         description: Matches against common services used to check your current IP and other system information
+#     message: Found use of a common IP-checker service
+#     languages:
+#     - python
+#     severity: ERROR
+#     pattern-either:
+#     - pattern-regex: 'api\.ipify\.org'
+#     - pattern-regex: 'ip-api\.com'
+#     - pattern-regex: 'geolocation-db\.com/jsonp'
+#     - pattern-regex: 'ip\.wtf'
+#     - pattern-regex: 'ifconfig\.me'
+#     - pattern-regex: 'geolocation\.com'
+#     - pattern-regex: 'checkip\.amazonaws\.com'

--- a/src/macaron/resources/pypi_malware_rules/anti_analysis.yaml
+++ b/src/macaron/resources/pypi_malware_rules/anti_analysis.yaml
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+rules:
+- id: anti_analysis-known-ouis
+  metadata:
+    description: Searches for packages that check the OUI of the machine against known virtualisation software commonly used for sandboxing/debugging
+  message: Found reference to an OUI known to be associated with common virtualisation software for sandboxing/debugging
+  languages:
+  - python
+  severity: ERROR
+  pattern-either:   # format usually either has no delimiter, or uses ":", ".", or "-"
+      # VMware virtualisation associated OUIs
+  - pattern-regex: (?i)00[\.:-]?0C[\.:-]?29[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w
+  - pattern-regex: 00[\.:-]?50[\.:-]?56[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w
+      # Virtualbox virtualisation associated OUIs
+  - pattern-regex: 08[\.:-]?00[\.:-]?27[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w       # Oracle Virtualbox
+  - pattern-regex: 52[\.:-]?54[\.:-]?00[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w       # Oracle Virtualbox/Vagrant
+      # Microsoft virtualisation associated OUIs
+  - pattern-regex: (?i)00[\.:-]?15[\.:-]?5D[\.:-]?\w\w[\.:-]?\w\w[\.:-]?\w\w       # Hyper-V Virtual Machines
+
+- id: anti_analysis-defender-evasion
+  metadata:
+    description: Looks for commands and/or names of services or accounts used by Windows Defender that may be used to evade it
+  message: Found reference to Windows Defender services, commands, or names/accounts
+  languages:
+  - python
+  severity: ERROR
+  pattern-either:
+       # Windows Defender Application Guard (WDAG) system account name
+  - pattern-regex: WDAGUtilityAccount
+      # PowerShell commands
+  - pattern-regex: Add-MpPreference       # modifies defender settings
+  - pattern-regex: Remove-MpPreference       # removes default actions/exclusions
+  - pattern-regex: Set-MpPreference       # modifies scans and updates
+  - pattern-regex: Get-MpComputerStatus       # gets status of Defender
+  - pattern-regex: Remove-MpThreat       # remove active threats (potentially yourself)
+      # Switches in MpCmdRun.exe
+  - pattern-regex: -RemoveDefinitions
+  - pattern-regex: -RemoveDynamicSignature
+
+      # Registry modification
+      # HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Paths
+      # HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Processes
+      # HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Extensions
+      # DisableAntiSpyware key
+      # DisableAntivirus key
+
+  # NOTE: Currently not yet suitable, need more strict that just detecting the URL
+  # - id: anti_analysis-ip-checkers
+  #   metadata:
+  #     description: Matches against common services used to check your current IP and other system information
+  #   message: Found use of a common IP-checker service
+  #   languages:
+  #   - python
+  #   severity: ERROR
+  #   pattern-either:
+  #     - pattern-regex: 'api\.ipify\.org'
+  #     - pattern-regex: 'ip-api\.com'
+  #     - pattern-regex: 'geolocation-db\.com/jsonp'
+  #     - pattern-regex: 'ip\.wtf'
+  #     - pattern-regex: 'ifconfig\.me'
+  #     - pattern-regex: 'geolocation\.com'
+  #     - pattern-regex: 'checkip\.amazonaws\.com'
+
+  # - id: anti_analysis-something
+  #   metadata:
+  #     description: blank
+  #   message: blank
+  #   languages:
+  #   - python
+  #   severity: ERROR
+  #   pattern-either:
+  #     # video card names used by virtualisation software
+  #     - pattern: virtualbox
+  #     - pattern: vmware
+  #     # registry values used in SYSTEM\CurrentControlSet\Services\Disk\Enum
+  #     - pattern: vmware
+  #     - pattern: qemu
+  #     - pattern: virtio
+  #     - pattern: vbox
+  #     - pattern: xen
+  #     - pattern: VMW
+  #     - pattern: Virtual
+
+  # - id: anti_analysis-known-debugging-processes
+  #   metadata:
+  #     description: blank
+  #   message: blank
+  #   languages:
+  #   - python
+  #   severity: ERROR
+  #   pattern-either:
+  #     - pattern: ollydbg
+  #     - pattern: taskmgr

--- a/src/macaron/resources/pypi_malware_rules/anti_analysis.yaml
+++ b/src/macaron/resources/pypi_malware_rules/anti_analysis.yaml
@@ -50,19 +50,19 @@ rules:
     # Many of these operations require admin privileges, which can be requested by:
   - pattern: ctypes.windll.shell32.ShellExecuteW(..., 'runas', ...)
 
-  # NOTE: Currently not yet suitable, need more strict that just detecting the URL
-#   - id: anti_analysis-ip-checkers
-#     metadata:
-#         description: Matches against common services used to check your current IP and other system information
-#     message: Found use of a common IP-checker service
-#     languages:
-#     - python
-#     severity: ERROR
-#     pattern-either:
-#     - pattern-regex: 'api\.ipify\.org'
-#     - pattern-regex: 'ip-api\.com'
-#     - pattern-regex: 'geolocation-db\.com/jsonp'
-#     - pattern-regex: 'ip\.wtf'
-#     - pattern-regex: 'ifconfig\.me'
-#     - pattern-regex: 'geolocation\.com'
-#     - pattern-regex: 'checkip\.amazonaws\.com'
+# NOTE: Currently not yet suitable, need more strict that just detecting the URL, so this is disabled in Macaron.
+- id: anti_analysis-ip-checkers
+  metadata:
+    description: Matches against common services used to check your current IP and other system information
+  message: Found use of a common IP-checker service
+  languages:
+  - python
+  severity: ERROR
+  pattern-either:
+  - pattern-regex: api\.ipify\.org
+  - pattern-regex: ip-api\.com
+  - pattern-regex: geolocation-db\.com/jsonp
+  - pattern-regex: ip\.wtf
+  - pattern-regex: ifconfig\.me
+  - pattern-regex: geolocation\.com
+  - pattern-regex: checkip\.amazonaws\.com

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/anti_analysis.py
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/anti_analysis.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+"""
+Running this code will not produce any malicious behavior, but code isolation measures are
+in place for safety.
+"""
+
+import sys
+
+# ensure no symbols are exported so this code cannot accidentally be used
+__all__ = []
+sys.exit()
+
+def test_function():
+    """
+    All code to be tested will be defined inside this function, so it is all local to it. This is
+    to isolate the code to be tested, as it exists to replicate the patterns present in malware
+    samples.
+    """
+    sys.exit()
+
+    class MyAntiAnalysisConfig:
+        # NOTE: these are randomly generated MAC addresses and aren't directly linked to any specific device.
+        MacAddresses = (
+            "00:0C:29:DF:3E:94",
+            "00-50-56-FA-EF-2A",
+            "08.00.27.AA.8E.E8",
+            "5254005A7E4F",
+            "00-15-5D-4E-5E-A8"
+        )
+
+        Users = (
+            "WDAGUtilityAccount"
+        )
+
+    def disable_defender_real_time_protection():
+        import subprocess
+        try:
+            subprocess.run([
+                'powershell', '-Command',
+                'Set-MpPreference -DisableRealtimeMonitoring $true'
+            ], check=True, capture_output=True)
+        except:
+            pass
+
+    def exclude_me_from_defender():
+        import subprocess
+        path = "."
+        try:
+            subprocess.run([
+                "powershell", "-Command", f"Add-MpPreference -ExclusionPath '{path}'"
+            ], shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Defender can still see me due to {e}")
+            pass

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/anti_analysis.py
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/anti_analysis.py
@@ -34,23 +34,39 @@ def test_function():
             "WDAGUtilityAccount"
         )
 
-    def disable_defender_real_time_protection():
+    def modify_defender():
         import subprocess
         try:
-            subprocess.run([
-                'powershell', '-Command',
-                'Set-MpPreference -DisableRealtimeMonitoring $true'
-            ], check=True, capture_output=True)
+            subprocess.Popen('powershell Set-MpPreference -ChangeSomething ' \
+                r'&& "Somewhere\MpCmdRun.exe" -RemoveDefinitions -Something',
+                shell=True)
         except:
             pass
 
-    def exclude_me_from_defender():
+    def cim_based_powershell():
         import subprocess
-        path = "."
         try:
-            subprocess.run([
-                "powershell", "-Command", f"Add-MpPreference -ExclusionPath '{path}'"
-            ], shell=True, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Defender can still see me due to {e}")
+            subprocess.Popen([
+                "powershell",
+                "-Command",
+                "Invoke-CimMethod -Namespace root/Microsoft/Windows/Defender -ClassName MSFT_MpPreference " \
+                "... more args ..."
+            ])
+        except:
             pass
+
+    def reg_modification():
+        import winreg
+        with winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, "SOFTWARE\\Policies\\Microsoft\\Windows Defender", 0, winreg.KEY_SET_VALUE) as key:
+            winreg.SetValueEx(key, "SomeValue", 0, winreg.REG_DWORD, 0)
+
+    def request_windows_privileges():
+        import ctypes
+        ctypes.windll.shell32.ShellExecuteW(None, "runas", "proc", "--args", None, 1)
+
+    def use_wmic_to_see_av_tools():
+        import subprocess
+        _ = subprocess.check_output(
+            'wmic /namespace:\\\\root\\SecurityCenter2 path AntiVirusProduct get displayName',
+            text=True
+        )

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/expected_results.json
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/expected_results.json
@@ -1,0 +1,55 @@
+{
+    "enabled_sourcecode_rule_findings": {
+        "src.macaron.resources.pypi_malware_rules.anti_analysis-known-ouis": {
+            "message": "Found reference to an OUI known to be associated with common virtualisation software for sandboxing/debugging",
+            "detections": [
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 23,
+                    "end": 23
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 24,
+                    "end": 24
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 25,
+                    "end": 25
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 26,
+                    "end": 26
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 27,
+                    "end": 27
+                }
+            ]
+        },
+        "src.macaron.resources.pypi_malware_rules.anti_analysis-defender-evasion": {
+            "message": "Found reference to Windows Defender services, commands, or names/accounts",
+            "detections": [
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 31,
+                    "end": 31
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 39,
+                    "end": 39
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 49,
+                    "end": 49
+                }
+            ]
+        }
+    },
+    "disabled_sourcecode_rule_findings": {}
+}

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/expected_results.json
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/expected_results.json
@@ -5,21 +5,6 @@
             "detections": [
                 {
                     "file": "anti_analysis/anti_analysis.py",
-                    "start": 23,
-                    "end": 23
-                },
-                {
-                    "file": "anti_analysis/anti_analysis.py",
-                    "start": 24,
-                    "end": 24
-                },
-                {
-                    "file": "anti_analysis/anti_analysis.py",
-                    "start": 25,
-                    "end": 25
-                },
-                {
-                    "file": "anti_analysis/anti_analysis.py",
                     "start": 26,
                     "end": 26
                 },
@@ -27,6 +12,21 @@
                     "file": "anti_analysis/anti_analysis.py",
                     "start": 27,
                     "end": 27
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 28,
+                    "end": 28
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 29,
+                    "end": 29
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 30,
+                    "end": 30
                 }
             ]
         },
@@ -35,18 +35,18 @@
             "detections": [
                 {
                     "file": "anti_analysis/anti_analysis.py",
-                    "start": 31,
-                    "end": 31
+                    "start": 34,
+                    "end": 34
                 },
                 {
                     "file": "anti_analysis/anti_analysis.py",
-                    "start": 39,
-                    "end": 39
+                    "start": 42,
+                    "end": 42
                 },
                 {
                     "file": "anti_analysis/anti_analysis.py",
-                    "start": 49,
-                    "end": 49
+                    "start": 52,
+                    "end": 52
                 }
             ]
         }

--- a/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/expected_results.json
+++ b/tests/malware_analyzer/pypi/resources/sourcecode_samples/anti_analysis/expected_results.json
@@ -40,13 +40,33 @@
                 },
                 {
                     "file": "anti_analysis/anti_analysis.py",
-                    "start": 42,
-                    "end": 42
+                    "start": 40,
+                    "end": 40
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 41,
+                    "end": 41
                 },
                 {
                     "file": "anti_analysis/anti_analysis.py",
                     "start": 52,
                     "end": 52
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 60,
+                    "end": 60
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 65,
+                    "end": 65
+                },
+                {
+                    "file": "anti_analysis/anti_analysis.py",
+                    "start": 70,
+                    "end": 70
                 }
             ]
         }

--- a/tests/malware_analyzer/pypi/test_pypi_sourcecode_analyzer.py
+++ b/tests/malware_analyzer/pypi/test_pypi_sourcecode_analyzer.py
@@ -121,6 +121,7 @@ def test_invalid_custom_rules(mock_defaults: MagicMock, pypi_package_json: Magic
     [
         pytest.param("obfuscation", "obfuscation.yaml", id="obfuscation"),
         pytest.param("exfiltration", "exfiltration.yaml", id="exfiltration"),
+        pytest.param("anti_analysis", "anti_analysis.yaml", id="anti_analysis")
     ],
 )
 def test_rules(


### PR DESCRIPTION
## Summary
This PR introduces a new type of source code detection rule called anti-analysis, which focuses on malware that performs operations to check if it is being analysed to inform behavioural decisions.

## Description of changes
The anti-analysis rules developed for this PR are informed from analysis of multiple malware samples. The general behaviour observed in these malware included blacklisting known analysis and virtualization tools (e.g. processes, MAC addresses, users, IP addresses) and system characteristics, and actively looking for ways to disable them (e.g. disable Antivirus or remove your signature, elevate privileges to do so). Included in this PR are behaviours that could be generalised into rules that were highly unlikely to appear in a benign python package:
- `anti_analysis-known-ouis`: some malware samples included a blacklist of MAC addresses that would prevent it from running, evidently targeted at detecting MAC addresses often assigned to virtual machines. This rules includes the OUIs of some well-known services (VMware, Virtualbox, Hyper-V) and looks for hard-coded instances of MAC addresses with those OUIs, which likely form such a blacklist.
- `anti_analysis-defender-evasion`: some malware samples used Microsoft tools (PowerShell, Registry editing, WMI, CIM classes) to disable part or all of Windows Defender capabilities to evade detection, or remove evidence of detection. Included in this rule are some common patterns used in these code snippets that play a key role in their execution.
- `anti_analysis-ip-checkers`: some malware samples would use public, benign IP information services to extract information about the machine they were running on, and evade detection based on this. This sample includes some of the commonly observed domains used for this purpose. This rule is currently disabled in Macaron, however, since matching on the existence of the string domain in a file alone is too broad and prone to false positives (e.g. this would fail when run against the `azure-cli` package). At this stage, no useful pattern from the malware samples was observed that could be generalised into a Semgrep rule. `defaults.ini` is updated to, by default, exclude this rule.

Appropriate unit tests have been added to ensure the accuracy of these rules and demonstrate examples of what they are looking for.

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
