### PR TITLE
fix: prefer tag commits over attestation commits

### DIFF
--- a/src/macaron/repo_finder/repo_finder.py
+++ b/src/macaron/repo_finder/repo_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 
 """
@@ -419,6 +419,7 @@ def prepare_repo(
     digest: str = "",
     purl: PackageURL | None = None,
     latest_version_fallback: bool = True,
+    provenance_commit_digest: str | None = None
 ) -> tuple[Git | None, CommitFinderInfo]:
     """Prepare the target repository for analysis.
 
@@ -444,6 +445,8 @@ def prepare_repo(
         The PURL of the analysis target.
     latest_version_fallback: bool
         A flag that determines whether the latest version of the same artifact can be checked as a fallback option.
+    provenance_commit_digest: str | None
+        The commit extracted from the provenance.
 
     Returns
     -------
@@ -504,16 +507,20 @@ def prepare_repo(
         found_digest, commit_finder_outcome = find_commit(git_obj, purl)
         if not found_digest:
             logger.error("Could not map the input purl string to a specific commit in the corresponding repository.")
-            if not latest_version_fallback:
-                return None, commit_finder_outcome
-            # If the commit could not be found, check if the latest version of the artifact has a different repository.
-            latest_purl = get_latest_purl_if_different(purl)
-            if not latest_purl:
-                return None, commit_finder_outcome
-            latest_repo = get_latest_repo_if_different(latest_purl, repo_path)
-            if not latest_repo:
-                return None, commit_finder_outcome
-            return prepare_repo(latest_repo, latest_repo, target_dir, latest_version_fallback=False)
+            if provenance_commit_digest:
+                found_digest = provenance_commit_digest
+                commit_finder_outcome = CommitFinderInfo.PROVENANCE_USED
+            else:
+                if not latest_version_fallback:
+                    return None, commit_finder_outcome
+                # If the commit could not be found, check if the latest version of the artifact has a different repository.
+                latest_purl = get_latest_purl_if_different(purl)
+                if not latest_purl:
+                    return None, commit_finder_outcome
+                latest_repo = get_latest_repo_if_different(latest_purl, repo_path)
+                if not latest_repo:
+                    return None, commit_finder_outcome
+                return prepare_repo(latest_repo, latest_repo, target_dir, latest_version_fallback=False)
 
         digest = found_digest
 

--- a/src/macaron/repo_finder/repo_finder_enums.py
+++ b/src/macaron/repo_finder/repo_finder_enums.py
@@ -140,5 +140,8 @@ class CommitFinderInfo(Enum):
     #: Reported if a match was found.
     MATCHED = "Matched"
 
+    #: Commit is extracted from the provenance.
+    PROVENANCE_USED = "Provenance used"
+
     #: Default state. Reported if the commit finder was not called. E.g. Because the Repo Finder failed.
     NOT_USED = "Not used"

--- a/src/macaron/slsa_analyzer/analyzer.py
+++ b/src/macaron/slsa_analyzer/analyzer.py
@@ -421,7 +421,6 @@ class Analyzer:
                 available_domains,
                 parsed_purl,
                 provenance_repo_url,
-                provenance_commit_digest,
                 package_registries_info,
             )
         except InvalidAnalysisTargetError as error:
@@ -454,6 +453,7 @@ class Analyzer:
                 analysis_target.branch,
                 analysis_target.digest,
                 analysis_target.parsed_purl,
+                provenance_commit_digest=provenance_commit_digest
             )
             if git_obj:
                 final_digest = git_obj.get_head().hash
@@ -880,7 +880,6 @@ class Analyzer:
         available_domains: list[str],
         parsed_purl: PackageURL | None,
         provenance_repo_url: str | None = None,
