### PR TITLE
chore: moved from deprecated OpenSSL URL

### DIFF
--- a/src/macaron/build_spec_generator/dockerfile/pypi_dockerfile_output.py
+++ b/src/macaron/build_spec_generator/dockerfile/pypi_dockerfile_output.py
@@ -173,12 +173,12 @@ def openssl_install_commands(version: Version) -> str:
     # and 3.6 to 3.9 can be compiled with OpenSSL 1.1.1. Therefore, we compile as below:
     if version in SpecifierSet(">=3.6"):
         openssl_version = "1.1.1w"
-        source_url = "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz"
+        source_url = "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz"
     # From the same document, "Python versions 3.6 to 3.9 are compatible with OpenSSL 1.0.2,
     # 1.1.0, and 1.1.1". As an attempt to generalize for any >= 3.3, we use OpenSSL 1.0.2.
     else:
         openssl_version = "1.0.2u"
-        source_url = "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz"
+        source_url = "https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u/openssl-1.0.2u.tar.gz"
 
     return f"""# Build OpenSSL {openssl_version}
     RUN <<EOF

--- a/tests/build_spec_generator/dockerfile/__snapshots__/test_pypi_dockerfile_output.ambr
+++ b/tests/build_spec_generator/dockerfile/__snapshots__/test_pypi_dockerfile_output.ambr
@@ -28,7 +28,7 @@
   
   # Build OpenSSL 1.1.1w
   RUN <<EOF
-      wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+      wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz
       tar xzf openssl-1.1.1w.tar.gz
       cd openssl-1.1.1w
       ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib

--- a/tests/build_spec_generator/dockerfile/test_pypi_dockerfile_output.py
+++ b/tests/build_spec_generator/dockerfile/test_pypi_dockerfile_output.py
@@ -8,6 +8,7 @@ Test the logic for dockerfile generation to rebuild PyPI packages.
 import pytest
 
 from macaron.build_spec_generator.common_spec.base_spec import BaseBuildSpecDict, SpecBuildCommandDict
+from macaron.build_spec_generator.dockerfile import pypi_dockerfile_output
 from macaron.build_spec_generator.dockerfile.pypi_dockerfile_output import gen_dockerfile
 
 
@@ -53,6 +54,9 @@ def fixture_base_build_spec() -> BaseBuildSpecDict:
     )
 
 
-def test_successful_generation(snapshot: str, pypi_build_spec: BaseBuildSpecDict) -> None:
+def test_successful_generation(
+    monkeypatch: pytest.MonkeyPatch, snapshot: str, pypi_build_spec: BaseBuildSpecDict
+) -> None:
     """Ensure that dockerfile is correctly generated for pypi_build_spec"""
+    monkeypatch.setattr(pypi_dockerfile_output, "get_latest_cpython_patch", lambda _major, _minor: "3.9.25")
     assert gen_dockerfile(pypi_build_spec) == snapshot

--- a/tests/integration/cases/pypi_cachetools/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_cachetools/expected_dockerfile.buildspec
@@ -25,7 +25,7 @@ RUN dnf install \
 
 # Build OpenSSL 1.1.1w
 RUN <<EOF
-    wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+    wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz
     tar xzf openssl-1.1.1w.tar.gz
     cd openssl-1.1.1w
     ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib

--- a/tests/integration/cases/pypi_markdown-it-py/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_markdown-it-py/expected_dockerfile.buildspec
@@ -25,7 +25,7 @@ RUN dnf install \
 
 # Build OpenSSL 1.1.1w
 RUN <<EOF
-    wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+    wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz
     tar xzf openssl-1.1.1w.tar.gz
     cd openssl-1.1.1w
     ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib

--- a/tests/integration/cases/pypi_pytesseract/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_pytesseract/expected_dockerfile.buildspec
@@ -25,7 +25,7 @@ RUN dnf install \
 
 # Build OpenSSL 1.1.1w
 RUN <<EOF
-    wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+    wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz
     tar xzf openssl-1.1.1w.tar.gz
     cd openssl-1.1.1w
     ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib

--- a/tests/integration/cases/pypi_toga/expected_dockerfile.buildspec
+++ b/tests/integration/cases/pypi_toga/expected_dockerfile.buildspec
@@ -25,7 +25,7 @@ RUN dnf install \
 
 # Build OpenSSL 1.1.1w
 RUN <<EOF
-    wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+    wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz
     tar xzf openssl-1.1.1w.tar.gz
     cd openssl-1.1.1w
     ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib


### PR DESCRIPTION
## Summary
Fixed deprecated OpenSSL URL use.

## Description of changes
Fixed deprecated OpenSSL URL use and modified tests appropriately.

## Related issues
Fixes https://github.com/oracle/macaron/issues/1406

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
