### PR TITLE
fix: handle short Maven group ids in the repository verifier

### DIFF
--- a/src/macaron/repo_verifier/repo_verifier_maven.py
+++ b/src/macaron/repo_verifier/repo_verifier_maven.py
@@ -114,6 +114,14 @@ class RepoVerifierMaven(RepoVerifierToolSpecific):
         reported_account = parsed_url.path.strip("/").split("/")[0]
 
         group_parts = self.namespace.split(".")
+        # Fewer than three segments names no account to compare against.
+        if len(group_parts) < 3:
+            return RepositoryVerificationResult(
+                status=RepositoryVerificationStatus.UNKNOWN,
+                reason="git_ns_mismatch",
+                build_tool=self.build_tool,
+            )
+
         for platform in RECOGNIZED_CODE_HOSTING_SERVICES:
             # For artifacts from recognized code hosting services, check if the
             # organization name is the same in maven and the source repository.

--- a/tests/repo_verifier/test_repo_verifier.py
+++ b/tests/repo_verifier/test_repo_verifier.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from macaron.repo_verifier.repo_verifier_base import RepositoryVerificationStatus
 from macaron.repo_verifier.repo_verifier_gradle import RepoVerifierGradle
 from macaron.repo_verifier.repo_verifier_maven import RepoVerifierMaven
 from macaron.slsa_analyzer.build_tool.base_build_tool import BaseBuildTool
@@ -140,3 +141,46 @@ def test_extract_group_id_from_pom(
     """
     verifier = maven_repo_verifier(build_tools["maven"], str(mock_repo))
     assert (verifier.extract_group_id_from_pom() is not None) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("namespace", "expected_status", "expected_reason"),
+    [
+        # A three-segment namespace under a recognized code hosting service still
+        # matches, which is the behaviour the short-namespace guard must not change.
+        ("com.github.example", RepositoryVerificationStatus.PASSED, "git_ns_match"),
+        ("io.github.example", RepositoryVerificationStatus.PASSED, "git_ns_match"),
+        # Fewer than three segments cannot name an account, so the comparison has
+        # no answer to give and must report a mismatch rather than raise IndexError.
+        ("com.github", RepositoryVerificationStatus.UNKNOWN, "git_ns_mismatch"),
+        ("io.github", RepositoryVerificationStatus.UNKNOWN, "git_ns_mismatch"),
+        ("com", RepositoryVerificationStatus.UNKNOWN, "git_ns_mismatch"),
+        ("io", RepositoryVerificationStatus.UNKNOWN, "git_ns_mismatch"),
+        # A short namespace outside the io/com prefixes was already safe and stays so.
+        ("org.example", RepositoryVerificationStatus.UNKNOWN, "git_ns_mismatch"),
+    ],
+)
+def test_verify_domains_handles_short_namespaces(
+    build_tools: dict[str, BaseBuildTool],
+    namespace: str,
+    expected_status: RepositoryVerificationStatus,
+    expected_reason: str,
+) -> None:
+    """A Maven namespace with fewer than three segments must not crash the repository check.
+
+    The namespace reaches this code as ``parsed_purl.namespace`` straight from the analysis
+    target, and the analyzer wraps the call in no exception handler, so an IndexError here
+    aborts the whole analysis.
+    """
+    verifier = RepoVerifierMaven(
+        namespace=namespace,
+        name="artifact",
+        version="1.0.0",
+        reported_repo_url="https://github.com/example/example",
+        reported_repo_fs="/nonexistent",
+        build_tool=build_tools["maven"],
+        provenance_repo_url=None,
+    )
+    result = verifier.verify_domains_from_recognized_code_hosting_services()
+    assert result.status == expected_status
+    assert result.reason == expected_reason


### PR DESCRIPTION
## Summary

Return a verification result instead of raising `IndexError` when a Maven group id has fewer than three segments.

## Description of changes

`verify_domains` compared `group_parts[1]` and `group_parts[2]` unconditionally. A group id such as `com.github` or `io.github`, with the repository reported on `github.com`, raised `IndexError` and aborted the analysis. Such a namespace names no account to compare, so the method now returns `UNKNOWN` with reason `git_ns_mismatch`, the same answer a wrong account gets and the same guard `maven_central_registry.same_organization` applies.

Validate: `pytest tests/repo_verifier/test_repo_verifier.py` fails on `main` for the four short namespaces and passes with this change; `make check` and `make test` pass.

## Related issues

Closes #1463

## Checklist

- [x] I have reviewed the [contribution guide](../CONTRIBUTING.md).
- [x] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] My commits include the "Signed-off-by" line.
- [x] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] I have updated the relevant documentation, if applicable.
- [x] I have tested my changes and verified they work as expected.