-        provenance_commit_digest: str | None = None,
         package_registries_info: list[PackageRegistryInfo] | None = None,
     ) -> AnalysisTarget:
         """Resolve the details of a software component from user input.
@@ -896,8 +895,6 @@ class Analyzer:
             The PURL to use for the analysis target, or None if one has not been provided.
         provenance_repo_url: str | None
             The repository URL extracted from provenance, or None if not found or no provenance.
-        provenance_commit_digest: str | None
-            The commit extracted from provenance, or None if not found or no provenance.
         package_registries_info: list[PackageRegistryInfo] | None
             The list of package registry information if available.
             If no package registries are loaded, this can be set to None.
@@ -930,12 +927,12 @@ class Analyzer:
                 repo: str | None = None
                 # parsed_purl cannot be None here, but mypy cannot detect that without some extra help.
                 if parsed_purl is not None:
-                    if provenance_repo_url or provenance_commit_digest:
+                    if provenance_repo_url:
                         return Analyzer.AnalysisTarget(
                             parsed_purl=parsed_purl,
                             repo_path=provenance_repo_url or "",
                             branch="",
-                            digest=provenance_commit_digest or "",
+                            digest="",
                             repo_finder_outcome=repo_finder_outcome,
                         )
 
@@ -978,7 +975,7 @@ class Analyzer:
                     parsed_purl=parsed_purl,
                     repo_path=repo_path_input,
                     branch=input_branch,
-                    digest=provenance_commit_digest or "",
+                    digest="",
                     repo_finder_outcome=repo_finder_outcome,
                 )
 

--- a/tests/integration/cases/pypi_aiohappyeyeballs/policy.dl
+++ b/tests/integration/cases/pypi_aiohappyeyeballs/policy.dl
@@ -1,0 +1,38 @@
+/* Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved. */
+/* Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/. */
+
+#include "prelude.dl"
+
+Policy("test_policy", component_id, "") :-
+    check_passed(component_id, "mcn_provenance_available_1"),
+    check_passed(component_id, "mcn_provenance_verified_1"),
+    check_passed(component_id, "mcn_provenance_derived_repo_1"),
+    check_failed(component_id, "mcn_provenance_derived_commit_1"),
+    check_passed(component_id, "mcn_scm_authenticity_1"),
+    provenance_available_check(_, asset_name, asset_url),
+    asset_name = "aiohappyeyeballs",
+    asset_url = "https://pypi.org/integrity/aiohappyeyeballs/2.6.1/aiohappyeyeballs-2.6.1-py3-none-any.whl/provenance",
+    provenance(_, component_id, _, slsa_level, _, repo_url, attested_commit, _, asset_name, asset_url, _),
+    slsa_level = 2,
+    repo_url = "https://github.com/aio-libs/aiohappyeyeballs",
+    attested_commit = "2042c82f9978f41c31b58aa4e3d8fc3b9c3ec2ec",
+    repository(
+        _,
+        component_id,
+        "github.com/aio-libs/aiohappyeyeballs",
+        "aio-libs/aiohappyeyeballs",
+        "github.com",
+        "aio-libs",
+        "aiohappyeyeballs",
+        "https://github.com/aio-libs/aiohappyeyeballs",
+        _,
+        _,
+        release_commit,
+        _,
+        _
+    ),
+    release_commit = "e3bd5bdf44f5d187802de6dcb08d27e1ca6da048",
+    attested_commit != release_commit.
+
+apply_policy_to("test_policy", component_id) :-
+    is_component(component_id, "pkg:pypi/aiohappyeyeballs@2.6.1").

--- a/tests/integration/cases/pypi_aiohappyeyeballs/test.yaml
+++ b/tests/integration/cases/pypi_aiohappyeyeballs/test.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+description: |
+  Analyzing a PyPI PURL that has provenance available on the PyPI registry, but whose attested commit does not match
+  the release tag commit.
+
+tags:
+- macaron-python-package
+
+steps:
+- name: Run macaron analyze
+  kind: analyze
+  options:
+    command_args:
+    - -purl
+    - pkg:pypi/aiohappyeyeballs@2.6.1
+- name: Run macaron verify-policy to verify passed/failed checks
+  kind: verify
+  options:
+    policy: policy.dl


### PR DESCRIPTION
## Summary

This PR updates how we resolve commits when an attestation/provenance is present.

In some cases, the provenance captures the workflow commit that triggered the release, while the actual release tag points to a different commit that is automatically generated and pushed afterward. This leads to inconsistencies when identifying the “true” commit.

With this change:

* We consistently use the **tag commit** as the actual commit.
* The check `mcn_provenance_derived_commit_1` additionally reports whether the commit was **derived from provenance** or not.

Fixes #1398