### PR TITLE
chore: temporarily ignore PYSEC-2026-2132 till Semgrep allows Click >=8.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,13 +304,16 @@ requirements.txt: pyproject.toml
 # Remove GHSA-vfmq-68hx-4jfw when the following issue is resolved to be able to
 # install the latest version of lxml.
 # https://github.com/semgrep/semgrep/issues/11630
+#
+# Remove PYSEC-2026-2132 when Semgrep allows Click >=8.3.3. Click is a
+# transitive dependency of Semgrep
 
 .PHONY: audit
 audit:
 	if ! $$(python -c "import pip_audit" &> /dev/null); then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-vfmq-68hx-4jfw
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-vfmq-68hx-4jfw --ignore-vuln PYSEC-2026-2132
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-ruff check-lint check-mypy check-go check-actionlint


### PR DESCRIPTION
## Summary
Unblocking CI by ignoring PYSEC-2026-2132 till Semgrep allows Click >=8.3.3

## Description of changes
Audit now does `--ignore-vuln PYSEC-2026-2132`

## Checklist
<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
