### PR TITLE
chore(deps): pin the `flit_core` package to the same range as `flit` to avoid version and feature conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ actions = [
 ]
 dev = [
     "flit >=3.2.0,<4.0.0",
+    "flit_core >=3.2.0,<4.0.0",
     "mypy >=2.0.0,<3.0.0",
     "types-pyyaml >=6.0.4,<7.0.0",
     "types-requests >=2.25.6,<3.0.0",


### PR DESCRIPTION
## Summary

It looks like flit_core is now — as of yesterday, actually, see [tags](https://github.com/pypa/flit/tags) — available on PyPI as v4 and that collides with the existing flit <4 dependency range… so we need to pin both.

## Related issues

For reference see https://github.com/pypa/flit/issues/811#issuecomment-5195444405 and [Allow package references as version specifiers](https://discuss.python.org/t/allow-package-references-as-version-specifiers/19226).

## Checklist

- [X] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [X] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [X] My commits include the "Signed-off-by" line.
- [X] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
- [X] I have updated the relevant documentation, if applicable.
- [ ] I have tested my changes and verified they work as expected.
