### PR TITLE
fix(action): replace string-built GitHub Action commands with a bash argv array and direct execution

### DIFF
--- a/scripts/actions/run_macaron_analysis.sh
+++ b/scripts/actions/run_macaron_analysis.sh
@@ -11,53 +11,53 @@ if [ -z "${MACARON:-}" ]; then
   exit 1
 fi
 
-CMD=""
+CMD=("$MACARON")
 if [ -n "${DEFAULTS_PATH:-}" ]; then
-  CMD="$MACARON --defaults-path ${DEFAULTS_PATH}"
-else
-  CMD="$MACARON"
+  CMD+=(--defaults-path "$DEFAULTS_PATH")
 fi
 
 OUTPUT_DIR=${OUTPUT_DIR:-output}
-CMD="$CMD --output ${OUTPUT_DIR} -lr . analyze"
+CMD+=(--output "$OUTPUT_DIR" -lr . analyze)
 
 if [ -n "${REPO_PATH:-}" ]; then
-  CMD="$CMD -rp ${REPO_PATH}"
+  CMD+=(-rp "$REPO_PATH")
 elif [ -n "${PACKAGE_URL:-}" ]; then
-  CMD="$CMD -purl ${PACKAGE_URL}"
+  CMD+=(-purl "$PACKAGE_URL")
 fi
 
 if [ -n "${BRANCH:-}" ]; then
-  CMD="$CMD --branch ${BRANCH}"
+  CMD+=(--branch "$BRANCH")
 fi
 
 if [ -n "${DIGEST:-}" ]; then
-  CMD="$CMD --digest ${DIGEST}"
+  CMD+=(--digest "$DIGEST")
 fi
 
-CMD="$CMD --deps-depth ${DEPS_DEPTH:-0}"
+CMD+=(--deps-depth "${DEPS_DEPTH:-0}")
 
 if [ -n "${SBOM_PATH:-}" ]; then
-  CMD="$CMD --sbom-path ${SBOM_PATH}"
+  CMD+=(--sbom-path "$SBOM_PATH")
 fi
 
 if [ -n "${PYTHON_VENV:-}" ]; then
-  CMD="$CMD --python-venv ${PYTHON_VENV}"
+  CMD+=(--python-venv "$PYTHON_VENV")
 fi
 
 if [ -n "${PROVENANCE_FILE:-}" ]; then
-  CMD="$CMD --provenance-file ${PROVENANCE_FILE}"
+  CMD+=(--provenance-file "$PROVENANCE_FILE")
 fi
 
 if [ -n "${PROVENANCE_EXPECTATION:-}" ]; then
-  CMD="$CMD --provenance-expectation ${PROVENANCE_EXPECTATION}"
+  CMD+=(--provenance-expectation "$PROVENANCE_EXPECTATION")
 fi
 
-echo "Executing: $CMD"
+printf 'Executing:'
+printf ' %q' "${CMD[@]}"
+printf '\n'
 
 output_file="$(mktemp)"
 set +e
-eval "$CMD" 2>&1 | tee "$output_file"
+"${CMD[@]}" 2>&1 | tee "$output_file"
 # Capture analyze command's exit code from the pipeline (index 0), then restore fail-fast mode.
 status=${PIPESTATUS[0]}
 set -e

--- a/scripts/actions/run_macaron_policy_verification.sh
+++ b/scripts/actions/run_macaron_policy_verification.sh
@@ -44,7 +44,7 @@ if [ -n "$FILE" ] && [ -f "$FILE" ]; then
       echo "vsa_report=VSA Not Generated." >> "$GITHUB_OUTPUT"
     fi
   fi
-elif [ -n "$PURL" ]; then
+elif [ -n "$FILE" ] && [ -n "$PURL" ]; then
   CMD+=(--existing-policy "$FILE" --package-url "$PURL")
 
   if run_macaron "${CMD[@]}"; then
@@ -56,5 +56,5 @@ elif [ -n "$PURL" ]; then
     fi
   fi
 else
-  echo "No file or pre-defined policy found for ${FILE} and policy_purl ${PURL}"
+  echo "No valid policy inputs found"
 fi

--- a/scripts/actions/run_macaron_policy_verification.sh
+++ b/scripts/actions/run_macaron_policy_verification.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2025 - 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2025 - 2026, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
 set -euo pipefail
 
@@ -15,23 +15,28 @@ if [ -z "${MACARON:-}" ]; then
   exit 1
 fi
 
+run_macaron() {
+  printf 'Executing:'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
 DEFAULTS_PATH=${DEFAULTS_PATH:-}
 OUTPUT_DIR=${OUTPUT_DIR:-output}
 FILE=${POLICY_FILE:-}
 PURL=${POLICY_PURL:-}
 
+CMD=("$MACARON")
 if [ -n "$DEFAULTS_PATH" ]; then
-  CMD="$MACARON --defaults-path ${DEFAULTS_PATH}"
-else
-  CMD="$MACARON"
+  CMD+=(--defaults-path "$DEFAULTS_PATH")
 fi
-CMD="$CMD --output ${OUTPUT_DIR} verify-policy --database ${OUTPUT_DIR}/macaron.db"
+CMD+=(--output "$OUTPUT_DIR" verify-policy --database "${OUTPUT_DIR}/macaron.db")
 
 if [ -n "$FILE" ] && [ -f "$FILE" ]; then
-  CMD="$CMD --file $FILE"
+  CMD+=(--file "$FILE")
 
-  echo "Executing: $CMD"
-  if eval "$CMD"; then
+  if run_macaron "${CMD[@]}"; then
     echo "policy_report=${OUTPUT_DIR}/policy_report.json" >> "$GITHUB_OUTPUT"
     if [ -f "${OUTPUT_DIR}/vsa.intoto.jsonl" ]; then
       echo "vsa_report=${OUTPUT_DIR}/vsa.intoto.jsonl" >> "$GITHUB_OUTPUT"
@@ -40,11 +45,9 @@ if [ -n "$FILE" ] && [ -f "$FILE" ]; then
     fi
   fi
 elif [ -n "$PURL" ]; then
-  CMD="$CMD --existing-policy ${FILE} --package-url ${PURL}"
+  CMD+=(--existing-policy "$FILE" --package-url "$PURL")
 
-  echo "Executing: $CMD"
-  echo "$CMD"
-  if eval "$CMD"; then
+  if run_macaron "${CMD[@]}"; then
     echo "policy_report=${OUTPUT_DIR}/policy_report.json" >> "$GITHUB_OUTPUT"
     if [ -f "${OUTPUT_DIR}/vsa.intoto.jsonl" ]; then
       echo "vsa_report=${OUTPUT_DIR}/vsa.intoto.jsonl" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
In the GitHub Actions script `run_macaron_analysis.sh` and `run_macaron_policy_verification.sh` replaced string-built `CMD` plus `eval "$CMD"` with a Bash argv array and direct execution via `"${CMD[@]}"`.